### PR TITLE
Core services reality pass: registry, health, operator system surface

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  transpilePackages: ['@aros/db', '@aros/config', '@aros/shared'],
+  transpilePackages: ['@aros/db', '@aros/core-services', '@aros/config', '@aros/shared'],
   experimental: {
     serverActions: {
       bodySizeLimit: '2mb',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "@aros/db": "*",
+    "@aros/core-services": "*",
     "@aros/config": "*",
     "@aros/shared": "*",
     "zod": "^3.24.0",

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -7,24 +7,63 @@ export const metadata = { title: 'Dashboard - AROS' };
 export default async function DashboardPage() {
   const user = await requireSession();
 
-  const membership = await prisma.membership.findFirst({
-    where: { userId: user.id },
-    include: { organization: true },
-  });
+  let membership: {
+    organizationId: string;
+    organization: { id: string; name: string; slug: string };
+  } | null = null;
+  let dataError: string | null = null;
+
+  try {
+    membership = await prisma.membership.findFirst({
+      where: { userId: user.id },
+      include: { organization: true },
+    });
+  } catch (e) {
+    dataError = e instanceof Error ? e.message : 'Database error';
+    console.error('[dashboard] membership load failed', e);
+  }
 
   if (!membership) {
     return (
-      <div className="text-center py-12">
-        <h2 className="text-lg font-semibold text-slate-900">No organization found</h2>
-        <p className="text-slate-500 mt-2">Please contact support.</p>
+      <div className="space-y-6">
+        {dataError && (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950" role="status">
+            <p className="font-medium">Data temporarily unavailable</p>
+            <p className="mt-1">
+              The dashboard could not load your organization. Check database connectivity and migrations.{' '}
+              {dataError && <span className="block mt-1 text-amber-900/90">Detail: {dataError}</span>}
+            </p>
+            <p className="mt-2">
+              Operators: see <Link href="/system" className="text-brand-700 underline">System &amp; core services</Link>{' '}
+              (requires admin/owner).
+            </p>
+          </div>
+        )}
+        <div className="text-center py-12">
+          <h2 className="text-lg font-semibold text-slate-900">No organization found</h2>
+          <p className="text-slate-500 mt-2">Please contact support.</p>
+        </div>
       </div>
     );
   }
 
   const orgId = membership.organizationId;
 
-  const [sitesCount, openFindings, clustersCount, pendingReviews, recentCrawls] =
-    await Promise.all([
+  let sitesCount = 0;
+  let openFindings = 0;
+  let clustersCount = 0;
+  let pendingReviews = 0;
+  let recentCrawls: Array<{
+    id: string;
+    status: string;
+    pagesCrawled: number;
+    pagesFound: number;
+    createdAt: Date;
+    site: { name: string; domain: string };
+  }> = [];
+
+  try {
+    [sitesCount, openFindings, clustersCount, pendingReviews, recentCrawls] = await Promise.all([
       prisma.site.count({
         where: { workspace: { organizationId: orgId } },
       }),
@@ -49,6 +88,10 @@ export default async function DashboardPage() {
         include: { site: { select: { name: true, domain: true } } },
       }),
     ]);
+  } catch (e) {
+    dataError = e instanceof Error ? e.message : 'Database error';
+    console.error('[dashboard] stats load failed', e);
+  }
 
   return (
     <div className="space-y-8">
@@ -58,6 +101,16 @@ export default async function DashboardPage() {
           Overview for {membership.organization.name}
         </p>
       </div>
+
+      {dataError && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950" role="status">
+          <p className="font-medium">Partial data</p>
+          <p className="mt-1">
+            Some dashboard metrics could not be loaded. Counts below may be zero until the database is healthy.{' '}
+            <span className="block mt-1 text-amber-900/90">Detail: {dataError}</span>
+          </p>
+        </div>
+      )}
 
       {/* Stats Grid */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/apps/web/src/app/(dashboard)/findings/page.tsx
+++ b/apps/web/src/app/(dashboard)/findings/page.tsx
@@ -1,7 +1,14 @@
 import { requireSession } from '@/lib/session';
 import { prisma } from '@/lib/db';
 import Link from 'next/link';
-import type { Severity, FindingStatus } from '@aros/db';
+import type { Prisma, Severity, FindingStatus } from '@aros/db';
+
+type FindingListRow = Prisma.CanonicalFindingGetPayload<{
+  include: {
+    _count: { select: { occurrences: true } };
+    cluster: { select: { id: true; name: true } };
+  };
+}>;
 
 export const metadata = { title: 'Findings - AROS' };
 
@@ -21,10 +28,31 @@ export default async function FindingsPage({
   const user = await requireSession();
   const params = await searchParams;
 
-  const membership = await prisma.membership.findFirst({
-    where: { userId: user.id },
-  });
-  if (!membership) return null;
+  let membership: { organizationId: string } | null = null;
+  let loadError: string | null = null;
+  try {
+    membership = await prisma.membership.findFirst({
+      where: { userId: user.id },
+    });
+  } catch (e) {
+    loadError = e instanceof Error ? e.message : 'Database error';
+    console.error('[findings] membership load failed', e);
+  }
+
+  if (!membership) {
+    return (
+      <div className="card text-center py-12 space-y-3">
+        <h1 className="text-lg font-semibold text-slate-900">Findings unavailable</h1>
+        {loadError ? (
+          <p className="text-sm text-slate-600">
+            Could not verify your organization ({loadError}). Check database connectivity.
+          </p>
+        ) : (
+          <p className="text-sm text-slate-600">No organization membership for this account.</p>
+        )}
+      </div>
+    );
+  }
 
   const page = parseInt(params.page ?? '1');
   const limit = 20;
@@ -51,28 +79,44 @@ export default async function FindingsPage({
     where.ruleId = params.ruleId;
   }
 
-  const [findings, total] = await Promise.all([
-    prisma.canonicalFinding.findMany({
-      where,
-      orderBy: [{ impact: 'asc' }, { occurrenceCount: 'desc' }],
-      skip,
-      take: limit,
-      include: {
-        _count: { select: { occurrences: true } },
-        cluster: { select: { id: true, name: true } },
-      },
-    }),
-    prisma.canonicalFinding.count({ where }),
-  ]);
+  let findings: FindingListRow[] = [];
+  let total = 0;
+  try {
+    [findings, total] = await Promise.all([
+      prisma.canonicalFinding.findMany({
+        where,
+        orderBy: [{ impact: 'asc' }, { occurrenceCount: 'desc' }],
+        skip,
+        take: limit,
+        include: {
+          _count: { select: { occurrences: true } },
+          cluster: { select: { id: true, name: true } },
+        },
+      }),
+      prisma.canonicalFinding.count({ where }),
+    ]);
+  } catch (e) {
+    loadError = e instanceof Error ? e.message : 'Database error';
+    console.error('[findings] query failed', e);
+  }
 
   const totalPages = Math.ceil(total / limit);
 
   return (
     <div className="space-y-6">
+      {loadError && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950" role="status">
+          <p className="font-medium">Findings list unavailable</p>
+          <p className="mt-1">Could not load findings from the database. Filters still work after recovery.</p>
+          <p className="mt-1 text-amber-900/90">Detail: {loadError}</p>
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-slate-900">Findings</h1>
-          <p className="text-slate-500 mt-1">{total} accessibility issues found</p>
+          <p className="text-slate-500 mt-1">
+            {loadError ? '—' : total} accessibility issues found
+          </p>
         </div>
       </div>
 

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@ import { getSession } from '@/lib/session';
 import { prisma } from '@/lib/db';
 import { Sidebar } from '@/components/layout/sidebar';
 import { TopBar } from '@/components/layout/top-bar';
+import { hasPermission } from '@aros/config';
 
 export default async function DashboardLayout({
   children,
@@ -31,9 +32,11 @@ export default async function DashboardLayout({
     workspaces: m.organization.workspaces,
   }));
 
+  const canViewSystem = memberships.some((m) => hasPermission(m.role, 'org:system:view'));
+
   return (
     <div className="flex h-screen overflow-hidden bg-slate-50">
-      <Sidebar orgs={orgs} user={user} />
+      <Sidebar orgs={orgs} user={user} canViewSystem={canViewSystem} />
       <div className="flex flex-1 flex-col overflow-hidden">
         <TopBar user={user} />
         <main className="flex-1 overflow-y-auto p-6">{children}</main>

--- a/apps/web/src/app/(dashboard)/system/page.tsx
+++ b/apps/web/src/app/(dashboard)/system/page.tsx
@@ -1,0 +1,247 @@
+import Link from 'next/link';
+import { requireSession } from '@/lib/session';
+import { prisma } from '@/lib/db';
+import { hasPermission } from '@aros/config';
+import { redirect } from 'next/navigation';
+import { getPlatformHealthPayload } from '@/lib/platform-health';
+
+export const metadata = { title: 'System & services - AROS' };
+
+const healthStateStyles: Record<string, string> = {
+  running: 'bg-emerald-100 text-emerald-900',
+  ready: 'bg-sky-100 text-sky-900',
+  degraded: 'bg-amber-100 text-amber-900',
+  failed: 'bg-red-100 text-red-900',
+  unavailable: 'bg-slate-200 text-slate-800',
+  misconfigured: 'bg-orange-100 text-orange-900',
+  disabled: 'bg-slate-100 text-slate-600',
+};
+
+export default async function SystemPage() {
+  const user = await requireSession();
+
+  const membership = await prisma.membership.findFirst({
+    where: { userId: user.id },
+    include: { organization: { select: { id: true, name: true, slug: true } } },
+  });
+
+  if (!membership) {
+    return (
+      <div className="card text-center py-12">
+        <h1 className="text-lg font-semibold text-slate-900">No organization</h1>
+        <p className="text-slate-500 mt-2">You need an organization membership to view system status.</p>
+      </div>
+    );
+  }
+
+  if (!hasPermission(membership.role, 'org:system:view')) {
+    redirect('/dashboard');
+  }
+
+  let payload: Awaited<ReturnType<typeof getPlatformHealthPayload>> | null = null;
+  let loadError: string | null = null;
+  try {
+    payload = await getPlatformHealthPayload();
+  } catch (e) {
+    loadError = e instanceof Error ? e.message : 'Failed to load platform health';
+    console.error('[system] platform health failed', e);
+  }
+
+  const orgId = membership.organizationId;
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">System & core services</h1>
+        <p className="text-slate-500 mt-1">
+          Live deployment status for {membership.organization.name}. Values are derived from connectivity checks,
+          queue metrics, and worker heartbeats — not static placeholders.
+        </p>
+      </div>
+
+      {loadError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900" role="alert">
+          <p className="font-medium">Could not load full platform report</p>
+          <p className="mt-1">{loadError}</p>
+          <p className="mt-2 text-red-800">
+            The UI stays usable; fix database connectivity or run{' '}
+            <code className="rounded bg-red-100 px-1">npm run db:migrate</code> and{' '}
+            <code className="rounded bg-red-100 px-1">npm run bootstrap</code>.
+          </p>
+        </div>
+      )}
+
+      {payload && (
+        <>
+          <section className="card space-y-4" aria-labelledby="readiness-heading">
+            <h2 id="readiness-heading" className="text-lg font-semibold text-slate-900">
+              Platform readiness
+            </h2>
+            <dl className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Installed</dt>
+                <dd className="mt-1 text-slate-900">
+                  {payload.report.bootstrap.installed ? 'Yes' : 'No — run migrations and bootstrap'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Readiness</dt>
+                <dd className="mt-1">
+                  <span className="badge bg-slate-100 text-slate-800">
+                    {payload.report.bootstrap.readiness}
+                  </span>
+                </dd>
+              </div>
+              <div className="sm:col-span-2">
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Environment validation</dt>
+                <dd className="mt-1 text-slate-900">
+                  {payload.envDiagnostics.valid ? (
+                    'Valid'
+                  ) : (
+                    <span>
+                      Invalid — see keys: {payload.envDiagnostics.invalidKeys.join(', ') || '(see server logs)'}
+                    </span>
+                  )}
+                </dd>
+              </div>
+            </dl>
+            {payload.report.bootstrap.blockers.length > 0 && (
+              <div>
+                <h3 className="text-sm font-medium text-red-800">Blockers</h3>
+                <ul className="mt-2 list-inside list-disc text-sm text-red-900">
+                  {payload.report.bootstrap.blockers.map((b) => (
+                    <li key={b}>{b}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {payload.report.bootstrap.warnings.length > 0 && (
+              <div>
+                <h3 className="text-sm font-medium text-amber-800">Warnings</h3>
+                <ul className="mt-2 list-inside list-disc text-sm text-amber-900">
+                  {payload.report.bootstrap.warnings.map((w) => (
+                    <li key={w}>{w}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+
+          <section className="card space-y-4" aria-labelledby="deps-heading">
+            <h2 id="deps-heading" className="text-lg font-semibold text-slate-900">
+              Dependencies
+            </h2>
+            <ul className="space-y-2 text-sm">
+              <DependencyRow label="PostgreSQL" result={payload.report.dependencies.database} />
+              <DependencyRow label="Redis" result={payload.report.dependencies.redis} />
+              <DependencyRow label="Sessions" result={payload.report.dependencies.sessionStore} />
+            </ul>
+          </section>
+
+          <section aria-labelledby="services-heading">
+            <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+              <h2 id="services-heading" className="text-lg font-semibold text-slate-900">
+                Core services
+              </h2>
+              <Link
+                href={`/api/org/${orgId}/platform/health`}
+                className="text-sm text-brand-600 hover:text-brand-700"
+                prefetch={false}
+              >
+                JSON API (authenticated)
+              </Link>
+            </div>
+            <div className="space-y-3">
+              {payload.report.services.map((svc) => (
+                <article
+                  key={svc.id}
+                  className="card border border-slate-200"
+                  aria-labelledby={`svc-${svc.id}-title`}
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <h3 id={`svc-${svc.id}-title`} className="font-semibold text-slate-900">
+                        {svc.name}
+                      </h3>
+                      <p className="text-sm text-slate-600 mt-1">{svc.purpose}</p>
+                      <p className="text-xs text-slate-500 mt-2">
+                        Scope: {svc.scope} · {svc.criticality === 'critical' ? 'Critical' : 'Optional'}
+                      </p>
+                    </div>
+                    <span
+                      className={`badge shrink-0 ${healthStateStyles[svc.healthState] ?? 'bg-slate-100 text-slate-800'}`}
+                    >
+                      {svc.healthState}
+                    </span>
+                  </div>
+                  <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
+                    <div>
+                      <dt className="text-slate-500">Enabled</dt>
+                      <dd className="text-slate-900">{svc.enabled ? 'Yes' : 'No'}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-slate-500">Config</dt>
+                      <dd className="text-slate-900">{svc.configState}</dd>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <dt className="text-slate-500">Last check</dt>
+                      <dd className="text-slate-900">{svc.lastCheckAt ?? '—'}</dd>
+                    </div>
+                    {svc.lastActivityAt && (
+                      <div className="sm:col-span-2">
+                        <dt className="text-slate-500">Last activity</dt>
+                        <dd className="text-slate-900">{svc.lastActivityAt}</dd>
+                      </div>
+                    )}
+                  </dl>
+                  {svc.configIssues.length > 0 && (
+                    <ul className="mt-3 list-inside list-disc text-sm text-orange-900">
+                      {svc.configIssues.map((issue) => (
+                        <li key={issue}>{issue}</li>
+                      ))}
+                    </ul>
+                  )}
+                  {svc.failureReason && (
+                    <p className="mt-3 text-sm text-red-800">
+                      <span className="font-medium">Failure: </span>
+                      {svc.failureReason}
+                    </p>
+                  )}
+                  <p className="mt-3 text-sm text-slate-700">
+                    <span className="font-medium text-slate-900">Next step: </span>
+                    {svc.nextStep}
+                  </p>
+                  {Object.keys(svc.configSummary).length > 0 && (
+                    <details className="mt-3 text-xs text-slate-600">
+                      <summary className="cursor-pointer font-medium text-slate-700">Non-sensitive config summary</summary>
+                      <pre className="mt-2 overflow-x-auto rounded bg-slate-50 p-2 text-slate-800">
+                        {JSON.stringify(svc.configSummary, null, 2)}
+                      </pre>
+                    </details>
+                  )}
+                </article>
+              ))}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function DependencyRow({
+  label,
+  result,
+}: {
+  label: string;
+  result: { ok: boolean; message?: string; checkedAt: string };
+}) {
+  return (
+    <li className="flex flex-wrap items-baseline justify-between gap-2 border-b border-slate-100 pb-2 last:border-0">
+      <span className="font-medium text-slate-800">{label}</span>
+      <span className={result.ok ? 'text-emerald-700' : 'text-red-700'}>
+        {result.ok ? 'OK' : result.message ?? 'Failed'}
+      </span>
+    </li>
+  );
+}

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { collectPlatformHealth, toPublicHealthSummary } from '@aros/core-services';
+import { prisma } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Liveness + coarse readiness for load balancers. No authentication; no secrets or env keys.
+ */
+export async function GET() {
+  try {
+    const report = await collectPlatformHealth(prisma);
+    const summary = toPublicHealthSummary(report);
+    const status = summary.ready ? 200 : 503;
+    return NextResponse.json(summary, { status });
+  } catch (e) {
+    console.error('[health] collection failed:', e);
+    return NextResponse.json(
+      {
+        checkedAt: new Date().toISOString(),
+        live: true,
+        installed: false,
+        readiness: 'blocked',
+        ready: false,
+        checks: { database: false, redis: false, session: false },
+        error: 'health_collection_failed',
+      },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/web/src/app/api/org/[organizationId]/platform/health/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/health/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { requireOrgAccess } from '@/lib/auth-guard';
+import { getPlatformHealthPayload } from '@/lib/platform-health';
+import { apiError } from '@/lib/api-utils';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ organizationId: string }> }
+) {
+  try {
+    const { organizationId } = await context.params;
+    await requireOrgAccess(organizationId, 'org:system:view');
+    const payload = await getPlatformHealthPayload();
+    return NextResponse.json({ success: true, data: payload });
+  } catch (e) {
+    return apiError(e);
+  }
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -16,6 +16,7 @@ interface OrgInfo {
 interface SidebarProps {
   orgs: OrgInfo[];
   user: { id: string; email: string; name: string | null };
+  canViewSystem?: boolean;
 }
 
 const navItems = [
@@ -29,7 +30,7 @@ const navItems = [
   { href: '/settings', label: 'Settings', icon: 'Settings' },
 ];
 
-export function Sidebar({ orgs, user }: SidebarProps) {
+export function Sidebar({ orgs, user, canViewSystem }: SidebarProps) {
   const pathname = usePathname();
   const [currentOrg, setCurrentOrg] = useState(orgs[0]);
 
@@ -85,6 +86,24 @@ export function Sidebar({ orgs, user }: SidebarProps) {
               </li>
             );
           })}
+          {canViewSystem && (
+            <li>
+              <Link
+                href="/system"
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  pathname === '/system' || pathname.startsWith('/system/')
+                    ? 'bg-brand-50 text-brand-700'
+                    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+                }`}
+                aria-current={pathname.startsWith('/system') ? 'page' : undefined}
+              >
+                <span className="w-5 text-center" aria-hidden="true">
+                  {iconMap.Server}
+                </span>
+                System
+              </Link>
+            </li>
+          )}
         </ul>
       </nav>
 
@@ -115,4 +134,5 @@ const iconMap: Record<string, string> = {
   CheckSquare: '\u2611',
   FileText: '\u2637',
   Settings: '\u2699',
+  Server: '\u229E',
 };

--- a/apps/web/src/lib/platform-health.ts
+++ b/apps/web/src/lib/platform-health.ts
@@ -1,0 +1,24 @@
+import { collectPlatformHealth } from '@aros/core-services';
+import { parseEnvDiagnostics } from '@aros/config';
+import { prisma } from './db';
+import type { PlatformHealthReport } from '@aros/core-services';
+
+export interface PlatformHealthApiPayload {
+  report: PlatformHealthReport;
+  envDiagnostics: {
+    valid: boolean;
+    invalidKeys: string[];
+  };
+}
+
+export async function getPlatformHealthPayload(): Promise<PlatformHealthApiPayload> {
+  const diag = parseEnvDiagnostics(process.env);
+  const invalidKeys = Object.keys(diag.fieldErrors).filter(
+    (k) => (diag.fieldErrors[k]?.length ?? 0) > 0
+  );
+  const report = await collectPlatformHealth(prisma);
+  return {
+    report,
+    envDiagnostics: { valid: diag.valid, invalidKeys },
+  };
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@aros/db": "*",
+    "@aros/core-services": "*",
     "@aros/shared": "*",
     "@aros/config": "*",
     "bullmq": "^5.31.0",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,7 @@
 import { Worker } from 'bullmq';
 import IORedis from 'ioredis';
+import { prisma } from '@aros/db';
+import { recordWorkerHeartbeat } from '@aros/core-services';
 import { bullmqConnectionOptions } from '@aros/shared';
 import { handleCrawlJob } from './jobs/crawl';
 import { handleScanJob } from './jobs/scan';
@@ -54,14 +56,29 @@ setupWorkerEvents(scanWorker, 'Scan');
 setupWorkerEvents(clusterWorker, 'Cluster');
 setupWorkerEvents(remediationWorker, 'Remediation');
 
+const HEARTBEAT_MS = 30_000;
+async function heartbeatTick() {
+  try {
+    await recordWorkerHeartbeat(prisma);
+  } catch (e) {
+    console.error('[Worker] Platform heartbeat failed:', e instanceof Error ? e.message : e);
+  }
+}
+void heartbeatTick();
+const heartbeatInterval = setInterval(() => {
+  void heartbeatTick();
+}, HEARTBEAT_MS);
+
 async function shutdown() {
   console.log('[Worker] Shutting down...');
+  clearInterval(heartbeatInterval);
   await Promise.all([
     crawlWorker.close(),
     scanWorker.close(),
     clusterWorker.close(),
     remediationWorker.close(),
   ]);
+  await prisma.$disconnect().catch(() => undefined);
   await redisForShutdown.quit();
   process.exit(0);
 }

--- a/docs/PLATFORM_CORE_SERVICES.md
+++ b/docs/PLATFORM_CORE_SERVICES.md
@@ -1,0 +1,59 @@
+# Platform core services (AROS)
+
+This document matches the code in `@aros/core-services`, not aspirational architecture.
+
+## Canonical service registry
+
+Services are defined in `packages/core-services/src/registry.ts`. Runtime state is computed in `collectPlatformHealth()` (`orchestrator.ts`) from:
+
+- PostgreSQL (`$queryRaw` ping + `platform_state` row)
+- Redis (`PING` + BullMQ queue job counts for `crawl`, `scan`, `cluster`, `remediation`)
+- Process environment (`parseEnvDiagnostics` — **no secret values** in summaries)
+- Worker liveness (`platform_state.workerLastHeartbeatAt`, updated every 30s by `apps/worker`)
+
+States are explicit: `unavailable`, `disabled`, `misconfigured`, `ready`, `running`, `degraded`, `failed`.
+
+## Configuration lifecycle
+
+| Layer | Mechanism |
+| --- | --- |
+| Deploy/runtime env | `packages/config/src/env.ts` (`envSchema`, `getEnv()`, `parseEnvDiagnostics`) |
+| Install marker | `platform_state` singleton row (id `platform`) |
+| Mutable product flags | `platform_state.productFlags` (JSON, non-secret; extend as needed) |
+
+Root scripts:
+
+- `npm run db:migrate` — apply Prisma migrations (includes `platform_state`)
+- `npm run db:seed` — demo data **and** ensures `platform_state` exists
+- `npm run bootstrap` — idempotent `platform_state` upsert only (`packages/db/scripts/ensure-platform.ts`)
+
+## Health endpoints
+
+- `GET /api/health` — **unauthenticated** coarse readiness for load balancers; **503** when DB/Redis/session prerequisites or worker/pipelines checks fail. No env keys or secrets.
+- `GET /api/org/:organizationId/platform/health` — full operator JSON; requires session + `org:system:view` (OWNER/ADMIN).
+
+## Operator UI
+
+- Route: `/system` (dashboard layout). Visible in the sidebar only if the user has `org:system:view`.
+
+## Worker heartbeat
+
+`apps/worker` calls `recordWorkerHeartbeat(prisma)` on startup and every 30 seconds. If the row is missing, the upsert creates it (bootstrap version 1).
+
+## Adding a service
+
+1. Add a row to `CORE_SERVICES` in `registry.ts`.
+2. Extend the `switch` in `orchestrator.ts` with real checks (or map to existing dependency checks).
+3. Adjust `toPublicHealthSummary` if the new service should affect public readiness.
+4. Add tests under `packages/core-services/src/*.test.ts`.
+
+## Verification
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+npm run build
+```
+
+With Docker Postgres/Redis and a valid `.env`, run `npm run db:migrate`, `npm run db:seed`, `npm run dev` and `npm run dev:worker`, then open `/system` as an admin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aros/config": "*",
+        "@aros/core-services": "*",
         "@aros/db": "*",
         "@aros/shared": "*",
         "autoprefixer": "^10.4.0",
@@ -53,6 +54,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aros/config": "*",
+        "@aros/core-services": "*",
         "@aros/db": "*",
         "@aros/shared": "*",
         "axe-core": "^4.10.0",
@@ -85,6 +87,10 @@
     },
     "node_modules/@aros/config": {
       "resolved": "packages/config",
+      "link": true
+    },
+    "node_modules/@aros/core-services": {
+      "resolved": "packages/core-services",
       "link": true
     },
     "node_modules/@aros/db": {
@@ -8810,6 +8816,22 @@
       "name": "@aros/config",
       "version": "0.1.0",
       "dependencies": {
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "packages/core-services": {
+      "name": "@aros/core-services",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aros/config": "*",
+        "@aros/db": "*",
+        "@aros/shared": "*",
+        "bullmq": "^5.31.0",
+        "ioredis": "^5.4.0",
         "zod": "^3.24.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:push": "npm run push --workspace=packages/db",
     "db:migrate": "npm run migrate --workspace=packages/db",
     "db:seed": "npm run seed --workspace=packages/db",
+    "bootstrap": "npm run bootstrap --workspace=packages/db",
     "db:studio": "npx prisma studio --schema=packages/db/prisma/schema.prisma",
     "lint": "npm run lint --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",

--- a/packages/config/src/__tests__/env-diagnostics.test.ts
+++ b/packages/config/src/__tests__/env-diagnostics.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnvDiagnostics } from '../env';
+
+describe('parseEnvDiagnostics', () => {
+  it('valid when required keys present', () => {
+    const d = parseEnvDiagnostics({
+      DATABASE_URL: 'postgresql://localhost:5432/db',
+      NEXTAUTH_SECRET: '0123456789abcdef',
+      NEXTAUTH_URL: 'http://localhost:3000',
+      NODE_ENV: 'test',
+    });
+    expect(d.valid).toBe(true);
+    expect(d.issues).toEqual([]);
+  });
+
+  it('invalid lists field issues without throwing', () => {
+    const d = parseEnvDiagnostics({
+      DATABASE_URL: 'not-a-url',
+      NEXTAUTH_SECRET: 'short',
+    });
+    expect(d.valid).toBe(false);
+    expect(d.issues.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/config/src/__tests__/permissions.test.ts
+++ b/packages/config/src/__tests__/permissions.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { hasPermission } from '../permissions';
 
 describe('hasPermission', () => {
+  it('OWNER and ADMIN can view org system status', () => {
+    expect(hasPermission('OWNER', 'org:system:view')).toBe(true);
+    expect(hasPermission('ADMIN', 'org:system:view')).toBe(true);
+    expect(hasPermission('DEVELOPER', 'org:system:view')).toBe(false);
+  });
+
   it('OWNER has all permissions', () => {
     expect(hasPermission('OWNER', 'org:manage')).toBe(true);
     expect(hasPermission('OWNER', 'org:billing')).toBe(true);

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -37,13 +37,61 @@ export const envSchema = z.object({
 
 export type Env = z.infer<typeof envSchema>;
 
+export type EnvDiagnostics = {
+  valid: boolean;
+  fieldErrors: Record<string, string[] | undefined>;
+  issues: string[];
+};
+
+export function tryParseEnv(
+  env: NodeJS.ProcessEnv
+): { ok: true; data: Env } | { ok: false; error: z.ZodError } {
+  const result = envSchema.safeParse(env);
+  if (result.success) {
+    return { ok: true, data: result.data };
+  }
+  return { ok: false, error: result.error };
+}
+
+let cachedEnv: Env | null = null;
+
 function loadEnv(): Env {
-  const result = envSchema.safeParse(process.env);
-  if (!result.success) {
+  const result = tryParseEnv(process.env);
+  if (!result.ok) {
     console.error('Invalid environment variables:', result.error.flatten().fieldErrors);
     throw new Error('Invalid environment variables');
   }
   return result.data;
 }
 
-export const env = loadEnv();
+/**
+ * Validated process env. Lazily parsed on first access so diagnostics can run first in tooling.
+ */
+export function getEnv(): Env {
+  if (!cachedEnv) {
+    cachedEnv = loadEnv();
+  }
+  return cachedEnv;
+}
+
+/** @deprecated Prefer getEnv() for clarity; kept for backward compatibility */
+export const env = new Proxy({} as Env, {
+  get(_, prop: keyof Env) {
+    return getEnv()[prop];
+  },
+});
+
+/**
+ * Safe parse for health/diagnostics — never throws; never includes secret values.
+ */
+export function parseEnvDiagnostics(processEnv: NodeJS.ProcessEnv): EnvDiagnostics {
+  const result = tryParseEnv(processEnv);
+  if (result.ok) {
+    return { valid: true, fieldErrors: {}, issues: [] };
+  }
+  const flat = result.error.flatten();
+  const issues = Object.entries(flat.fieldErrors).flatMap(([key, messages]) =>
+    (messages ?? []).map((msg) => `${key}: ${msg}`)
+  );
+  return { valid: false, fieldErrors: flat.fieldErrors, issues };
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,11 @@
-export { env, envSchema } from './env';
+export {
+  env,
+  envSchema,
+  getEnv,
+  tryParseEnv,
+  parseEnvDiagnostics,
+  type Env,
+  type EnvDiagnostics,
+} from './env';
 export { PLANS, type PlanConfig } from './plans';
 export { PERMISSIONS, hasPermission, type Permission } from './permissions';

--- a/packages/config/src/permissions.ts
+++ b/packages/config/src/permissions.ts
@@ -1,4 +1,5 @@
 export type Permission =
+  | 'org:system:view'
   | 'org:manage'
   | 'org:billing'
   | 'org:members:manage'
@@ -30,6 +31,7 @@ type Role = 'OWNER' | 'ADMIN' | 'DEVELOPER' | 'CONTENT_EDITOR' | 'AUDITOR' | 'RE
 
 const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
   OWNER: [
+    'org:system:view',
     'org:manage', 'org:billing', 'org:members:manage', 'org:members:view',
     'workspace:create', 'workspace:manage',
     'site:create', 'site:manage', 'site:view',
@@ -43,6 +45,7 @@ const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
     'audit:view',
   ],
   ADMIN: [
+    'org:system:view',
     'org:members:manage', 'org:members:view',
     'workspace:create', 'workspace:manage',
     'site:create', 'site:manage', 'site:view',

--- a/packages/core-services/package.json
+++ b/packages/core-services/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@aros/core-services",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@aros/config": "*",
+    "@aros/db": "*",
+    "@aros/shared": "*",
+    "bullmq": "^5.31.0",
+    "ioredis": "^5.4.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/core-services/src/checks.ts
+++ b/packages/core-services/src/checks.ts
@@ -1,0 +1,81 @@
+import IORedis from 'ioredis';
+import { bullmqConnectionOptions } from '@aros/shared';
+import { Queue } from 'bullmq';
+import type { DependencyCheckResult } from './types';
+
+export async function checkPostgres(ping: () => Promise<unknown>): Promise<DependencyCheckResult> {
+  const checkedAt = new Date().toISOString();
+  try {
+    await ping();
+    return { ok: true, checkedAt };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Database unreachable';
+    return { ok: false, message, checkedAt };
+  }
+}
+
+export async function checkRedisPing(url: string): Promise<DependencyCheckResult> {
+  const checkedAt = new Date().toISOString();
+  const client = new IORedis(url, { maxRetriesPerRequest: 1, connectTimeout: 3000, lazyConnect: true });
+  try {
+    await client.connect();
+    const pong = await client.ping();
+    if (pong !== 'PONG') {
+      return { ok: false, message: `Unexpected PING response: ${pong}`, checkedAt };
+    }
+    return { ok: true, checkedAt };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Redis unreachable';
+    return { ok: false, message, checkedAt };
+  } finally {
+    await client.quit().catch(() => client.disconnect());
+  }
+}
+
+export interface QueueDepthSnapshot {
+  crawl: { waiting: number; active: number; failed: number };
+  scan: { waiting: number; active: number; failed: number };
+  cluster: { waiting: number; active: number; failed: number };
+  remediation: { waiting: number; active: number; failed: number };
+}
+
+/**
+ * Opens short-lived queue handles to read counts. Fails closed if Redis is down.
+ */
+export async function getQueueDepths(): Promise<{
+  ok: true;
+  snapshot: QueueDepthSnapshot;
+  checkedAt: string;
+} | { ok: false; message: string; checkedAt: string }> {
+  const checkedAt = new Date().toISOString();
+  const connection = bullmqConnectionOptions();
+  const q = (name: string) => new Queue(name, { connection });
+
+  const crawl = q('crawl');
+  const scan = q('scan');
+  const cluster = q('cluster');
+  const remediation = q('remediation');
+
+  try {
+    const [c, s, cl, r] = await Promise.all([
+      crawl.getJobCounts('waiting', 'active', 'failed'),
+      scan.getJobCounts('waiting', 'active', 'failed'),
+      cluster.getJobCounts('waiting', 'active', 'failed'),
+      remediation.getJobCounts('waiting', 'active', 'failed'),
+    ]);
+
+    const snapshot: QueueDepthSnapshot = {
+      crawl: { waiting: c.waiting ?? 0, active: c.active ?? 0, failed: c.failed ?? 0 },
+      scan: { waiting: s.waiting ?? 0, active: s.active ?? 0, failed: s.failed ?? 0 },
+      cluster: { waiting: cl.waiting ?? 0, active: cl.active ?? 0, failed: cl.failed ?? 0 },
+      remediation: { waiting: r.waiting ?? 0, active: r.active ?? 0, failed: r.failed ?? 0 },
+    };
+
+    return { ok: true, snapshot, checkedAt };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Could not read queue metrics';
+    return { ok: false, message, checkedAt };
+  } finally {
+    await Promise.all([crawl.close(), scan.close(), cluster.close(), remediation.close()]);
+  }
+}

--- a/packages/core-services/src/heartbeat.ts
+++ b/packages/core-services/src/heartbeat.ts
@@ -1,0 +1,15 @@
+import type { PrismaClient } from '@aros/db';
+
+const PLATFORM_ID = 'platform';
+
+export async function recordWorkerHeartbeat(prisma: PrismaClient): Promise<void> {
+  await prisma.platformState.upsert({
+    where: { id: PLATFORM_ID },
+    create: {
+      id: PLATFORM_ID,
+      bootstrapVersion: 1,
+      workerLastHeartbeatAt: new Date(),
+    },
+    update: { workerLastHeartbeatAt: new Date() },
+  });
+}

--- a/packages/core-services/src/index.ts
+++ b/packages/core-services/src/index.ts
@@ -1,0 +1,18 @@
+export { CORE_SERVICES, getServiceDefinition } from './registry';
+export { collectPlatformHealth } from './orchestrator';
+export { toPublicHealthSummary } from './public-summary';
+export { recordWorkerHeartbeat } from './heartbeat';
+export { checkPostgres, checkRedisPing, getQueueDepths } from './checks';
+export {
+  isWorkerHeartbeatStale,
+  queueFailurePressure,
+  deriveReadinessFromServices,
+} from './state';
+export type {
+  CoreServiceDefinition,
+  CoreServiceRuntimeView,
+  PlatformHealthReport,
+  PlatformBootstrapStatus,
+  ServiceHealthState,
+  ServiceCriticality,
+} from './types';

--- a/packages/core-services/src/orchestrator.test.ts
+++ b/packages/core-services/src/orchestrator.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { collectPlatformHealth } from './orchestrator';
+import type { PrismaClient } from '@aros/db';
+
+vi.mock('./checks', () => ({
+  checkPostgres: vi.fn().mockResolvedValue({ ok: true, checkedAt: 't' }),
+  checkRedisPing: vi.fn().mockResolvedValue({ ok: true, checkedAt: 't' }),
+  getQueueDepths: vi.fn().mockResolvedValue({
+    ok: true,
+    checkedAt: 't',
+    snapshot: {
+      crawl: { waiting: 0, active: 0, failed: 0 },
+      scan: { waiting: 0, active: 0, failed: 0 },
+      cluster: { waiting: 0, active: 0, failed: 0 },
+      remediation: { waiting: 0, active: 0, failed: 0 },
+    },
+  }),
+}));
+
+vi.mock('@aros/config', () => ({
+  parseEnvDiagnostics: vi.fn().mockReturnValue({ valid: true, fieldErrors: {}, issues: [] }),
+}));
+
+describe('collectPlatformHealth', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-03-22T12:00:00.000Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports not_installed when platform row missing', async () => {
+    const prisma = {
+      $queryRaw: vi.fn().mockResolvedValue([{ '?column?': 1 }]),
+      platformState: {
+        findUnique: vi.fn().mockResolvedValue(null),
+      },
+    } as unknown as PrismaClient;
+
+    const report = await collectPlatformHealth(prisma);
+    expect(report.bootstrap.installed).toBe(false);
+    expect(report.bootstrap.readiness).toBe('not_installed');
+  });
+
+  it('marks worker running when heartbeat is fresh', async () => {
+    const prisma = {
+      $queryRaw: vi.fn().mockResolvedValue([{ '?column?': 1 }]),
+      platformState: {
+        findUnique: vi.fn().mockResolvedValue({
+          installedAt: new Date('2025-01-01T00:00:00.000Z'),
+          bootstrapVersion: 1,
+          workerLastHeartbeatAt: new Date('2025-03-22T11:59:30.000Z'),
+        }),
+      },
+    } as unknown as PrismaClient;
+
+    const report = await collectPlatformHealth(prisma);
+    const worker = report.services.find((s) => s.id === 'worker-runtime');
+    expect(worker?.healthState).toBe('running');
+  });
+});

--- a/packages/core-services/src/orchestrator.ts
+++ b/packages/core-services/src/orchestrator.ts
@@ -1,0 +1,459 @@
+import type { PrismaClient } from '@aros/db';
+import { parseEnvDiagnostics, type EnvDiagnostics } from '@aros/config';
+import { CORE_SERVICES } from './registry';
+import { checkPostgres, checkRedisPing, getQueueDepths } from './checks';
+import { deriveReadinessFromServices, isWorkerHeartbeatStale, queueFailurePressure } from './state';
+import type { CoreServiceRuntimeView, PlatformHealthReport } from './types';
+
+const PLATFORM_ID = 'platform';
+
+function stripeConfigIssues(d: EnvDiagnostics): string[] {
+  const issues: string[] = [];
+  const hasSecret = Boolean(process.env.STRIPE_SECRET_KEY?.trim());
+  const hasWebhook = Boolean(process.env.STRIPE_WEBHOOK_SECRET?.trim());
+  if (hasSecret && !hasWebhook) {
+    issues.push('STRIPE_WEBHOOK_SECRET is required when STRIPE_SECRET_KEY is set (webhook idempotency and subscription sync).');
+  }
+  if (!hasSecret && hasWebhook) {
+    issues.push('STRIPE_SECRET_KEY is missing but STRIPE_WEBHOOK_SECRET is set; billing API calls will fail.');
+  }
+  return issues;
+}
+
+function githubConfigIssues(): { enabled: boolean; issues: string[]; summary: Record<string, string | boolean> } {
+  const appId = Boolean(process.env.GITHUB_APP_ID?.trim());
+  const pk = Boolean(process.env.GITHUB_APP_PRIVATE_KEY?.trim());
+  const clientId = Boolean(process.env.GITHUB_CLIENT_ID?.trim());
+  const clientSecret = Boolean(process.env.GITHUB_CLIENT_SECRET?.trim());
+  const any = appId || pk || clientId || clientSecret;
+  const appPair = appId && pk;
+  const oauthPair = clientId && clientSecret;
+  if (!any) {
+    return { enabled: false, issues: [], summary: { configured: false } };
+  }
+  if (!appPair && !oauthPair) {
+    return {
+      enabled: true,
+      issues: [
+        'Set either GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY (GitHub App) or GITHUB_CLIENT_ID + GITHUB_CLIENT_SECRET (OAuth).',
+      ],
+      summary: { configured: 'partial' },
+    };
+  }
+  return { enabled: true, issues: [], summary: { configured: true, mode: appPair ? 'github_app' : 'oauth' } };
+}
+
+function s3ConfigIssues(): { enabled: boolean; issues: string[]; summary: Record<string, string | boolean> } {
+  const b = Boolean(process.env.S3_BUCKET?.trim());
+  const r = Boolean(process.env.S3_REGION?.trim());
+  const k = Boolean(process.env.S3_ACCESS_KEY?.trim());
+  const s = Boolean(process.env.S3_SECRET_KEY?.trim());
+  const any = b || r || k || s;
+  if (!any) {
+    return { enabled: false, issues: [], summary: { configured: false } };
+  }
+  const issues: string[] = [];
+  if (!b) issues.push('S3_BUCKET is required when object storage is enabled.');
+  if (!r) issues.push('S3_REGION is required when object storage is enabled.');
+  if (!k || !s) issues.push('S3_ACCESS_KEY and S3_SECRET_KEY are both required when object storage is enabled.');
+  return {
+    enabled: true,
+    issues,
+    summary: {
+      configured: issues.length === 0,
+      bucketSet: b,
+      regionSet: r,
+    },
+  };
+}
+
+function aiConfigSummary(): { enabled: boolean; summary: Record<string, boolean> } {
+  const openai = Boolean(process.env.OPENAI_API_KEY?.trim());
+  const anthropic = Boolean(process.env.ANTHROPIC_API_KEY?.trim());
+  return {
+    enabled: openai || anthropic,
+    summary: { openai, anthropic },
+  };
+}
+
+export async function collectPlatformHealth(prisma: PrismaClient): Promise<PlatformHealthReport> {
+  const checkedAt = new Date().toISOString();
+  const envDiag = parseEnvDiagnostics(process.env);
+
+  const dbCheck = await checkPostgres(() => prisma.$queryRaw`SELECT 1`);
+  const redisUrl = process.env.REDIS_URL?.trim() || 'redis://localhost:6379';
+  const redisCheck = await checkRedisPing(redisUrl);
+
+  let platformRow: {
+    installedAt: Date;
+    bootstrapVersion: number;
+    workerLastHeartbeatAt: Date | null;
+  } | null = null;
+
+  if (dbCheck.ok) {
+    try {
+      platformRow = await prisma.platformState.findUnique({
+        where: { id: PLATFORM_ID },
+        select: { installedAt: true, bootstrapVersion: true, workerLastHeartbeatAt: true },
+      });
+    } catch {
+      platformRow = null;
+    }
+  }
+
+  const installed = platformRow !== null;
+
+  const queueResult = redisCheck.ok ? await getQueueDepths() : null;
+
+  const workerStale = isWorkerHeartbeatStale(platformRow?.workerLastHeartbeatAt ?? null);
+  const workerRunning = installed && redisCheck.ok && !workerStale && platformRow?.workerLastHeartbeatAt != null;
+
+  const qPressure =
+    queueResult?.ok === true ? queueFailurePressure(queueResult.snapshot) : { degraded: false, totalFailed: 0 };
+
+  const sessionOk = dbCheck.ok && envDiag.valid;
+
+  const services: CoreServiceRuntimeView[] = [];
+
+  for (const def of CORE_SERVICES) {
+    let view: CoreServiceRuntimeView;
+
+    switch (def.id) {
+      case 'app-api': {
+        const ok = envDiag.valid;
+        view = {
+          ...def,
+          enabled: true,
+          configState: envDiag.valid ? 'valid' : 'invalid',
+          configIssues: envDiag.valid ? [] : ['Fix environment validation errors (see config summary).'],
+          configSummary: { envValid: envDiag.valid },
+          healthState: ok ? 'ready' : 'misconfigured',
+          lastCheckAt: checkedAt,
+          lastActivityAt: null,
+          failureReason: ok ? null : 'Invalid deployment environment',
+          nextStep: ok ? 'No action required.' : 'Correct invalid environment variables and restart the app.',
+          dependencies: { env: { ok: envDiag.valid, checkedAt, message: envDiag.valid ? undefined : 'See fieldErrors' } },
+        };
+        break;
+      }
+      case 'database': {
+        view = {
+          ...def,
+          enabled: true,
+          configState: 'valid',
+          configIssues: [],
+          configSummary: { reachable: dbCheck.ok },
+          healthState: dbCheck.ok ? 'running' : 'unavailable',
+          lastCheckAt: checkedAt,
+          lastActivityAt: dbCheck.ok ? checkedAt : null,
+          failureReason: dbCheck.ok ? null : dbCheck.message ?? 'Unreachable',
+          nextStep: dbCheck.ok
+            ? 'No action required.'
+            : 'Verify DATABASE_URL and database availability; run migrations after connectivity is restored.',
+          dependencies: { postgres: dbCheck },
+        };
+        break;
+      }
+      case 'redis-queue': {
+        view = {
+          ...def,
+          enabled: true,
+          configState: 'valid',
+          configIssues: [],
+          configSummary: { reachable: redisCheck.ok, urlHost: redisUrl.split('@').pop()?.slice(0, 48) ?? 'default' },
+          healthState: redisCheck.ok ? 'running' : 'unavailable',
+          lastCheckAt: checkedAt,
+          lastActivityAt: redisCheck.ok ? checkedAt : null,
+          failureReason: redisCheck.ok ? null : (redisCheck.message ?? 'Redis unreachable'),
+          nextStep: redisCheck.ok
+            ? 'No action required.'
+            : 'Start Redis and set REDIS_URL; docker compose up includes Redis.',
+          dependencies: { redis: redisCheck },
+        };
+        break;
+      }
+      case 'worker-runtime': {
+        let health: CoreServiceRuntimeView['healthState'] = 'failed';
+        let reason: string | null = 'No recent worker heartbeat recorded.';
+        let next = 'Start the worker process: npm run dev:worker (or your process supervisor).';
+
+        if (!redisCheck.ok) {
+          health = 'unavailable';
+          reason = 'Redis unreachable; workers cannot run.';
+          next = 'Restore Redis first.';
+        } else if (!installed) {
+          health = 'unavailable';
+          reason = 'Platform not bootstrapped in database.';
+          next = 'Run npm run db:migrate && npm run db:seed.';
+        } else if (workerRunning) {
+          health = 'running';
+          reason = null;
+          next = 'No action required.';
+        } else if (platformRow?.workerLastHeartbeatAt) {
+          health = 'failed';
+          reason = `Last heartbeat at ${platformRow.workerLastHeartbeatAt.toISOString()} is stale (>${120}s).`;
+        }
+
+        view = {
+          ...def,
+          enabled: true,
+          configState: 'valid',
+          configIssues: [],
+          configSummary: {
+            heartbeatFresh: workerRunning,
+            lastHeartbeatAt: platformRow?.workerLastHeartbeatAt?.toISOString() ?? 'never',
+          },
+          healthState: health,
+          lastCheckAt: checkedAt,
+          lastActivityAt: platformRow?.workerLastHeartbeatAt?.toISOString() ?? null,
+          failureReason: reason,
+          nextStep: next,
+          dependencies: { redis: redisCheck, database: dbCheck },
+        };
+        break;
+      }
+      case 'job-pipelines': {
+        let health: CoreServiceRuntimeView['healthState'] = 'ready';
+        let reason: string | null = null;
+        let next = 'No action required.';
+
+        if (!dbCheck.ok || !redisCheck.ok) {
+          health = 'unavailable';
+          reason = !dbCheck.ok ? 'Database unavailable.' : 'Redis unavailable.';
+          next = 'Restore database and Redis.';
+        } else if (!workerRunning) {
+          health = 'failed';
+          reason = 'Workers are not processing jobs (missing or stale heartbeat).';
+          next = 'Start workers and verify they can reach Redis.';
+        } else if (queueResult?.ok === false) {
+          health = 'degraded';
+          reason = queueResult.message ?? 'Could not read queue metrics.';
+          next = 'Check Redis memory, BullMQ keys, and worker logs.';
+        } else if (qPressure.degraded) {
+          health = 'degraded';
+          reason = `Elevated failed job count across queues (${qPressure.totalFailed}).`;
+          next = 'Inspect failed jobs in Redis/BullMQ and worker error logs.';
+        } else {
+          health = 'running';
+        }
+
+        view = {
+          ...def,
+          enabled: true,
+          configState: 'valid',
+          configIssues: [],
+          configSummary:
+            queueResult?.ok === true
+              ? {
+                  queuesReadable: true,
+                  failedJobsTotal: qPressure.totalFailed,
+                }
+              : { queuesReadable: false },
+          healthState: health,
+          lastCheckAt: checkedAt,
+          lastActivityAt: platformRow?.workerLastHeartbeatAt?.toISOString() ?? null,
+          failureReason: reason,
+          nextStep: next,
+          dependencies: { postgres: dbCheck, redis: redisCheck },
+        };
+        break;
+      }
+      case 'session-auth': {
+        view = {
+          ...def,
+          enabled: true,
+          configState: envDiag.valid ? 'valid' : 'invalid',
+          configIssues: envDiag.valid ? [] : ['NEXTAUTH_SECRET and NEXTAUTH_URL must be valid for sessions.'],
+          configSummary: {
+            nextAuthUrlConfigured: Boolean(process.env.NEXTAUTH_URL?.trim()),
+            nextAuthSecretConfigured: Boolean(process.env.NEXTAUTH_SECRET && process.env.NEXTAUTH_SECRET.length >= 16),
+          },
+          healthState: sessionOk ? 'running' : dbCheck.ok ? 'misconfigured' : 'unavailable',
+          lastCheckAt: checkedAt,
+          lastActivityAt: null,
+          failureReason: sessionOk ? null : !dbCheck.ok ? dbCheck.message ?? null : 'Session environment invalid',
+          nextStep: sessionOk
+            ? 'No action required.'
+            : 'Fix NEXTAUTH_* and DATABASE_URL; see environment validation errors.',
+          dependencies: { postgres: dbCheck, env: { ok: envDiag.valid, checkedAt } },
+        };
+        break;
+      }
+      case 'stripe-billing': {
+        const issues = stripeConfigIssues(envDiag);
+        const hasAnyStripe = Boolean(process.env.STRIPE_SECRET_KEY?.trim() || process.env.STRIPE_WEBHOOK_SECRET?.trim());
+        const misconfigured = issues.length > 0;
+        const billingReady =
+          hasAnyStripe && !misconfigured && dbCheck.ok;
+        view = {
+          ...def,
+          enabled: hasAnyStripe,
+          configState: misconfigured ? 'invalid' : hasAnyStripe ? 'valid' : 'partial',
+          configIssues: issues,
+          configSummary: {
+            billingConfigured: hasAnyStripe && !misconfigured,
+          },
+          healthState: !hasAnyStripe
+            ? 'disabled'
+            : misconfigured
+              ? 'misconfigured'
+              : billingReady
+                ? 'ready'
+                : 'degraded',
+          lastCheckAt: checkedAt,
+          lastActivityAt: null,
+          failureReason: misconfigured ? issues[0] : !dbCheck.ok ? 'Database unavailable; billing state cannot be persisted safely.' : null,
+          nextStep: !hasAnyStripe
+            ? 'Optional: set STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET to enable billing.'
+            : misconfigured
+              ? issues[0]
+              : !dbCheck.ok
+                ? 'Restore database connectivity before relying on billing webhooks.'
+                : 'No action required for billing connectivity.',
+          dependencies: { postgres: dbCheck },
+        };
+        break;
+      }
+      case 'github-connector': {
+        const gh = githubConfigIssues();
+        const misconfigured = gh.issues.length > 0;
+        view = {
+          ...def,
+          enabled: gh.enabled,
+          configState: !gh.enabled ? 'partial' : misconfigured ? 'invalid' : 'valid',
+          configIssues: gh.issues,
+          configSummary: gh.summary as Record<string, string | boolean>,
+          healthState: !gh.enabled ? 'disabled' : misconfigured ? 'misconfigured' : dbCheck.ok ? 'ready' : 'unavailable',
+          lastCheckAt: checkedAt,
+          lastActivityAt: null,
+          failureReason: misconfigured ? gh.issues[0] : null,
+          nextStep: !gh.enabled
+            ? 'Optional: configure GitHub App or OAuth credentials for repository features.'
+            : misconfigured
+              ? gh.issues[0]
+              : 'No action required.',
+          dependencies: { postgres: dbCheck },
+        };
+        break;
+      }
+      case 'jira-connector': {
+        view = {
+          ...def,
+          enabled: true,
+          configState: 'partial',
+          configIssues: [],
+          configSummary: {
+            note: 'Connections are stored per organization in integration_connections (type JIRA).',
+          },
+          healthState: dbCheck.ok ? 'ready' : 'unavailable',
+          lastCheckAt: checkedAt,
+          lastActivityAt: null,
+          failureReason: dbCheck.ok ? null : dbCheck.message ?? null,
+          nextStep: dbCheck.ok
+            ? 'Add a Jira integration from organization settings when needed.'
+            : 'Restore database connectivity.',
+          dependencies: { postgres: dbCheck },
+        };
+        break;
+      }
+      case 'ai-remediation': {
+        const ai = aiConfigSummary();
+        view = {
+          ...def,
+          enabled: ai.enabled,
+          configState: ai.enabled ? 'valid' : 'partial',
+          configIssues: [],
+          configSummary: ai.summary as Record<string, string | boolean>,
+          healthState: ai.enabled ? (workerRunning ? 'running' : 'degraded') : 'disabled',
+          lastCheckAt: checkedAt,
+          lastActivityAt: null,
+          failureReason:
+            ai.enabled && !workerRunning
+              ? 'Remediation queue needs workers; heartbeat is missing or stale.'
+              : null,
+          nextStep: ai.enabled
+            ? workerRunning
+              ? 'No action required.'
+              : 'Start workers to process remediation jobs.'
+            : 'Optional: set OPENAI_API_KEY or ANTHROPIC_API_KEY for enhanced suggestions (rule-based path works without).',
+          dependencies: { redis: redisCheck },
+        };
+        break;
+      }
+      case 'object-storage': {
+        const s3 = s3ConfigIssues();
+        const misconfigured = s3.issues.length > 0;
+        view = {
+          ...def,
+          enabled: s3.enabled,
+          configState: !s3.enabled ? 'partial' : misconfigured ? 'invalid' : 'valid',
+          configIssues: s3.issues,
+          configSummary: s3.summary as Record<string, string | boolean>,
+          healthState: !s3.enabled ? 'disabled' : misconfigured ? 'misconfigured' : 'ready',
+          lastCheckAt: checkedAt,
+          lastActivityAt: null,
+          failureReason: misconfigured ? s3.issues[0] : null,
+          nextStep: !s3.enabled
+            ? 'Optional: configure S3_* variables for screenshot/evidence storage.'
+            : misconfigured
+              ? s3.issues[0]
+              : 'No action required.',
+          dependencies: {},
+        };
+        break;
+      }
+      default: {
+        view = {
+          ...def,
+          enabled: false,
+          configState: 'partial',
+          configIssues: [],
+          configSummary: {},
+          healthState: 'unavailable',
+          lastCheckAt: checkedAt,
+          lastActivityAt: null,
+          failureReason: 'Unknown service id in registry',
+          nextStep: 'Update @aros/core-services registry.',
+          dependencies: {},
+        };
+      }
+    }
+
+    services.push(view);
+  }
+
+  const readinessPartial = deriveReadinessFromServices(services);
+
+  const bootstrap = installed
+    ? {
+        installed: true as const,
+        installedAt: platformRow!.installedAt.toISOString(),
+        bootstrapVersion: platformRow!.bootstrapVersion,
+        ...readinessPartial,
+      }
+    : {
+        installed: false as const,
+        installedAt: null,
+        bootstrapVersion: 0,
+        readiness: 'not_installed' as const,
+        blockers: [
+          'Platform state row missing. Apply migrations and seed: npm run db:migrate && npm run db:seed.',
+        ],
+        warnings: [] as string[],
+      };
+
+  return {
+    checkedAt,
+    bootstrap,
+    dependencies: {
+      database: dbCheck,
+      redis: redisCheck,
+      sessionStore: {
+        ok: sessionOk,
+        checkedAt,
+        message: sessionOk ? undefined : 'Sessions require valid DB + NEXTAUTH_*',
+      },
+    },
+    services,
+  };
+}

--- a/packages/core-services/src/public-summary.test.ts
+++ b/packages/core-services/src/public-summary.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { toPublicHealthSummary } from './public-summary';
+import type { PlatformHealthReport } from './types';
+
+function baseReport(overrides: Partial<PlatformHealthReport> = {}): PlatformHealthReport {
+  const services = [
+    {
+      id: 'worker-runtime',
+      name: 'Workers',
+      purpose: 'p',
+      category: 'queue' as const,
+      criticality: 'critical' as const,
+      scope: 'deployment' as const,
+      userVisibleWhenDown: true,
+      enabled: true,
+      configState: 'valid' as const,
+      configIssues: [] as string[],
+      configSummary: {},
+      healthState: 'running' as const,
+      lastCheckAt: 't',
+      lastActivityAt: 't',
+      failureReason: null,
+      nextStep: 'n',
+      dependencies: {},
+    },
+    {
+      id: 'job-pipelines',
+      name: 'Pipelines',
+      purpose: 'p',
+      category: 'data' as const,
+      criticality: 'critical' as const,
+      scope: 'deployment' as const,
+      userVisibleWhenDown: true,
+      enabled: true,
+      configState: 'valid' as const,
+      configIssues: [],
+      configSummary: {},
+      healthState: 'running' as const,
+      lastCheckAt: 't',
+      lastActivityAt: null,
+      failureReason: null,
+      nextStep: 'n',
+      dependencies: {},
+    },
+  ];
+
+  return {
+    checkedAt: '2025-01-01T00:00:00.000Z',
+    bootstrap: {
+      installed: true,
+      installedAt: '2025-01-01T00:00:00.000Z',
+      bootstrapVersion: 1,
+      readiness: 'ready',
+      blockers: [],
+      warnings: [],
+    },
+    dependencies: {
+      database: { ok: true, checkedAt: 't' },
+      redis: { ok: true, checkedAt: 't' },
+      sessionStore: { ok: true, checkedAt: 't' },
+    },
+    services,
+    ...overrides,
+  };
+}
+
+describe('toPublicHealthSummary', () => {
+  it('ready when deps and worker ok', () => {
+    const s = toPublicHealthSummary(baseReport());
+    expect(s.ready).toBe(true);
+    expect(s.checks.worker).toBe(true);
+  });
+  it('not ready when worker failed', () => {
+    const report = baseReport();
+    report.services = report.services.map((x) =>
+      x.id === 'worker-runtime' ? { ...x, healthState: 'failed' as const } : x
+    );
+    expect(toPublicHealthSummary(report).ready).toBe(false);
+  });
+});

--- a/packages/core-services/src/public-summary.ts
+++ b/packages/core-services/src/public-summary.ts
@@ -1,0 +1,34 @@
+import type { PlatformHealthReport } from './types';
+
+/** Minimal, operator-safe payload for unauthenticated load balancers (no secrets, no config details). */
+export function toPublicHealthSummary(report: PlatformHealthReport) {
+  const worker = report.services.find((s) => s.id === 'worker-runtime');
+  const pipelines = report.services.find((s) => s.id === 'job-pipelines');
+
+  const workerOk = worker?.healthState === 'running';
+  const pipelinesOk =
+    pipelines?.healthState === 'running' || pipelines?.healthState === 'degraded';
+
+  const ready =
+    report.bootstrap.installed &&
+    report.dependencies.database.ok &&
+    report.dependencies.redis.ok &&
+    report.dependencies.sessionStore.ok &&
+    workerOk &&
+    pipelinesOk;
+
+  return {
+    checkedAt: report.checkedAt,
+    live: true,
+    installed: report.bootstrap.installed,
+    readiness: report.bootstrap.readiness,
+    ready,
+    checks: {
+      database: report.dependencies.database.ok,
+      redis: report.dependencies.redis.ok,
+      session: report.dependencies.sessionStore.ok,
+      worker: workerOk,
+      jobPipelines: pipelinesOk,
+    },
+  };
+}

--- a/packages/core-services/src/registry.ts
+++ b/packages/core-services/src/registry.ts
@@ -1,0 +1,111 @@
+import type { CoreServiceDefinition } from './types';
+
+/**
+ * Canonical registry of platform-managed capabilities.
+ * IDs are stable API contracts; add new services here and wire checks in orchestrator.
+ */
+export const CORE_SERVICES: CoreServiceDefinition[] = [
+  {
+    id: 'app-api',
+    name: 'Web application',
+    purpose: 'Serves the Next.js UI and API routes.',
+    category: 'data',
+    criticality: 'critical',
+    scope: 'deployment',
+    userVisibleWhenDown: true,
+  },
+  {
+    id: 'database',
+    name: 'PostgreSQL',
+    purpose: 'Primary data store for orgs, sites, findings, and platform state.',
+    category: 'data',
+    criticality: 'critical',
+    scope: 'deployment',
+    userVisibleWhenDown: true,
+  },
+  {
+    id: 'redis-queue',
+    name: 'Redis (BullMQ)',
+    purpose: 'Job queues for crawl, scan, cluster, and remediation workers.',
+    category: 'queue',
+    criticality: 'critical',
+    scope: 'deployment',
+    userVisibleWhenDown: true,
+  },
+  {
+    id: 'worker-runtime',
+    name: 'Background workers',
+    purpose: 'Processes queued crawl, scan, cluster, and remediation jobs.',
+    category: 'queue',
+    criticality: 'critical',
+    scope: 'deployment',
+    userVisibleWhenDown: true,
+  },
+  {
+    id: 'job-pipelines',
+    name: 'Accessibility job pipelines',
+    purpose: 'End-to-end crawl → scan → cluster → remediation execution path.',
+    category: 'data',
+    criticality: 'critical',
+    scope: 'deployment',
+    userVisibleWhenDown: true,
+  },
+  {
+    id: 'session-auth',
+    name: 'Sessions & sign-in',
+    purpose: 'Cookie-backed sessions and organization access control.',
+    category: 'auth',
+    criticality: 'critical',
+    scope: 'deployment',
+    userVisibleWhenDown: true,
+  },
+  {
+    id: 'stripe-billing',
+    name: 'Stripe billing',
+    purpose: 'Subscription lifecycle and webhook processing.',
+    category: 'billing',
+    criticality: 'optional',
+    scope: 'deployment',
+    userVisibleWhenDown: false,
+  },
+  {
+    id: 'github-connector',
+    name: 'GitHub connector',
+    purpose: 'Repository mappings and GitHub App connectivity.',
+    category: 'integration',
+    criticality: 'optional',
+    scope: 'deployment',
+    userVisibleWhenDown: false,
+  },
+  {
+    id: 'jira-connector',
+    name: 'Jira connector',
+    purpose: 'Export and ticketing integrations (org connections in database).',
+    category: 'integration',
+    criticality: 'optional',
+    scope: 'deployment',
+    userVisibleWhenDown: false,
+  },
+  {
+    id: 'ai-remediation',
+    name: 'AI-assisted remediation',
+    purpose: 'Optional LLM-backed suggestion quality (rule-based fallback without keys).',
+    category: 'ai',
+    criticality: 'optional',
+    scope: 'deployment',
+    userVisibleWhenDown: false,
+  },
+  {
+    id: 'object-storage',
+    name: 'Object storage (S3)',
+    purpose: 'Screenshots and evidence artifacts when configured.',
+    category: 'storage',
+    criticality: 'optional',
+    scope: 'deployment',
+    userVisibleWhenDown: false,
+  },
+];
+
+export function getServiceDefinition(id: string): CoreServiceDefinition | undefined {
+  return CORE_SERVICES.find((s) => s.id === id);
+}

--- a/packages/core-services/src/state.test.ts
+++ b/packages/core-services/src/state.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveReadinessFromServices,
+  isWorkerHeartbeatStale,
+  queueFailurePressure,
+} from './state';
+
+describe('isWorkerHeartbeatStale', () => {
+  it('returns true when null', () => {
+    expect(isWorkerHeartbeatStale(null)).toBe(true);
+  });
+  it('returns false for fresh heartbeat', () => {
+    expect(isWorkerHeartbeatStale(new Date())).toBe(false);
+  });
+  it('returns true for old heartbeat', () => {
+    expect(isWorkerHeartbeatStale(new Date(Date.now() - 300_000))).toBe(true);
+  });
+});
+
+describe('queueFailurePressure', () => {
+  it('flags degraded when many failures', () => {
+    const r = queueFailurePressure({
+      crawl: { failed: 30 },
+      scan: { failed: 0 },
+      cluster: { failed: 0 },
+      remediation: { failed: 0 },
+    });
+    expect(r.degraded).toBe(true);
+    expect(r.totalFailed).toBe(30);
+  });
+});
+
+describe('deriveReadinessFromServices', () => {
+  it('blocked when critical service failed', () => {
+    const r = deriveReadinessFromServices([
+      { id: 'database', criticality: 'critical', healthState: 'failed' },
+    ]);
+    expect(r.readiness).toBe('blocked');
+    expect(r.blockers.length).toBeGreaterThan(0);
+  });
+  it('degraded when only warnings', () => {
+    const r = deriveReadinessFromServices([
+      { id: 'x', criticality: 'critical', healthState: 'degraded' },
+      { id: 'y', criticality: 'critical', healthState: 'running' },
+    ]);
+    expect(r.readiness).toBe('degraded');
+  });
+});

--- a/packages/core-services/src/state.ts
+++ b/packages/core-services/src/state.ts
@@ -1,0 +1,45 @@
+import type { CoreServiceRuntimeView, PlatformBootstrapStatus, PlatformReadiness } from './types';
+
+const WORKER_STALE_MS = 120_000;
+const FAILED_JOBS_WARNING = 25;
+
+export function isWorkerHeartbeatStale(lastHeartbeatAt: Date | null | undefined): boolean {
+  if (!lastHeartbeatAt) return true;
+  return Date.now() - lastHeartbeatAt.getTime() > WORKER_STALE_MS;
+}
+
+export function queueFailurePressure(snapshot: {
+  crawl: { failed: number };
+  scan: { failed: number };
+  cluster: { failed: number };
+  remediation: { failed: number };
+}): { degraded: boolean; totalFailed: number } {
+  const totalFailed =
+    snapshot.crawl.failed + snapshot.scan.failed + snapshot.cluster.failed + snapshot.remediation.failed;
+  return { degraded: totalFailed >= FAILED_JOBS_WARNING, totalFailed };
+}
+
+export function deriveReadinessFromServices(
+  services: Pick<CoreServiceRuntimeView, 'id' | 'criticality' | 'healthState'>[]
+): Pick<PlatformBootstrapStatus, 'readiness' | 'blockers' | 'warnings'> {
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+
+  for (const s of services) {
+    if (s.criticality !== 'critical') continue;
+    if (s.healthState === 'failed' || s.healthState === 'unavailable' || s.healthState === 'misconfigured') {
+      blockers.push(`${s.id}: ${s.healthState}`);
+    } else if (s.healthState === 'degraded') {
+      warnings.push(`${s.id} is degraded`);
+    }
+  }
+
+  let readiness: PlatformReadiness = 'ready';
+  if (blockers.length > 0) {
+    readiness = 'blocked';
+  } else if (warnings.length > 0) {
+    readiness = 'degraded';
+  }
+
+  return { readiness, blockers, warnings };
+}

--- a/packages/core-services/src/types.ts
+++ b/packages/core-services/src/types.ts
@@ -1,0 +1,75 @@
+export type ServiceCriticality = 'critical' | 'optional';
+
+export type ServiceCategory =
+  | 'data'
+  | 'queue'
+  | 'auth'
+  | 'billing'
+  | 'integration'
+  | 'ai'
+  | 'storage';
+
+export type ServiceScope = 'deployment' | 'organization';
+
+/** Unified runtime + config posture for a registered service */
+export type ServiceHealthState =
+  | 'unavailable'
+  | 'disabled'
+  | 'misconfigured'
+  | 'ready'
+  | 'running'
+  | 'degraded'
+  | 'failed';
+
+export interface CoreServiceDefinition {
+  id: string;
+  name: string;
+  purpose: string;
+  category: ServiceCategory;
+  criticality: ServiceCriticality;
+  scope: ServiceScope;
+  /** When false, service is deployment-gated (not merely misconfigured) */
+  userVisibleWhenDown: boolean;
+}
+
+export interface DependencyCheckResult {
+  ok: boolean;
+  message?: string;
+  checkedAt: string;
+}
+
+export interface CoreServiceRuntimeView extends CoreServiceDefinition {
+  enabled: boolean;
+  configState: 'valid' | 'invalid' | 'partial';
+  configIssues: string[];
+  /** Non-sensitive summary only */
+  configSummary: Record<string, string | boolean | number>;
+  healthState: ServiceHealthState;
+  lastCheckAt: string | null;
+  lastActivityAt: string | null;
+  failureReason: string | null;
+  nextStep: string;
+  dependencies: Record<string, DependencyCheckResult>;
+}
+
+export type PlatformReadiness = 'not_installed' | 'blocked' | 'degraded' | 'ready';
+
+export interface PlatformBootstrapStatus {
+  installed: boolean;
+  installedAt: string | null;
+  bootstrapVersion: number;
+  readiness: PlatformReadiness;
+  blockers: string[];
+  warnings: string[];
+}
+
+export interface PlatformHealthReport {
+  checkedAt: string;
+  bootstrap: PlatformBootstrapStatus;
+  dependencies: {
+    database: DependencyCheckResult;
+    redis: DependencyCheckResult;
+    sessionStore: DependencyCheckResult;
+  };
+  services: CoreServiceRuntimeView[];
+}

--- a/packages/core-services/tsconfig.json
+++ b/packages/core-services/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/core-services/vitest.config.ts
+++ b/packages/core-services/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,6 +9,7 @@
     "push": "prisma db push --schema=prisma/schema.prisma",
     "migrate": "prisma migrate dev --schema=prisma/schema.prisma",
     "seed": "tsx prisma/seed.ts",
+    "bootstrap": "tsx scripts/ensure-platform.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/db/prisma/migrations/20250322120000_platform_state/migration.sql
+++ b/packages/db/prisma/migrations/20250322120000_platform_state/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "platform_state" (
+    "id" TEXT NOT NULL DEFAULT 'platform',
+    "installedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "bootstrapVersion" INTEGER NOT NULL DEFAULT 1,
+    "workerLastHeartbeatAt" TIMESTAMP(3),
+    "productFlags" JSONB NOT NULL DEFAULT '{}',
+
+    CONSTRAINT "platform_state_pkey" PRIMARY KEY ("id")
+);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -591,6 +591,19 @@ model UsageRecord {
   @@map("usage_records")
 }
 
+// ─── PLATFORM / INSTALL ───────────────────────────────────────
+
+/// Singleton row: installation marker, worker liveness, optional product flags (non-secret).
+model PlatformState {
+  id                    String    @id @default("platform")
+  installedAt           DateTime  @default(now())
+  bootstrapVersion      Int       @default(1)
+  workerLastHeartbeatAt DateTime?
+  productFlags          Json      @default("{}")
+
+  @@map("platform_state")
+}
+
 // ─── AUDIT ───────────────────────────────────────────────────
 
 model AuditLog {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -12,6 +12,16 @@ async function hashPassword(password: string): Promise<string> {
 async function main() {
   console.log('Seeding database...');
 
+  await prisma.platformState.upsert({
+    where: { id: 'platform' },
+    create: {
+      id: 'platform',
+      bootstrapVersion: 1,
+      productFlags: {},
+    },
+    update: {},
+  });
+
   // Create demo user
   const passwordHash = await hashPassword('demo1234');
   const user = await prisma.user.upsert({

--- a/packages/db/scripts/ensure-platform.ts
+++ b/packages/db/scripts/ensure-platform.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const row = await prisma.platformState.upsert({
+    where: { id: 'platform' },
+    create: {
+      id: 'platform',
+      bootstrapVersion: 1,
+      productFlags: {},
+    },
+    update: {},
+  });
+  console.log('Platform state OK:', {
+    id: row.id,
+    installedAt: row.installedAt.toISOString(),
+    bootstrapVersion: row.bootstrapVersion,
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error('Bootstrap failed:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,18 +25,27 @@ fi
 echo "5. Generating Prisma client..."
 npm run db:generate
 
-echo "6. Pushing database schema..."
-npm run db:push
+echo "6. Applying database schema..."
+if [ "${AROS_USE_MIGRATE:-}" = "1" ]; then
+  npm run db:migrate
+else
+  npm run db:push
+fi
 
 echo "7. Seeding database..."
 npm run db:seed
+
+echo "8. Ensuring platform bootstrap row..."
+npm run bootstrap
 
 echo ""
 echo "=== Setup Complete ==="
 echo ""
 echo "To start development:"
 echo "  npm run dev          # Start web app on http://localhost:3000"
-echo "  npm run dev:worker   # Start background workers"
+echo "  npm run dev:worker   # Start background workers (required for live worker status)"
+echo ""
+echo "Production-style schema: set AROS_USE_MIGRATE=1 before running this script to use db:migrate instead of db:push."
 echo ""
 echo "Demo credentials:"
 echo "  Email: demo@aros.dev"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Connects crawl/scan/cluster/remediation workers, database, Redis, and environment validation into a single **canonical core-services layer** (`@aros/core-services`) with **real** checks (Postgres ping, Redis PING, BullMQ queue counts, worker heartbeat) and an **operator-facing** `/system` page plus authenticated JSON API.

## Key changes

- **`platform_state`** Prisma model: install/bootstrap marker + `workerLastHeartbeatAt` (migration added; folder is gitignored except forced-add for this migration).
- **`@aros/core-services`**: service registry, `collectPlatformHealth`, public health summary for load balancers.
- **Worker**: writes heartbeat every 30s via Prisma upsert (creates row if missing).
- **Config**: `getEnv()`, `parseEnvDiagnostics()` — health reporting without leaking secrets.
- **Web**: `GET /api/health` (503 when not ready), `GET /api/org/:id/platform/health` (OWNER/ADMIN + `org:system:view`), `/system` UI, sidebar link, graceful degradation on dashboard/findings when DB throws.
- **Docs**: `docs/PLATFORM_CORE_SERVICES.md`; `scripts/setup.sh` runs `npm run bootstrap` after seed; optional `AROS_USE_MIGRATE=1` for `db:migrate`.

## Verification

- `npm run verify` (lint, typecheck, test, build) — **passed** in this environment.
- Docker not available here — **no** live Postgres/Redis smoke; follow doc steps locally.

## Follow-up

- Consider removing `migrations/` from `.gitignore` so future migrations are tracked without `-f`.
- Extend orchestrator tests with integration tests behind `DATABASE_URL` when CI has services.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54f90d21-3275-487a-a1ed-36ee3f06fbc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54f90d21-3275-487a-a1ed-36ee3f06fbc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

