### PR TITLE
Operator remediation: diagnostics, control-plane actions, audit

### DIFF
--- a/apps/web/e2e/reliability.spec.ts
+++ b/apps/web/e2e/reliability.spec.ts
@@ -16,6 +16,8 @@ test.describe('reliability surfaces', () => {
     await signInAsDemo(page);
     await page.goto('/system');
     await expect(page.getByRole('heading', { name: /system & core services/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /first-run/i })).toBeVisible();
+    await expect(page.getByTestId('platform-recheck-button')).toBeVisible();
 
     const list = page.getByTestId('core-services-list');
     await expect(list).toBeVisible();

--- a/apps/web/src/app/(dashboard)/system/page.tsx
+++ b/apps/web/src/app/(dashboard)/system/page.tsx
@@ -7,6 +7,11 @@ import { redirect } from 'next/navigation';
 import { getPlatformHealthPayload } from '@/lib/platform-health';
 import { getRoutePlatformTruth } from '@/lib/platform-truth-cache';
 import { RouteReliabilityNotice } from '@/components/reliability/route-reliability-notice';
+import {
+  IssueAcknowledgeButton,
+  OperatorControlPlaneClient,
+} from '@/components/system/operator-control-plane-client';
+import { parseOperatorPlatformFlags, type PlatformDiagnosticIssue } from '@aros/core-services';
 
 export const metadata = { title: 'System & services - AROS' };
 
@@ -64,18 +69,19 @@ export default async function SystemPage() {
     redirect('/dashboard');
   }
 
+  const orgId = membership.organizationId;
+  const canRunOperatorActions = hasPermission(membership.role as MemberRole, 'org:system:manage');
+
   const platformTruth = await getRoutePlatformTruth().catch(() => null);
 
   let payload: Awaited<ReturnType<typeof getPlatformHealthPayload>> | null = null;
   let loadError: string | null = null;
   try {
-    payload = await getPlatformHealthPayload();
+    payload = await getPlatformHealthPayload(orgId);
   } catch (e) {
     loadError = e instanceof Error ? e.message : 'Failed to load platform health';
     console.error('[system] platform health failed', e);
   }
-
-  const orgId = membership.organizationId;
 
   return (
     <div className="space-y-8">
@@ -84,6 +90,13 @@ export default async function SystemPage() {
         <p className="text-slate-500 mt-1">
           Live deployment status for {membership.organization.name}. Values are derived from connectivity checks, queue
           metrics, and worker heartbeats — not static placeholders.
+        </p>
+        <p className="mt-3 text-sm text-slate-600 max-w-3xl">
+          <span className="font-medium text-slate-800">Deployment-managed</span> settings (secrets, DATABASE_URL,
+          REDIS_URL, integration keys) are never editable here — only validated and summarized.{' '}
+          <span className="font-medium text-slate-800">In-product</span> actions (recheck, acknowledgements, optional banner
+          suppression) require the <span className="font-mono text-xs">org:system:manage</span> permission (owners and
+          admins) and persist to platform audit logs for this organization.
         </p>
       </div>
 
@@ -110,6 +123,91 @@ export default async function SystemPage() {
 
       {payload && (
         <>
+          <section className="card space-y-4" aria-labelledby="setup-heading">
+            <h2 id="setup-heading" className="text-lg font-semibold text-slate-900">
+              First-run &amp; setup checklist
+            </h2>
+            <p className="text-sm text-slate-600">
+              Blocking steps must pass before the deployment is ready for normal operator use. Optional steps improve
+              integrations but do not gate core scanning.
+            </p>
+            <ol className="mt-2 space-y-2">
+              {payload.diagnostics.setupChecklist.map((step) => (
+                <li
+                  key={step.id}
+                  className={`flex flex-wrap items-start gap-2 rounded-md border p-3 text-sm ${
+                    step.done ? 'border-emerald-200 bg-emerald-50/50' : 'border-amber-200 bg-amber-50/40'
+                  }`}
+                >
+                  <span className="font-mono text-xs text-slate-500 shrink-0" aria-hidden>
+                    {step.done ? '✓' : '○'}
+                  </span>
+                  <div>
+                    <p className="font-medium text-slate-900">{step.title}</p>
+                    <p className="text-slate-600 mt-0.5">{step.detail}</p>
+                    <p className="text-xs text-slate-500 mt-1">
+                      {step.blocking ? 'Blocking' : 'Non-blocking'} ·{' '}
+                      {step.fixInProduct ? 'Fix in product where applicable' : 'Fix in deployment / infrastructure'}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className="card space-y-4" aria-labelledby="operator-actions-heading">
+            <h2 id="operator-actions-heading" className="text-lg font-semibold text-slate-900">
+              Operator actions
+            </h2>
+            <ul className="text-sm text-slate-600 space-y-1 list-disc list-inside">
+              {payload.operatorActions.map((a) => (
+                <li key={a.id}>
+                  <span className="font-medium text-slate-800">{a.label}</span> — {a.description}
+                </li>
+              ))}
+            </ul>
+            {canRunOperatorActions ? (
+              <OperatorControlPlaneClient
+                organizationId={orgId}
+                optionalIssueIds={optionalDiagnosticIds(payload)}
+                initialSuppressedIds={
+                  parseOperatorPlatformFlags(payload.report.operatorPlatformFlags).prefs.suppressedOptionalDiagnosticIds
+                }
+              />
+            ) : (
+              <p className="text-sm text-slate-600" role="status">
+                Your role can view diagnostics but cannot run in-product platform actions. Ask an organization owner or
+                admin.
+              </p>
+            )}
+          </section>
+
+          <DiagnosticBucketsSection orgId={orgId} payload={payload} canAcknowledge={canRunOperatorActions} />
+
+          <section className="card space-y-3" aria-labelledby="audit-heading">
+            <h2 id="audit-heading" className="text-lg font-semibold text-slate-900">
+              Recent platform actions (audit)
+            </h2>
+            <p className="text-sm text-slate-600">
+              Organization-scoped audit entries for rechecks, acknowledgements, and operator preferences. No secrets are
+              stored in metadata.
+            </p>
+            {payload.recentPlatformActions.length === 0 ? (
+              <p className="text-sm text-slate-500">No platform actions recorded yet for this organization.</p>
+            ) : (
+              <ul className="divide-y divide-slate-100 text-sm">
+                {payload.recentPlatformActions.map((row: (typeof payload.recentPlatformActions)[number]) => (
+                  <li key={row.id} className="py-2 flex flex-wrap gap-2 justify-between">
+                    <span className="font-mono text-xs text-slate-700">{row.action}</span>
+                    <time className="text-slate-500 text-xs" dateTime={row.createdAt.toISOString()}>
+                      {row.createdAt.toISOString()}
+                    </time>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
           <section className="card space-y-4" aria-labelledby="readiness-heading">
             <h2 id="readiness-heading" className="text-lg font-semibold text-slate-900">
               Platform readiness
@@ -187,7 +285,9 @@ export default async function SystemPage() {
               </Link>
             </div>
             <div className="space-y-3" data-testid="core-services-list">
-              {payload.report.services.map((svc) => (
+              {payload.report.services.map((svc) => {
+                const diag = diagnosticForService(payload.diagnostics.issues, svc.id);
+                return (
                 <article
                   key={svc.id}
                   className="card border border-slate-200"
@@ -210,6 +310,72 @@ export default async function SystemPage() {
                       {svc.healthState}
                     </span>
                   </div>
+                  {diag && (
+                    <div
+                      className="mt-4 rounded-md border border-slate-200 bg-slate-50 p-3 text-sm space-y-2"
+                      data-testid={`service-diagnostic-${svc.id}`}
+                    >
+                      <p className="font-medium text-slate-900">Operator diagnostic</p>
+                      <dl className="grid gap-1 text-xs sm:grid-cols-2 text-slate-700">
+                        <div>
+                          <dt className="text-slate-500">Severity</dt>
+                          <dd className="font-mono">{diag.severity}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-slate-500">Blocks readiness</dt>
+                          <dd>{diag.blocksReadiness ? 'Yes' : 'No'}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-slate-500">End-user impact</dt>
+                          <dd>{diag.appUsable ? 'App may still be usable' : 'App likely unusable for core flows'}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-slate-500">Fix location</dt>
+                          <dd>
+                            {diag.fixInProduct ? 'In-product / org settings' : 'Deployment or infrastructure'}
+                            {diag.requiresDeployOrInfra ? ' (env change required)' : ''}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="text-slate-500">Recheck safe</dt>
+                          <dd>{diag.retrySafe ? 'Yes' : 'No — may need infra change first'}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-slate-500">Who acts</dt>
+                          <dd className="font-mono text-[11px]">{diag.whoShouldAct}</dd>
+                        </div>
+                      </dl>
+                      <p className="text-slate-800">
+                        <span className="font-medium">Summary: </span>
+                        {diag.summary}
+                      </p>
+                      <p className="text-slate-700">
+                        <span className="font-medium">Impact: </span>
+                        {diag.impactUser}
+                      </p>
+                      <p className="text-slate-700">
+                        <span className="font-medium">Operator: </span>
+                        {diag.impactOperator}
+                      </p>
+                      <p className="text-slate-800">
+                        <span className="font-medium">Next step: </span>
+                        {diag.recommendedNextStep}
+                      </p>
+                      {diag.evidence.length > 0 && (
+                        <details>
+                          <summary className="cursor-pointer text-xs font-medium text-slate-600">Evidence</summary>
+                          <ul className="mt-1 list-inside list-disc text-xs text-slate-600">
+                            {diag.evidence.map((ev) => (
+                              <li key={ev}>{ev}</li>
+                            ))}
+                          </ul>
+                        </details>
+                      )}
+                      {canRunOperatorActions && (
+                        <IssueAcknowledgeButton organizationId={orgId} issue={diag} />
+                      )}
+                    </div>
+                  )}
                   <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
                     <div>
                       <dt className="text-slate-500">Enabled</dt>
@@ -256,11 +422,119 @@ export default async function SystemPage() {
                     </details>
                   )}
                 </article>
-              ))}
+              );
+              })}
             </div>
           </section>
         </>
       )}
+    </div>
+  );
+}
+
+function optionalDiagnosticIds(payload: NonNullable<Awaited<ReturnType<typeof getPlatformHealthPayload>>>) {
+  const optionalSvcIds = new Set(
+    payload.report.services.filter((s) => s.criticality === 'optional').map((s) => s.id)
+  );
+  return payload.diagnostics.issues
+    .filter((i) => i.target.kind === 'service' && optionalSvcIds.has(i.target.id))
+    .map((i) => i.id);
+}
+
+function diagnosticForService(issues: PlatformDiagnosticIssue[], serviceId: string) {
+  return issues.find((i) => i.target.kind === 'service' && i.target.id === serviceId) ?? null;
+}
+
+function DiagnosticBucketsSection({
+  orgId,
+  payload,
+  canAcknowledge,
+}: {
+  orgId: string;
+  payload: NonNullable<Awaited<ReturnType<typeof getPlatformHealthPayload>>>;
+  canAcknowledge: boolean;
+}) {
+  const s = payload.diagnostics.summary;
+  return (
+    <section className="card space-y-4" aria-labelledby="diagnostics-heading">
+      <h2 id="diagnostics-heading" className="text-lg font-semibold text-slate-900">
+        Control plane summary
+      </h2>
+      <p className="text-sm text-slate-600">
+        Derived from the same live report as core services. Acknowledgements and optional suppressions only change how
+        issues are highlighted — not underlying connectivity.
+      </p>
+      <BucketList
+        title="Critical blockers"
+        issues={s.criticalBlockers}
+        orgId={orgId}
+        tone="red"
+        canAcknowledge={canAcknowledge}
+      />
+      <BucketList
+        title="Recoverable / high severity"
+        issues={s.recoverableIssues}
+        orgId={orgId}
+        tone="amber"
+        canAcknowledge={canAcknowledge}
+      />
+      <BucketList title="Warnings" issues={s.warnings} orgId={orgId} tone="amber" canAcknowledge={canAcknowledge} />
+      <BucketList
+        title="Optional services affected"
+        issues={s.optionalUnavailable}
+        orgId={orgId}
+        tone="slate"
+        canAcknowledge={canAcknowledge}
+      />
+      {s.acknowledgedIssues.length > 0 && (
+        <BucketList
+          title="Acknowledged (informational)"
+          issues={s.acknowledgedIssues}
+          orgId={orgId}
+          tone="slate"
+          canAcknowledge={canAcknowledge}
+        />
+      )}
+    </section>
+  );
+}
+
+function BucketList({
+  title,
+  issues,
+  orgId,
+  tone,
+  canAcknowledge,
+}: {
+  title: string;
+  issues: PlatformDiagnosticIssue[];
+  orgId: string;
+  tone: 'red' | 'amber' | 'slate';
+  canAcknowledge: boolean;
+}) {
+  const border =
+    tone === 'red' ? 'border-red-200' : tone === 'amber' ? 'border-amber-200' : 'border-slate-200';
+  if (issues.length === 0) {
+    return (
+      <div className={`rounded-lg border ${border} p-3`}>
+        <h3 className="text-sm font-medium text-slate-800">{title}</h3>
+        <p className="text-sm text-slate-500 mt-1">None</p>
+      </div>
+    );
+  }
+  return (
+    <div className={`rounded-lg border ${border} p-3 space-y-2`}>
+      <h3 className="text-sm font-medium text-slate-900">{title}</h3>
+      <ul className="space-y-3">
+        {issues.map((issue) => (
+          <li key={issue.id} className="text-sm text-slate-700 border-t border-slate-100 pt-2 first:border-0 first:pt-0">
+            <p className="font-medium text-slate-900">{issue.summary}</p>
+            <p className="text-xs text-slate-500 mt-1 font-mono">{issue.id}</p>
+            <p className="mt-1">{issue.recommendedNextStep}</p>
+            {canAcknowledge && <IssueAcknowledgeButton organizationId={orgId} issue={issue} />}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/apps/web/src/app/api/org/[organizationId]/platform/acknowledge/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/acknowledge/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { collectPlatformHealth, derivePlatformDiagnostics, parseOperatorPlatformFlags } from '@aros/core-services';
+import { requireOrgAccess } from '@/lib/auth-guard';
+import { prisma } from '@/lib/db';
+import { apiError } from '@/lib/api-utils';
+import { logOperatorPlatformAction } from '@/lib/operator-platform-audit';
+import { updateOperatorFlags } from '@/lib/operator-product-flags';
+import { getPlatformHealthPayload } from '@/lib/platform-health';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  issueId: z.string().min(1).max(256),
+});
+
+export async function POST(
+  req: Request,
+  context: { params: Promise<{ organizationId: string }> }
+) {
+  try {
+    const { organizationId } = await context.params;
+    const ctx = await requireOrgAccess(organizationId, 'org:system:manage');
+    const json = await req.json().catch(() => null);
+    const parsedBody = bodySchema.safeParse(json);
+    if (!parsedBody.success) {
+      await logOperatorPlatformAction({
+        organizationId,
+        userId: ctx.user.id,
+        action: 'platform.issue.acknowledged',
+        outcome: 'validation_failed',
+        metadata: { reason: 'invalid_body' },
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error: { code: 'VALIDATION_ERROR', message: 'Invalid request body', details: parsedBody.error.flatten() },
+        },
+        { status: 400 }
+      );
+    }
+    const { issueId } = parsedBody.data;
+
+    const report = await collectPlatformHealth(prisma);
+    const flags = parseOperatorPlatformFlags(report.operatorPlatformFlags);
+    const { issues } = derivePlatformDiagnostics(report, flags);
+    const known = issues.some((i) => i.id === issueId);
+    if (!known) {
+      await logOperatorPlatformAction({
+        organizationId,
+        userId: ctx.user.id,
+        action: 'platform.issue.acknowledged',
+        outcome: 'validation_failed',
+        metadata: { issueId, reason: 'unknown_issue' },
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'UNKNOWN_ISSUE',
+            message: 'No active diagnostic matches this id after the latest check.',
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    await updateOperatorFlags((current) => {
+      const next = new Set(current.acknowledgements.acknowledgedIssueIds);
+      next.add(issueId);
+      return {
+        ...current,
+        acknowledgements: {
+          acknowledgedIssueIds: [...next],
+          updatedAt: new Date().toISOString(),
+        },
+      };
+    });
+
+    await logOperatorPlatformAction({
+      organizationId,
+      userId: ctx.user.id,
+      action: 'platform.issue.acknowledged',
+      outcome: 'success',
+      metadata: { issueId },
+    });
+
+    const payload = await getPlatformHealthPayload(organizationId);
+    return NextResponse.json({ success: true, data: { issueId, payload } });
+  } catch (e) {
+    return apiError(e);
+  }
+}

--- a/apps/web/src/app/api/org/[organizationId]/platform/health/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/health/route.ts
@@ -12,7 +12,7 @@ export async function GET(
   try {
     const { organizationId } = await context.params;
     await requireOrgAccess(organizationId, 'org:system:view');
-    const payload = await getPlatformHealthPayload();
+    const payload = await getPlatformHealthPayload(organizationId);
     return NextResponse.json({ success: true, data: payload });
   } catch (e) {
     return apiError(e);

--- a/apps/web/src/app/api/org/[organizationId]/platform/operator-preferences/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/operator-preferences/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireOrgAccess } from '@/lib/auth-guard';
+import { apiError } from '@/lib/api-utils';
+import { logOperatorPlatformAction } from '@/lib/operator-platform-audit';
+import { updateOperatorFlags } from '@/lib/operator-product-flags';
+import { getPlatformHealthPayload } from '@/lib/platform-health';
+import { validateSuppressedOptionalDiagnosticIds } from '@/lib/operator-preferences-validation';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  suppressedOptionalDiagnosticIds: z.array(z.string().min(3).max(256)).max(32),
+});
+
+export async function PATCH(
+  req: Request,
+  context: { params: Promise<{ organizationId: string }> }
+) {
+  try {
+    const { organizationId } = await context.params;
+    const ctx = await requireOrgAccess(organizationId, 'org:system:manage');
+    const json = await req.json().catch(() => null);
+    const parsedBody = bodySchema.safeParse(json);
+    if (!parsedBody.success) {
+      await logOperatorPlatformAction({
+        organizationId,
+        userId: ctx.user.id,
+        action: 'platform.operator_prefs.updated',
+        outcome: 'validation_failed',
+        metadata: { reason: 'invalid_body' },
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error: { code: 'VALIDATION_ERROR', message: 'Invalid request body', details: parsedBody.error.flatten() },
+        },
+        { status: 400 }
+      );
+    }
+
+    const ids = parsedBody.data.suppressedOptionalDiagnosticIds;
+    const validation = validateSuppressedOptionalDiagnosticIds(ids);
+    if (!validation.ok) {
+      const invalid = validation.invalid;
+      await logOperatorPlatformAction({
+        organizationId,
+        userId: ctx.user.id,
+        action: 'platform.operator_prefs.updated',
+        outcome: 'validation_failed',
+        metadata: { invalidIds: invalid },
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'INVALID_DIAGNOSTIC_IDS',
+            message: 'Only optional core-service diagnostics (svc:<serviceId>) may be suppressed.',
+            details: { invalid },
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    await updateOperatorFlags((current) => ({
+      ...current,
+      prefs: {
+        ...current.prefs,
+        suppressedOptionalDiagnosticIds: [...new Set(ids)],
+      },
+    }));
+
+    await logOperatorPlatformAction({
+      organizationId,
+      userId: ctx.user.id,
+      action: 'platform.operator_prefs.updated',
+      outcome: 'success',
+      metadata: { count: ids.length },
+    });
+
+    const payload = await getPlatformHealthPayload(organizationId);
+    return NextResponse.json({ success: true, data: { suppressedOptionalDiagnosticIds: ids, payload } });
+  } catch (e) {
+    return apiError(e);
+  }
+}

--- a/apps/web/src/app/api/org/[organizationId]/platform/recheck/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/recheck/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { requireOrgAccess } from '@/lib/auth-guard';
+import { getPlatformHealthPayload } from '@/lib/platform-health';
+import { apiError } from '@/lib/api-utils';
+import { logOperatorPlatformAction } from '@/lib/operator-platform-audit';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _req: Request,
+  context: { params: Promise<{ organizationId: string }> }
+) {
+  try {
+    const { organizationId } = await context.params;
+    const ctx = await requireOrgAccess(organizationId, 'org:system:manage');
+    const payload = await getPlatformHealthPayload(organizationId);
+    await logOperatorPlatformAction({
+      organizationId,
+      userId: ctx.user.id,
+      action: 'platform.recheck',
+      outcome: 'success',
+      metadata: {
+        readiness: payload.report.bootstrap.readiness,
+        checkedAt: payload.report.checkedAt,
+      },
+    });
+    return NextResponse.json({
+      success: true,
+      data: {
+        kind: 'synchronous_recheck',
+        checkedAt: payload.report.checkedAt,
+        payload,
+      },
+    });
+  } catch (e) {
+    return apiError(e);
+  }
+}

--- a/apps/web/src/components/system/operator-control-plane-client.tsx
+++ b/apps/web/src/components/system/operator-control-plane-client.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useState, useTransition } from 'react';
+import type { PlatformDiagnosticIssue } from '@aros/core-services';
+
+interface Props {
+  organizationId: string;
+  optionalIssueIds: string[];
+  initialSuppressedIds: string[];
+}
+
+export function OperatorControlPlaneClient({
+  organizationId,
+  optionalIssueIds,
+  initialSuppressedIds,
+}: Props) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [suppressed, setSuppressed] = useState<Set<string>>(() => new Set(initialSuppressedIds));
+
+  const base = `/api/org/${organizationId}/platform`;
+
+  const runRecheck = useCallback(() => {
+    setActionError(null);
+    setActionMessage(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`${base}/recheck`, { method: 'POST' });
+        const body = await res.json().catch(() => null);
+        if (!res.ok || !body?.success) {
+          setActionError(body?.error?.message ?? `Recheck failed (${res.status})`);
+          return;
+        }
+        setActionMessage(`Recheck completed at ${body.data?.checkedAt ?? 'now'}.`);
+        router.refresh();
+      } catch {
+        setActionError('Network error during recheck.');
+      }
+    });
+  }, [base, router]);
+
+  const saveSuppressions = useCallback(() => {
+    setActionError(null);
+    setActionMessage(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`${base}/operator-preferences`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ suppressedOptionalDiagnosticIds: [...suppressed] }),
+        });
+        const body = await res.json().catch(() => null);
+        if (!res.ok || !body?.success) {
+          setActionError(body?.error?.message ?? `Save failed (${res.status})`);
+          return;
+        }
+        setActionMessage('Optional diagnostic banner preferences updated.');
+        router.refresh();
+      } catch {
+        setActionError('Network error saving preferences.');
+      }
+    });
+  }, [base, router, suppressed]);
+
+  const toggleSuppressed = (id: string, checked: boolean) => {
+    setSuppressed((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          data-testid="platform-recheck-button"
+          onClick={runRecheck}
+          disabled={pending}
+          className="rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-60"
+        >
+          {pending ? 'Running checks…' : 'Recheck readiness'}
+        </button>
+        <p className="text-sm text-slate-600 max-w-xl">
+          Runs live checks synchronously on the server. Results replace the data below after refresh — there is no hidden
+          optimistic green state.
+        </p>
+      </div>
+
+      {actionError && (
+        <p className="text-sm text-red-800" role="alert">
+          {actionError}
+        </p>
+      )}
+      {actionMessage && (
+        <p className="text-sm text-slate-700" role="status">
+          {actionMessage}
+        </p>
+      )}
+
+      {optionalIssueIds.length > 0 && (
+        <fieldset className="rounded-lg border border-slate-200 bg-slate-50/80 p-4">
+          <legend className="px-1 text-sm font-medium text-slate-900">Optional service banner suppression</legend>
+          <p className="mt-2 text-xs text-slate-600">
+            Deployment-wide preference only. It hides specific optional-service diagnostics from summary banners; it does
+            not disable integrations or change environment variables.
+          </p>
+          <ul className="mt-3 space-y-2">
+            {optionalIssueIds.map((id) => (
+              <li key={id} className="flex items-start gap-2 text-sm">
+                <input
+                  id={`suppress-${id}`}
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 rounded border-slate-300"
+                  checked={suppressed.has(id)}
+                  onChange={(e) => toggleSuppressed(id, e.target.checked)}
+                  aria-describedby={`suppress-${id}-hint`}
+                />
+                <label htmlFor={`suppress-${id}`} className="text-slate-800">
+                  <span className="font-mono text-xs text-slate-600">{id}</span>
+                  <span id={`suppress-${id}-hint`} className="sr-only">
+                    When checked, this optional diagnostic is suppressed from operator summary banners.
+                  </span>
+                </label>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            onClick={saveSuppressions}
+            disabled={pending}
+            className="mt-3 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-800 hover:bg-slate-50 disabled:opacity-60"
+          >
+            Save suppression preferences
+          </button>
+        </fieldset>
+      )}
+    </div>
+  );
+}
+
+export function IssueAcknowledgeButton({
+  organizationId,
+  issue,
+}: {
+  organizationId: string;
+  issue: PlatformDiagnosticIssue;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [err, setErr] = useState<string | null>(null);
+
+  const canAck =
+    !issue.acknowledged &&
+    (!issue.blocksReadiness || ['medium', 'low', 'info'].includes(issue.severity));
+
+  if (issue.acknowledged) {
+    return (
+      <p className="text-xs text-slate-500" role="status">
+        Acknowledged (informational only).
+      </p>
+    );
+  }
+
+  if (!canAck) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        disabled={pending}
+        onClick={() => {
+          setErr(null);
+          startTransition(async () => {
+            try {
+              const res = await fetch(`/api/org/${organizationId}/platform/acknowledge`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ issueId: issue.id }),
+              });
+              const body = await res.json().catch(() => null);
+              if (!res.ok || !body?.success) {
+                setErr(body?.error?.message ?? 'Acknowledge failed');
+                return;
+              }
+              router.refresh();
+            } catch {
+              setErr('Network error');
+            }
+          });
+        }}
+        className="text-sm text-brand-700 underline-offset-2 hover:underline disabled:opacity-60"
+      >
+        {pending ? 'Saving…' : 'Acknowledge (does not repair)'}
+      </button>
+      {err && (
+        <p className="mt-1 text-xs text-red-700" role="alert">
+          {err}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/operator-platform-audit.ts
+++ b/apps/web/src/lib/operator-platform-audit.ts
@@ -1,0 +1,51 @@
+import { prisma } from '@/lib/db';
+
+const PLATFORM_ACTIONS = [
+  'platform.recheck',
+  'platform.issue.acknowledged',
+  'platform.operator_prefs.updated',
+] as const;
+
+export type PlatformAuditAction = (typeof PLATFORM_ACTIONS)[number];
+
+export async function logOperatorPlatformAction(input: {
+  organizationId: string;
+  userId: string;
+  action: PlatformAuditAction;
+  outcome: 'success' | 'blocked' | 'validation_failed' | 'forbidden';
+  metadata?: Record<string, unknown>;
+}) {
+  await prisma.auditLog.create({
+    data: {
+      organizationId: input.organizationId,
+      userId: input.userId,
+      action: input.action,
+      entityType: 'Platform',
+      entityId: 'platform',
+      metadata: {
+        outcome: input.outcome,
+        ...(input.metadata ?? {}),
+      },
+    },
+  });
+}
+
+export async function getRecentPlatformAuditEntries(organizationId: string, take = 12) {
+  return prisma.auditLog.findMany({
+    where: {
+      organizationId,
+      action: { in: [...PLATFORM_ACTIONS] },
+    },
+    orderBy: { createdAt: 'desc' },
+    take,
+    select: {
+      id: true,
+      action: true,
+      metadata: true,
+      createdAt: true,
+      userId: true,
+    },
+  });
+}
+
+export type RecentPlatformAuditEntry = Awaited<ReturnType<typeof getRecentPlatformAuditEntries>>[number];

--- a/apps/web/src/lib/operator-preferences-validation.test.ts
+++ b/apps/web/src/lib/operator-preferences-validation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { isValidOptionalDiagnosticId, validateSuppressedOptionalDiagnosticIds } from './operator-preferences-validation';
+
+describe('validateSuppressedOptionalDiagnosticIds', () => {
+  it('accepts optional service svc: ids', () => {
+    expect(validateSuppressedOptionalDiagnosticIds(['svc:stripe-billing']).ok).toBe(true);
+  });
+
+  it('rejects critical service ids', () => {
+    const r = validateSuppressedOptionalDiagnosticIds(['svc:database']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.invalid).toEqual(['svc:database']);
+  });
+
+  it('rejects malformed ids', () => {
+    const r = validateSuppressedOptionalDiagnosticIds(['database', 'svc:unknown']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.invalid).toContain('database');
+  });
+});
+
+describe('isValidOptionalDiagnosticId', () => {
+  it('returns false for non svc prefix', () => {
+    expect(isValidOptionalDiagnosticId('stripe-billing')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/operator-preferences-validation.ts
+++ b/apps/web/src/lib/operator-preferences-validation.ts
@@ -1,0 +1,17 @@
+import { CORE_SERVICES } from '@aros/core-services';
+
+const optionalServiceIds = new Set(
+  CORE_SERVICES.filter((s) => s.criticality === 'optional').map((s) => s.id)
+);
+
+export function isValidOptionalDiagnosticId(id: string): boolean {
+  if (!id.startsWith('svc:')) return false;
+  const svcId = id.slice(4);
+  return optionalServiceIds.has(svcId);
+}
+
+export function validateSuppressedOptionalDiagnosticIds(ids: string[]): { ok: true } | { ok: false; invalid: string[] } {
+  const invalid = ids.filter((id) => !isValidOptionalDiagnosticId(id));
+  if (invalid.length > 0) return { ok: false, invalid };
+  return { ok: true };
+}

--- a/apps/web/src/lib/operator-product-flags.ts
+++ b/apps/web/src/lib/operator-product-flags.ts
@@ -1,0 +1,40 @@
+import type { Prisma } from '@aros/db';
+import { ApiError } from '@aros/shared';
+import { prisma } from '@/lib/db';
+import {
+  parseOperatorPlatformFlags,
+  serializeOperatorPlatformFlags,
+  type ParsedOperatorPlatformFlags,
+} from '@aros/core-services';
+
+export async function loadProductFlagsRecord(): Promise<Record<string, unknown>> {
+  const row = await prisma.platformState.findUnique({
+    where: { id: 'platform' },
+    select: { productFlags: true },
+  });
+  const raw = row?.productFlags;
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return { ...(raw as Record<string, unknown>) };
+  }
+  return {};
+}
+
+export async function saveProductFlagsRecord(next: Record<string, unknown>) {
+  await prisma.platformState.update({
+    where: { id: 'platform' },
+    data: { productFlags: next as Prisma.InputJsonValue },
+  });
+}
+
+export async function updateOperatorFlags(mutator: (current: ParsedOperatorPlatformFlags) => ParsedOperatorPlatformFlags) {
+  const exists = await prisma.platformState.findUnique({ where: { id: 'platform' }, select: { id: true } });
+  if (!exists) {
+    throw ApiError.badRequest('Platform is not installed in the database; run migrations and bootstrap before using operator actions.');
+  }
+  const merged = await loadProductFlagsRecord();
+  const parsed = parseOperatorPlatformFlags(merged);
+  const updated = mutator(parsed);
+  const serialized = serializeOperatorPlatformFlags(updated);
+  await saveProductFlagsRecord({ ...merged, ...serialized });
+  return updated;
+}

--- a/apps/web/src/lib/platform-health.ts
+++ b/apps/web/src/lib/platform-health.ts
@@ -1,7 +1,18 @@
-import { collectPlatformHealth, buildRoutePlatformTruth } from '@aros/core-services';
+import {
+  collectPlatformHealth,
+  buildRoutePlatformTruth,
+  derivePlatformDiagnostics,
+  listOperatorActions,
+  parseOperatorPlatformFlags,
+  type ControlPlaneSummary,
+  type OperatorActionDescriptor,
+  type PlatformDiagnosticIssue,
+  type PlatformSetupStep,
+} from '@aros/core-services';
 import { parseEnvDiagnostics } from '@aros/config';
 import { prisma } from './db';
 import type { PlatformHealthReport, RoutePlatformTruth } from '@aros/core-services';
+import { getRecentPlatformAuditEntries, type RecentPlatformAuditEntry } from './operator-platform-audit';
 
 export interface PlatformHealthApiPayload {
   report: PlatformHealthReport;
@@ -11,17 +22,33 @@ export interface PlatformHealthApiPayload {
   };
   /** Same projection as dashboard shell — safe for JSON (no secrets). */
   routePlatformTruth: RoutePlatformTruth;
+  diagnostics: {
+    issues: PlatformDiagnosticIssue[];
+    setupChecklist: PlatformSetupStep[];
+    summary: ControlPlaneSummary;
+  };
+  operatorActions: OperatorActionDescriptor[];
+  recentPlatformActions: RecentPlatformAuditEntry[];
 }
 
-export async function getPlatformHealthPayload(): Promise<PlatformHealthApiPayload> {
+export async function getPlatformHealthPayload(organizationId?: string): Promise<PlatformHealthApiPayload> {
   const diag = parseEnvDiagnostics(process.env);
   const invalidKeys = Object.keys(diag.fieldErrors).filter(
     (k) => (diag.fieldErrors[k]?.length ?? 0) > 0
   );
   const report = await collectPlatformHealth(prisma);
+  const parsedFlags = parseOperatorPlatformFlags(report.operatorPlatformFlags);
+  const { issues, setupChecklist, summary } = derivePlatformDiagnostics(report, parsedFlags);
+  const recentPlatformActions =
+    organizationId != null
+      ? await getRecentPlatformAuditEntries(organizationId).catch(() => [])
+      : [];
   return {
     report,
     envDiagnostics: { valid: diag.valid, invalidKeys },
     routePlatformTruth: buildRoutePlatformTruth(report),
+    diagnostics: { issues, setupChecklist, summary },
+    operatorActions: listOperatorActions(),
+    recentPlatformActions,
   };
 }

--- a/docs/FIRST_RUN_AND_BOOTSTRAP.md
+++ b/docs/FIRST_RUN_AND_BOOTSTRAP.md
@@ -1,0 +1,19 @@
+# First run and bootstrap
+
+## What “installed” means
+
+`PlatformState` (singleton id `platform`) must exist in PostgreSQL. The seed and `npm run bootstrap` (packages/db `ensure-platform.ts`) create this row.
+
+## Setup checklist (in product)
+
+The `/system` page shows **`deriveSetupChecklist(report)`**: ordered steps (database, env validation, platform row, Redis, workers, optional integrations). Blocking vs non-blocking is explicit.
+
+## When readiness is not `ready`
+
+- **`not_installed`**: no `PlatformState` row — run migrations, seed, and/or `npm run bootstrap`.
+- **`blocked`**: a critical service or dependency is failed/unavailable/misconfigured — see diagnostics and dependency rows on `/system`.
+- **`degraded`**: non-fatal pressure (for example optional integrations or elevated failed job counts) — see warnings.
+
+## Recheck
+
+Operators with `org:system:manage` can call **`POST /api/org/:organizationId/platform/recheck`**, which re-runs `collectPlatformHealth` synchronously and returns the full payload. There is no fake async “healing” job.

--- a/docs/OPERATOR_REMEDIATION_MODEL.md
+++ b/docs/OPERATOR_REMEDIATION_MODEL.md
@@ -1,0 +1,27 @@
+# Operator remediation model
+
+## Diagnostic layer
+
+`derivePlatformDiagnostics(report, parsedFlags)` in `@aros/core-services` builds **`PlatformDiagnosticIssue[]`** from the same `PlatformHealthReport` produced by `collectPlatformHealth`. It is not hand-maintained marketing copy.
+
+Each issue includes:
+
+- Stable `id` (for acknowledgements) and `code`
+- `severity`, `stateCategory`, `blocksReadiness`
+- User and operator impact strings
+- `recommendedNextStep` (aligned with service `nextStep` where applicable)
+- `remediationType`, `fixInProduct`, `requiresDeployOrInfra`, `retrySafe`, `whoShouldAct`
+- `evidence` (non-secret strings only)
+- `acknowledged` / `suppressedFromBanner` from `PlatformState.productFlags`
+
+Dependency failures (Postgres, Redis, session stack) emit **`dep:*`** issues so they are not duplicated on individual service cards.
+
+## Control plane summary
+
+`ControlPlaneSummary` buckets issues into critical blockers, recoverable/high, warnings, optional, and acknowledged — used on `/system`.
+
+## Adding a new actionable diagnostic
+
+1. Register the service in `CORE_SERVICES` and implement checks in `collectPlatformHealth` (`orchestrator.ts`).
+2. If the failure mode is a raw dependency, prefer a `dep:*` issue in `dependencyIssues()` inside `operator-diagnostics.ts` **or** skip duplicate service rows via the early-return guards in `issueFromService`.
+3. Tune `remediationForService` if the default classification is wrong for the new id.

--- a/docs/PLATFORM_ACTIONS_AND_AUDIT.md
+++ b/docs/PLATFORM_ACTIONS_AND_AUDIT.md
@@ -1,0 +1,30 @@
+# Platform actions and audit
+
+## Permissions
+
+| Capability | Permission |
+| --- | --- |
+| View `/system`, `GET .../platform/health` | `org:system:view` (OWNER, ADMIN) |
+| Recheck, acknowledge, operator preferences | `org:system:manage` (OWNER, ADMIN) |
+
+## Endpoints
+
+- `POST /api/org/:organizationId/platform/recheck` — synchronous health refresh; audits `platform.recheck`.
+- `POST /api/org/:organizationId/platform/acknowledge` — body `{ issueId }`; validates id against current diagnostics; audits `platform.issue.acknowledged`.
+- `PATCH /api/org/:organizationId/platform/operator-preferences` — body `{ suppressedOptionalDiagnosticIds: string[] }` (only `svc:<optionalServiceId>`); audits `platform.operator_prefs.updated`.
+
+## Persistence
+
+Acknowledgements and suppression lists live under **`PlatformState.productFlags`** (`operatorAcknowledgements`, `operatorPrefs`). This is **deployment-wide**, not per-organization — the audit log row is still scoped to the acting user’s organization for traceability.
+
+## Audit metadata
+
+`AuditLog.metadata` stores outcomes and non-secret fields only (issue ids, counts, readiness). Secret values and raw env are never written.
+
+## Verification
+
+```bash
+npm run test --workspace=@aros/core-services
+npm run test --workspace=@aros/web
+npm run test:e2e --workspace=@aros/web
+```

--- a/docs/PLATFORM_DEGRADATION_MODEL.md
+++ b/docs/PLATFORM_DEGRADATION_MODEL.md
@@ -26,7 +26,7 @@
 
 ## API
 
-`GET /api/org/:organizationId/platform/health` returns `getPlatformHealthPayload()` including `routePlatformTruth` alongside the full report (authorized operators only).
+`GET /api/org/:organizationId/platform/health` returns `getPlatformHealthPayload()` including `routePlatformTruth`, **`diagnostics`** (`derivePlatformDiagnostics`), **`operatorActions`**, and **`recentPlatformActions`** alongside the full report (requires `org:system:view`). Mutation routes require `org:system:manage` — see `docs/PLATFORM_ACTIONS_AND_AUDIT.md`.
 
 ## Local degraded testing
 

--- a/packages/config/src/__tests__/permissions.test.ts
+++ b/packages/config/src/__tests__/permissions.test.ts
@@ -8,6 +8,12 @@ describe('hasPermission', () => {
     expect(hasPermission('DEVELOPER', 'org:system:view')).toBe(false);
   });
 
+  it('OWNER and ADMIN can run platform operator mutations', () => {
+    expect(hasPermission('OWNER', 'org:system:manage')).toBe(true);
+    expect(hasPermission('ADMIN', 'org:system:manage')).toBe(true);
+    expect(hasPermission('DEVELOPER', 'org:system:manage')).toBe(false);
+  });
+
   it('OWNER has all permissions', () => {
     expect(hasPermission('OWNER', 'org:manage')).toBe(true);
     expect(hasPermission('OWNER', 'org:billing')).toBe(true);

--- a/packages/config/src/permissions.ts
+++ b/packages/config/src/permissions.ts
@@ -1,5 +1,6 @@
 export type Permission =
   | 'org:system:view'
+  | 'org:system:manage'
   | 'org:manage'
   | 'org:billing'
   | 'org:members:manage'
@@ -32,6 +33,7 @@ type Role = 'OWNER' | 'ADMIN' | 'DEVELOPER' | 'CONTENT_EDITOR' | 'AUDITOR' | 'RE
 const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
   OWNER: [
     'org:system:view',
+    'org:system:manage',
     'org:manage', 'org:billing', 'org:members:manage', 'org:members:view',
     'workspace:create', 'workspace:manage',
     'site:create', 'site:manage', 'site:view',
@@ -46,6 +48,7 @@ const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
   ],
   ADMIN: [
     'org:system:view',
+    'org:system:manage',
     'org:members:manage', 'org:members:view',
     'workspace:create', 'workspace:manage',
     'site:create', 'site:manage', 'site:view',

--- a/packages/core-services/src/index.ts
+++ b/packages/core-services/src/index.ts
@@ -18,3 +18,22 @@ export type {
   ServiceHealthState,
   ServiceCriticality,
 } from './types';
+export {
+  derivePlatformDiagnostics,
+  deriveSetupChecklist,
+  listOperatorActions,
+  parseOperatorPlatformFlags,
+  serializeOperatorPlatformFlags,
+} from './operator-diagnostics';
+export type {
+  ControlPlaneSummary,
+  OperatorActionDescriptor,
+  OperatorProductFlags,
+  OperatorAcknowledgements,
+  ParsedOperatorPlatformFlags,
+  PlatformDiagnosticIssue,
+  PlatformSetupStep,
+  DiagnosticSeverity,
+  RemediationType,
+  ActorResponsibility,
+} from './operator-diagnostics';

--- a/packages/core-services/src/operator-diagnostics.test.ts
+++ b/packages/core-services/src/operator-diagnostics.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+  derivePlatformDiagnostics,
+  parseOperatorPlatformFlags,
+  serializeOperatorPlatformFlags,
+} from './operator-diagnostics';
+import type { PlatformHealthReport } from './types';
+
+function minimalService(
+  id: string,
+  overrides: Partial<PlatformHealthReport['services'][number]> = {}
+): PlatformHealthReport['services'][number] {
+  const base = {
+    id,
+    name: id,
+    purpose: 'p',
+    category: 'data' as const,
+    criticality: 'critical' as const,
+    scope: 'deployment' as const,
+    userVisibleWhenDown: true,
+    enabled: true,
+    configState: 'valid' as const,
+    configIssues: [] as string[],
+    configSummary: {},
+    healthState: 'running' as const,
+    lastCheckAt: 't',
+    lastActivityAt: null as string | null,
+    failureReason: null as string | null,
+    nextStep: 'n',
+    dependencies: {},
+  };
+  return { ...base, ...overrides };
+}
+
+function baseReport(overrides: Partial<PlatformHealthReport> = {}): PlatformHealthReport {
+  const defaultServices: PlatformHealthReport['services'] = [
+    minimalService('app-api', { healthState: 'ready', criticality: 'critical' }),
+    minimalService('database', { healthState: 'running' }),
+    minimalService('redis-queue', { healthState: 'running' }),
+    minimalService('worker-runtime', { healthState: 'running' }),
+    minimalService('job-pipelines', { healthState: 'running' }),
+    minimalService('session-auth', { healthState: 'running' }),
+    minimalService('stripe-billing', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+    minimalService('github-connector', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+    minimalService('jira-connector', { criticality: 'optional', healthState: 'ready' }),
+    minimalService('ai-remediation', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+    minimalService('object-storage', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+  ];
+  const services = overrides.services ?? defaultServices;
+
+  return {
+    checkedAt: overrides.checkedAt ?? '2025-01-01T00:00:00.000Z',
+    bootstrap: {
+      installed: true,
+      installedAt: '2025-01-01T00:00:00.000Z',
+      bootstrapVersion: 1,
+      readiness: 'ready',
+      blockers: [],
+      warnings: [],
+      ...overrides.bootstrap,
+    },
+    dependencies: {
+      database: { ok: true, checkedAt: 't' },
+      redis: { ok: true, checkedAt: 't' },
+      sessionStore: { ok: true, checkedAt: 't' },
+      ...overrides.dependencies,
+    },
+    services,
+    operatorPlatformFlags: overrides.operatorPlatformFlags ?? {},
+  };
+}
+
+describe('parseOperatorPlatformFlags', () => {
+  it('round-trips through serialize', () => {
+    const parsed = {
+      prefs: { suppressedOptionalDiagnosticIds: ['svc:stripe-billing'] },
+      acknowledgements: { acknowledgedIssueIds: ['svc:github-connector'], updatedAt: 'x' },
+    };
+    const raw = serializeOperatorPlatformFlags(parsed);
+    expect(parseOperatorPlatformFlags(raw)).toEqual(parsed);
+  });
+});
+
+describe('derivePlatformDiagnostics', () => {
+  it('does not duplicate redis failure on redis-queue service row', () => {
+    const report = baseReport({
+      dependencies: {
+        database: { ok: true, checkedAt: 't' },
+        redis: { ok: false, checkedAt: 't', message: 'econnrefused' },
+        sessionStore: { ok: true, checkedAt: 't' },
+      },
+      services: [
+        minimalService('app-api', { healthState: 'ready' }),
+        minimalService('database', { healthState: 'running' }),
+        minimalService('redis-queue', { healthState: 'unavailable', failureReason: 'Redis unreachable' }),
+        minimalService('worker-runtime', { healthState: 'unavailable' }),
+        minimalService('job-pipelines', { healthState: 'unavailable' }),
+        minimalService('session-auth', { healthState: 'running' }),
+        minimalService('stripe-billing', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+        minimalService('github-connector', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+        minimalService('jira-connector', { criticality: 'optional', healthState: 'ready' }),
+        minimalService('ai-remediation', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+        minimalService('object-storage', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+      ],
+    });
+    const { issues } = derivePlatformDiagnostics(report);
+    const redisSvcIssues = issues.filter((i) => i.id === 'svc:redis-queue');
+    expect(redisSvcIssues).toHaveLength(0);
+    expect(issues.some((i) => i.id === 'dep:redis')).toBe(true);
+  });
+
+  it('marks acknowledged issues and respects suppression for optional', () => {
+    const report = baseReport({
+      services: [
+        minimalService('app-api', { healthState: 'ready' }),
+        minimalService('database', { healthState: 'running' }),
+        minimalService('redis-queue', { healthState: 'running' }),
+        minimalService('worker-runtime', { healthState: 'running' }),
+        minimalService('job-pipelines', { healthState: 'running' }),
+        minimalService('session-auth', { healthState: 'running' }),
+        minimalService('stripe-billing', {
+          criticality: 'optional',
+          enabled: true,
+          healthState: 'misconfigured',
+          configIssues: ['bad'],
+          failureReason: 'stripe pair invalid',
+          nextStep: 'fix env',
+        }),
+        minimalService('github-connector', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+        minimalService('jira-connector', { criticality: 'optional', healthState: 'ready' }),
+        minimalService('ai-remediation', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+        minimalService('object-storage', { criticality: 'optional', healthState: 'disabled', enabled: false }),
+      ],
+    });
+    const stripeIssueId = 'svc:stripe-billing';
+    const withAck = derivePlatformDiagnostics(report, {
+      prefs: { suppressedOptionalDiagnosticIds: [stripeIssueId] },
+      acknowledgements: { acknowledgedIssueIds: [], updatedAt: null },
+    });
+    expect(withAck.issues.find((i) => i.id === stripeIssueId)?.suppressedFromBanner).toBe(true);
+    expect(withAck.summary.optionalUnavailable.some((i) => i.id === stripeIssueId)).toBe(false);
+
+    const withAck2 = derivePlatformDiagnostics(report, {
+      prefs: { suppressedOptionalDiagnosticIds: [] },
+      acknowledgements: { acknowledgedIssueIds: [stripeIssueId], updatedAt: 't' },
+    });
+    expect(withAck2.issues.find((i) => i.id === stripeIssueId)?.acknowledged).toBe(true);
+  });
+});

--- a/packages/core-services/src/operator-diagnostics.ts
+++ b/packages/core-services/src/operator-diagnostics.ts
@@ -1,0 +1,601 @@
+import type { CoreServiceRuntimeView, PlatformHealthReport, ServiceHealthState } from './types';
+
+export type DiagnosticSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export type RemediationType =
+  | 'in_app'
+  | 'deployment_env'
+  | 'dependency_recovery'
+  | 'bootstrap_completion'
+  | 'retry_recheck'
+  | 'permission'
+  | 'documentation';
+
+export type ActorResponsibility = 'platform_operator' | 'deployment_engineer' | 'org_admin' | 'end_user_unaffected';
+
+export interface OperatorProductFlags {
+  /** Optional service diagnostic IDs suppressed from critical/warning banners (deployment-wide). */
+  suppressedOptionalDiagnosticIds: string[];
+}
+
+export interface OperatorAcknowledgements {
+  /** Diagnostic issue IDs acknowledged by an operator (does not change underlying health). */
+  acknowledgedIssueIds: string[];
+  updatedAt: string | null;
+}
+
+export interface ParsedOperatorPlatformFlags {
+  prefs: OperatorProductFlags;
+  acknowledgements: OperatorAcknowledgements;
+}
+
+export interface PlatformSetupStep {
+  id: string;
+  title: string;
+  detail: string;
+  done: boolean;
+  blocking: boolean;
+  fixRemediationType: RemediationType;
+  fixInProduct: boolean;
+}
+
+export interface PlatformDiagnosticIssue {
+  id: string;
+  code: string;
+  target: { kind: 'service' | 'bootstrap' | 'dependency' | 'platform'; id: string };
+  severity: DiagnosticSeverity;
+  stateCategory: ServiceHealthState | 'bootstrap' | 'dependency' | 'environment';
+  summary: string;
+  impactUser: string;
+  impactOperator: string;
+  recommendedNextStep: string;
+  remediationType: RemediationType;
+  fixInProduct: boolean;
+  requiresDeployOrInfra: boolean;
+  retrySafe: boolean;
+  evidence: string[];
+  lastCheckedAt: string;
+  blocksReadiness: boolean;
+  appUsable: boolean;
+  canOperatorContinueSafely: boolean;
+  whoShouldAct: ActorResponsibility;
+  acknowledged: boolean;
+  suppressedFromBanner: boolean;
+}
+
+export interface OperatorActionDescriptor {
+  id: string;
+  label: string;
+  description: string;
+  method: 'POST' | 'PATCH';
+  pathSuffix: string;
+  /** When false, UI should not offer the action (e.g. wrong permission tier). */
+  available: boolean;
+}
+
+export interface ControlPlaneSummary {
+  criticalBlockers: PlatformDiagnosticIssue[];
+  warnings: PlatformDiagnosticIssue[];
+  recoverableIssues: PlatformDiagnosticIssue[];
+  optionalUnavailable: PlatformDiagnosticIssue[];
+  acknowledgedIssues: PlatformDiagnosticIssue[];
+}
+
+const DEFAULT_FLAGS: ParsedOperatorPlatformFlags = {
+  prefs: { suppressedOptionalDiagnosticIds: [] },
+  acknowledgements: { acknowledgedIssueIds: [], updatedAt: null },
+};
+
+export function parseOperatorPlatformFlags(raw: unknown): ParsedOperatorPlatformFlags {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...DEFAULT_FLAGS, prefs: { ...DEFAULT_FLAGS.prefs }, acknowledgements: { ...DEFAULT_FLAGS.acknowledgements } };
+  }
+  const o = raw as Record<string, unknown>;
+  const op = o.operatorPrefs;
+  const oa = o.operatorAcknowledgements;
+  const suppressed =
+    op &&
+    typeof op === 'object' &&
+    !Array.isArray(op) &&
+    Array.isArray((op as { suppressedOptionalDiagnosticIds?: unknown }).suppressedOptionalDiagnosticIds)
+      ? ((op as { suppressedOptionalDiagnosticIds: string[] }).suppressedOptionalDiagnosticIds.filter(
+          (x) => typeof x === 'string'
+        ) as string[])
+      : [];
+  const ackIds =
+    oa &&
+    typeof oa === 'object' &&
+    !Array.isArray(oa) &&
+    Array.isArray((oa as { acknowledgedIssueIds?: unknown }).acknowledgedIssueIds)
+      ? ((oa as { acknowledgedIssueIds: string[] }).acknowledgedIssueIds.filter((x) => typeof x === 'string') as string[])
+      : [];
+  const updatedAt =
+    oa &&
+    typeof oa === 'object' &&
+    typeof (oa as { updatedAt?: unknown }).updatedAt === 'string'
+      ? ((oa as { updatedAt: string }).updatedAt as string)
+      : null;
+  return {
+    prefs: { suppressedOptionalDiagnosticIds: suppressed },
+    acknowledgements: { acknowledgedIssueIds: ackIds, updatedAt },
+  };
+}
+
+export function serializeOperatorPlatformFlags(parsed: ParsedOperatorPlatformFlags): Record<string, unknown> {
+  return {
+    operatorPrefs: {
+      suppressedOptionalDiagnosticIds: parsed.prefs.suppressedOptionalDiagnosticIds,
+    },
+    operatorAcknowledgements: {
+      acknowledgedIssueIds: parsed.acknowledgements.acknowledgedIssueIds,
+      updatedAt: parsed.acknowledgements.updatedAt,
+    },
+  };
+}
+
+function severityForService(svc: CoreServiceRuntimeView): DiagnosticSeverity {
+  if (svc.criticality === 'critical') {
+    if (svc.healthState === 'unavailable' || svc.healthState === 'failed' || svc.healthState === 'misconfigured') {
+      return 'critical';
+    }
+    if (svc.healthState === 'degraded') return 'high';
+  } else {
+    if (svc.healthState === 'misconfigured') return 'medium';
+    if (svc.healthState === 'failed' || svc.healthState === 'unavailable') return 'medium';
+    if (svc.healthState === 'degraded') return 'low';
+  }
+  return 'info';
+}
+
+function remediationForService(svc: CoreServiceRuntimeView): {
+  remediationType: RemediationType;
+  fixInProduct: boolean;
+  requiresDeployOrInfra: boolean;
+  retrySafe: boolean;
+  who: ActorResponsibility;
+} {
+  const deployHeavy = ['app-api', 'database', 'redis-queue', 'worker-runtime', 'job-pipelines', 'session-auth'].includes(
+    svc.id
+  );
+
+  if (deployHeavy) {
+    const retry = ['worker-runtime', 'job-pipelines'].includes(svc.id);
+    return {
+      remediationType: svc.healthState === 'misconfigured' ? 'deployment_env' : 'dependency_recovery',
+      fixInProduct: false,
+      requiresDeployOrInfra: true,
+      retrySafe: retry,
+      who: 'deployment_engineer',
+    };
+  }
+
+  if (svc.criticality === 'optional') {
+    return {
+      remediationType: 'deployment_env',
+      fixInProduct: false,
+      requiresDeployOrInfra: true,
+      retrySafe: true,
+      who: 'deployment_engineer',
+    };
+  }
+
+  return {
+    remediationType: 'documentation',
+    fixInProduct: false,
+    requiresDeployOrInfra: true,
+    retrySafe: false,
+    who: 'platform_operator',
+  };
+}
+
+function appUsableFromReport(report: PlatformHealthReport): boolean {
+  const db = report.dependencies.database.ok;
+  const session = report.dependencies.sessionStore.ok;
+  const installed = report.bootstrap.installed;
+  return db && session && installed;
+}
+
+function issueFromService(report: PlatformHealthReport, svc: CoreServiceRuntimeView): PlatformDiagnosticIssue | null {
+  if (svc.id === 'database' && !report.dependencies.database.ok) return null;
+  if (svc.id === 'redis-queue' && !report.dependencies.redis.ok) return null;
+  if (svc.id === 'session-auth' && !report.dependencies.sessionStore.ok) return null;
+  if (svc.id === 'worker-runtime' && !report.dependencies.redis.ok) return null;
+  if (
+    svc.id === 'job-pipelines' &&
+    (!report.dependencies.redis.ok || !report.dependencies.database.ok)
+  ) {
+    return null;
+  }
+
+  const okStates: ServiceHealthState[] = ['ready', 'running', 'disabled'];
+  if (okStates.includes(svc.healthState)) return null;
+  if (svc.criticality === 'optional' && svc.healthState === 'disabled') return null;
+
+  const { remediationType, fixInProduct, requiresDeployOrInfra, retrySafe, who } = remediationForService(svc);
+  const severity = severityForService(svc);
+  const blocks = svc.criticality === 'critical' && !['ready', 'running', 'disabled'].includes(svc.healthState);
+  const usable = appUsableFromReport(report);
+  const evidence: string[] = [];
+  if (svc.failureReason) evidence.push(svc.failureReason);
+  if (svc.configIssues.length) evidence.push(...svc.configIssues);
+  evidence.push(`healthState=${svc.healthState}`, `criticality=${svc.criticality}`);
+
+  const impactUser =
+    svc.criticality === 'critical'
+      ? 'End users may see errors, missing data, or failed background work for core features.'
+      : 'Core scanning and findings are unaffected; this integration or enhancement may be unavailable.';
+
+  const impactOperator =
+    who === 'deployment_engineer'
+      ? 'Requires deployment configuration, infrastructure, or process changes outside this screen.'
+      : 'Can be addressed from organization settings or in-app workflows where applicable.';
+
+  return {
+    id: `svc:${svc.id}`,
+    code: `SVC_${svc.id.replace(/-/g, '_').toUpperCase()}`,
+    target: { kind: 'service', id: svc.id },
+    severity,
+    stateCategory: svc.healthState,
+    summary: svc.failureReason ?? `${svc.name} is ${svc.healthState.replace(/_/g, ' ')}`,
+    impactUser,
+    impactOperator,
+    recommendedNextStep: svc.nextStep,
+    remediationType,
+    fixInProduct,
+    requiresDeployOrInfra,
+    retrySafe,
+    evidence,
+    lastCheckedAt: svc.lastCheckAt ?? report.checkedAt,
+    blocksReadiness: blocks,
+    appUsable: usable && !blocks,
+    canOperatorContinueSafely: usable,
+    whoShouldAct: who,
+    acknowledged: false,
+    suppressedFromBanner: false,
+  };
+}
+
+function bootstrapIssues(report: PlatformHealthReport): PlatformDiagnosticIssue[] {
+  const out: PlatformDiagnosticIssue[] = [];
+  const checkedAt = report.checkedAt;
+  if (!report.bootstrap.installed) {
+    out.push({
+      id: 'bootstrap:not_installed',
+      code: 'BOOTSTRAP_NOT_INSTALLED',
+      target: { kind: 'bootstrap', id: 'platform' },
+      severity: 'critical',
+      stateCategory: 'bootstrap',
+      summary: 'Platform installation row is missing in the database.',
+      impactUser: 'The product cannot reliably persist organization data until installation completes.',
+      impactOperator: 'Run migrations and seed/bootstrap so PlatformState exists.',
+      recommendedNextStep: report.bootstrap.blockers[0] ?? 'Run npm run db:migrate && npm run db:seed && npm run bootstrap.',
+      remediationType: 'bootstrap_completion',
+      fixInProduct: false,
+      requiresDeployOrInfra: true,
+      retrySafe: true,
+      evidence: [...report.bootstrap.blockers],
+      lastCheckedAt: checkedAt,
+      blocksReadiness: true,
+      appUsable: false,
+      canOperatorContinueSafely: false,
+      whoShouldAct: 'deployment_engineer',
+      acknowledged: false,
+      suppressedFromBanner: false,
+    });
+    return out;
+  }
+
+  for (const b of report.bootstrap.blockers) {
+    out.push({
+      id: `bootstrap:blocker:${hashStable(b)}`,
+      code: 'BOOTSTRAP_BLOCKER',
+      target: { kind: 'bootstrap', id: 'platform' },
+      severity: 'critical',
+      stateCategory: 'bootstrap',
+      summary: b,
+      impactUser: 'Core platform subsystems are failing; some features and jobs will not run correctly.',
+      impactOperator: 'Resolve the failing dependency or service, then use Recheck readiness on the System page.',
+      recommendedNextStep: 'Follow the next-step guidance for the affected core service below.',
+      remediationType: 'dependency_recovery',
+      fixInProduct: false,
+      requiresDeployOrInfra: true,
+      retrySafe: true,
+      evidence: [b],
+      lastCheckedAt: checkedAt,
+      blocksReadiness: true,
+      appUsable: appUsableFromReport(report),
+      canOperatorContinueSafely: appUsableFromReport(report),
+      whoShouldAct: 'deployment_engineer',
+      acknowledged: false,
+      suppressedFromBanner: false,
+    });
+  }
+
+  for (const w of report.bootstrap.warnings) {
+    out.push({
+      id: `bootstrap:warning:${hashStable(w)}`,
+      code: 'BOOTSTRAP_WARNING',
+      target: { kind: 'bootstrap', id: 'platform' },
+      severity: 'medium',
+      stateCategory: 'bootstrap',
+      summary: w,
+      impactUser: 'Some workflows may be slower, fail intermittently, or lack optional capabilities.',
+      impactOperator: 'Review the linked service; optional issues can be acknowledged if accepted.',
+      recommendedNextStep: 'Inspect the degraded service and deployment logs.',
+      remediationType: 'dependency_recovery',
+      fixInProduct: false,
+      requiresDeployOrInfra: true,
+      retrySafe: true,
+      evidence: [w],
+      lastCheckedAt: checkedAt,
+      blocksReadiness: false,
+      appUsable: true,
+      canOperatorContinueSafely: true,
+      whoShouldAct: 'deployment_engineer',
+      acknowledged: false,
+      suppressedFromBanner: false,
+    });
+  }
+
+  return out;
+}
+
+function dependencyIssues(report: PlatformHealthReport): PlatformDiagnosticIssue[] {
+  const out: PlatformDiagnosticIssue[] = [];
+  const t = report.checkedAt;
+  if (!report.dependencies.database.ok) {
+    out.push({
+      id: 'dep:database',
+      code: 'DEP_POSTGRES',
+      target: { kind: 'dependency', id: 'database' },
+      severity: 'critical',
+      stateCategory: 'dependency',
+      summary: report.dependencies.database.message ?? 'PostgreSQL is not reachable.',
+      impactUser: 'Sign-in, sites, findings, and settings cannot load reliably.',
+      impactOperator: 'Restore database connectivity and verify DATABASE_URL.',
+      recommendedNextStep:
+        'Verify DATABASE_URL and database availability; run migrations after connectivity is restored.',
+      remediationType: 'dependency_recovery',
+      fixInProduct: false,
+      requiresDeployOrInfra: true,
+      retrySafe: true,
+      evidence: [report.dependencies.database.message ?? 'check failed'],
+      lastCheckedAt: report.dependencies.database.checkedAt,
+      blocksReadiness: true,
+      appUsable: false,
+      canOperatorContinueSafely: false,
+      whoShouldAct: 'deployment_engineer',
+      acknowledged: false,
+      suppressedFromBanner: false,
+    });
+  }
+  if (!report.dependencies.redis.ok) {
+    out.push({
+      id: 'dep:redis',
+      code: 'DEP_REDIS',
+      target: { kind: 'dependency', id: 'redis' },
+      severity: 'critical',
+      stateCategory: 'dependency',
+      summary: report.dependencies.redis.message ?? 'Redis is not reachable.',
+      impactUser: 'Background jobs will not run; some actions may queue indefinitely.',
+      impactOperator: 'Start Redis and confirm REDIS_URL for this deployment.',
+      recommendedNextStep: 'Start Redis and set REDIS_URL; docker compose up includes Redis.',
+      remediationType: 'dependency_recovery',
+      fixInProduct: false,
+      requiresDeployOrInfra: true,
+      retrySafe: true,
+      evidence: [report.dependencies.redis.message ?? 'check failed'],
+      lastCheckedAt: report.dependencies.redis.checkedAt,
+      blocksReadiness: true,
+      appUsable: appUsableFromReport(report),
+      canOperatorContinueSafely: appUsableFromReport(report),
+      whoShouldAct: 'deployment_engineer',
+      acknowledged: false,
+      suppressedFromBanner: false,
+    });
+  }
+  if (!report.dependencies.sessionStore.ok) {
+    out.push({
+      id: 'dep:session',
+      code: 'DEP_SESSION',
+      target: { kind: 'dependency', id: 'sessionStore' },
+      severity: 'critical',
+      stateCategory: 'environment',
+      summary: report.dependencies.sessionStore.message ?? 'Session stack is not healthy.',
+      impactUser: 'Authentication and organization access may break.',
+      impactOperator: 'Fix NEXTAUTH_* and database per environment validation.',
+      recommendedNextStep: 'Correct invalid environment variables and restart the app.',
+      remediationType: 'deployment_env',
+      fixInProduct: false,
+      requiresDeployOrInfra: true,
+      retrySafe: true,
+      evidence: [report.dependencies.sessionStore.message ?? 'session check failed'],
+      lastCheckedAt: report.dependencies.sessionStore.checkedAt,
+      blocksReadiness: true,
+      appUsable: false,
+      canOperatorContinueSafely: false,
+      whoShouldAct: 'deployment_engineer',
+      acknowledged: false,
+      suppressedFromBanner: false,
+    });
+  }
+  return out;
+}
+
+/** Deterministic short hash for stable IDs from free-form strings (no crypto dependency). */
+function hashStable(s: string): string {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h).toString(36);
+}
+
+export function deriveSetupChecklist(report: PlatformHealthReport): PlatformSetupStep[] {
+  const steps: PlatformSetupStep[] = [];
+  steps.push({
+    id: 'db-connectivity',
+    title: 'Database reachable',
+    detail: 'PostgreSQL accepts connections using DATABASE_URL.',
+    done: report.dependencies.database.ok,
+    blocking: true,
+    fixRemediationType: 'dependency_recovery',
+    fixInProduct: false,
+  });
+  steps.push({
+    id: 'env-valid',
+    title: 'Deployment environment valid',
+    detail: 'Required env vars pass validation (see System page).',
+    done: report.services.find((s) => s.id === 'app-api')?.healthState === 'ready',
+    blocking: true,
+    fixRemediationType: 'deployment_env',
+    fixInProduct: false,
+  });
+  steps.push({
+    id: 'platform-bootstrapped',
+    title: 'Platform bootstrapped in database',
+    detail: 'PlatformState row exists (npm run bootstrap / seed).',
+    done: report.bootstrap.installed,
+    blocking: true,
+    fixRemediationType: 'bootstrap_completion',
+    fixInProduct: false,
+  });
+  steps.push({
+    id: 'redis',
+    title: 'Redis for job queues',
+    detail: 'Redis reachable at REDIS_URL.',
+    done: report.dependencies.redis.ok,
+    blocking: true,
+    fixRemediationType: 'dependency_recovery',
+    fixInProduct: false,
+  });
+  const worker = report.services.find((s) => s.id === 'worker-runtime');
+  steps.push({
+    id: 'workers',
+    title: 'Background workers running',
+    detail: 'Worker process reports a fresh heartbeat.',
+    done: worker?.healthState === 'running',
+    blocking: true,
+    fixRemediationType: 'dependency_recovery',
+    fixInProduct: false,
+  });
+  steps.push({
+    id: 'optional-integrations',
+    title: 'Optional integrations (Stripe, GitHub, S3, AI)',
+    detail: 'Configure only what you need; missing optional keys do not block core readiness.',
+    done: report.bootstrap.readiness === 'ready' || report.bootstrap.readiness === 'degraded',
+    blocking: false,
+    fixRemediationType: 'deployment_env',
+    fixInProduct: false,
+  });
+  return steps;
+}
+
+export function derivePlatformDiagnostics(
+  report: PlatformHealthReport,
+  flags: ParsedOperatorPlatformFlags = DEFAULT_FLAGS
+): {
+  issues: PlatformDiagnosticIssue[];
+  setupChecklist: PlatformSetupStep[];
+  summary: ControlPlaneSummary;
+} {
+  const issues: PlatformDiagnosticIssue[] = [];
+
+  issues.push(...dependencyIssues(report));
+  issues.push(...bootstrapIssues(report));
+
+  for (const svc of report.services) {
+    const i = issueFromService(report, svc);
+    if (i) issues.push(i);
+  }
+
+  const ackSet = new Set(flags.acknowledgements.acknowledgedIssueIds);
+  const suppressed = new Set(flags.prefs.suppressedOptionalDiagnosticIds);
+
+  for (const issue of issues) {
+    issue.acknowledged = ackSet.has(issue.id);
+    const isOptionalSvc =
+      issue.target.kind === 'service' &&
+      report.services.find((s) => s.id === issue.target.id)?.criticality === 'optional';
+    issue.suppressedFromBanner = isOptionalSvc && suppressed.has(issue.id);
+  }
+
+  const summary = splitSummary(issues, report);
+
+  return {
+    issues,
+    setupChecklist: deriveSetupChecklist(report),
+    summary,
+  };
+}
+
+function splitSummary(issues: PlatformDiagnosticIssue[], report: PlatformHealthReport): ControlPlaneSummary {
+  const optionalIds = new Set(
+    report.services.filter((s) => s.criticality === 'optional').map((s) => s.id)
+  );
+
+  const criticalBlockers = issues.filter(
+    (i) => i.blocksReadiness && i.severity === 'critical' && !i.acknowledged && !i.suppressedFromBanner
+  );
+  const warnings = issues.filter(
+    (i) =>
+      !i.blocksReadiness &&
+      ['high', 'medium', 'low'].includes(i.severity) &&
+      !i.acknowledged &&
+      !i.suppressedFromBanner
+  );
+  const recoverableIssues = issues.filter(
+    (i) =>
+      i.blocksReadiness &&
+      i.severity === 'high' &&
+      !i.acknowledged &&
+      !i.suppressedFromBanner
+  );
+  const optionalUnavailable = issues.filter(
+    (i) =>
+      i.target.kind === 'service' &&
+      optionalIds.has(i.target.id) &&
+      !i.acknowledged &&
+      !i.suppressedFromBanner
+  );
+  const acknowledgedIssues = issues.filter((i) => i.acknowledged);
+  return {
+    criticalBlockers,
+    warnings,
+    recoverableIssues,
+    optionalUnavailable,
+    acknowledgedIssues,
+  };
+}
+
+export function listOperatorActions(): OperatorActionDescriptor[] {
+  return [
+    {
+      id: 'recheck_readiness',
+      label: 'Recheck readiness',
+      description:
+        'Re-runs live connectivity, queue, and worker checks synchronously. Does not change configuration.',
+      method: 'POST',
+      pathSuffix: 'recheck',
+      available: true,
+    },
+    {
+      id: 'ack_issue',
+      label: 'Acknowledge issue',
+      description:
+        'Records operator acknowledgement for a diagnostic id (does not repair underlying health). Use for accepted risk.',
+      method: 'POST',
+      pathSuffix: 'acknowledge',
+      available: true,
+    },
+    {
+      id: 'suppress_optional',
+      label: 'Hide optional warning',
+      description:
+        'Stops showing a specific optional-service diagnostic in operator banners. Deployment-wide; does not disable the service.',
+      method: 'PATCH',
+      pathSuffix: 'operator-preferences',
+      available: true,
+    },
+  ];
+}

--- a/packages/core-services/src/orchestrator.test.ts
+++ b/packages/core-services/src/orchestrator.test.ts
@@ -41,6 +41,7 @@ describe('collectPlatformHealth', () => {
     const report = await collectPlatformHealth(prisma);
     expect(report.bootstrap.installed).toBe(false);
     expect(report.bootstrap.readiness).toBe('not_installed');
+    expect(report.operatorPlatformFlags).toBeNull();
   });
 
   it('marks worker running when heartbeat is fresh', async () => {
@@ -51,6 +52,7 @@ describe('collectPlatformHealth', () => {
           installedAt: new Date('2025-01-01T00:00:00.000Z'),
           bootstrapVersion: 1,
           workerLastHeartbeatAt: new Date('2025-03-22T11:59:30.000Z'),
+          productFlags: {},
         }),
       },
     } as unknown as PrismaClient;
@@ -58,5 +60,6 @@ describe('collectPlatformHealth', () => {
     const report = await collectPlatformHealth(prisma);
     const worker = report.services.find((s) => s.id === 'worker-runtime');
     expect(worker?.healthState).toBe('running');
+    expect(report.operatorPlatformFlags).toEqual({});
   });
 });

--- a/packages/core-services/src/orchestrator.ts
+++ b/packages/core-services/src/orchestrator.ts
@@ -88,13 +88,19 @@ export async function collectPlatformHealth(prisma: PrismaClient): Promise<Platf
     installedAt: Date;
     bootstrapVersion: number;
     workerLastHeartbeatAt: Date | null;
+    productFlags: unknown;
   } | null = null;
 
   if (dbCheck.ok) {
     try {
       platformRow = await prisma.platformState.findUnique({
         where: { id: PLATFORM_ID },
-        select: { installedAt: true, bootstrapVersion: true, workerLastHeartbeatAt: true },
+        select: {
+          installedAt: true,
+          bootstrapVersion: true,
+          workerLastHeartbeatAt: true,
+          productFlags: true,
+        },
       });
     } catch {
       platformRow = null;
@@ -442,6 +448,12 @@ export async function collectPlatformHealth(prisma: PrismaClient): Promise<Platf
         warnings: [] as string[],
       };
 
+  const rawFlags = platformRow?.productFlags;
+  const operatorPlatformFlags =
+    rawFlags && typeof rawFlags === 'object' && !Array.isArray(rawFlags)
+      ? (rawFlags as Record<string, unknown>)
+      : null;
+
   return {
     checkedAt,
     bootstrap,
@@ -455,5 +467,6 @@ export async function collectPlatformHealth(prisma: PrismaClient): Promise<Platf
       },
     },
     services,
+    operatorPlatformFlags,
   };
 }

--- a/packages/core-services/src/public-summary.test.ts
+++ b/packages/core-services/src/public-summary.test.ts
@@ -60,6 +60,7 @@ function baseReport(overrides: Partial<PlatformHealthReport> = {}): PlatformHeal
       sessionStore: { ok: true, checkedAt: 't' },
     },
     services,
+    operatorPlatformFlags: overrides.operatorPlatformFlags ?? {},
     ...overrides,
   };
 }

--- a/packages/core-services/src/route-platform-truth.test.ts
+++ b/packages/core-services/src/route-platform-truth.test.ts
@@ -21,6 +21,7 @@ function baseReport(overrides: Partial<PlatformHealthReport> = {}): PlatformHeal
       sessionStore: { ok: true, checkedAt: '2025-01-01T00:00:00.000Z' },
       ...overrides.dependencies,
     },
+    operatorPlatformFlags: overrides.operatorPlatformFlags ?? {},
     services:
       services ??
       ([

--- a/packages/core-services/src/types.ts
+++ b/packages/core-services/src/types.ts
@@ -72,4 +72,9 @@ export interface PlatformHealthReport {
     sessionStore: DependencyCheckResult;
   };
   services: CoreServiceRuntimeView[];
+  /**
+   * Raw JSON from PlatformState.productFlags (non-secret operator prefs/acks).
+   * Null when platform row missing or database unreachable.
+   */
+  operatorPlatformFlags: Record<string, unknown> | null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Turns platform health into an actionable operator control plane: structured diagnostics derived from `collectPlatformHealth`, guided first-run/setup checklist, synchronous recheck, safe acknowledgements and optional banner suppression (with validation), org-scoped audit entries, and stricter authz for mutations (`org:system:manage`).

## Key changes

- `@aros/core-services`: `derivePlatformDiagnostics`, `PlatformHealthReport.operatorPlatformFlags`, deduped dep vs service issues
- `apps/web`: `/system` UX (buckets, per-service diagnostic cards, setup checklist), API routes under `/api/org/:id/platform/*`
- `packages/config`: new `org:system:manage` permission (OWNER/ADMIN)
- Docs: `docs/OPERATOR_REMEDIATION_MODEL.md`, `FIRST_RUN_AND_BOOTSTRAP.md`, `PLATFORM_ACTIONS_AND_AUDIT.md`

## Verification

- `npm run lint` — pass
- `npm run typecheck` (after `npm run db:generate`) — pass
- `npm run test` — pass
- `npm run build` — pass
- `npm run test:e2e` — **not run** (Docker unavailable in this environment for Postgres/Redis global setup)

## Notes

- Operator prefs/acks live in `PlatformState.productFlags` (deployment-wide); audit rows remain org-scoped for the acting membership.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c60a8217-c349-4b3f-87f4-5f11e9a8fde5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c60a8217-c349-4b3f-87f4-5f11e9a8fde5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

