### PR TITLE
Accessibility evidence workflow: findings lifecycle, reporting, and scan linkage

### DIFF
--- a/apps/web/e2e/findings-workflow.spec.ts
+++ b/apps/web/e2e/findings-workflow.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+const DEMO_EMAIL = 'demo@aros.dev';
+const DEMO_PASSWORD = 'demo1234';
+
+async function signInAsDemo(page: import('@playwright/test').Page) {
+  await page.goto('/login');
+  await page.getByLabel('Email address').fill(DEMO_EMAIL);
+  await page.getByLabel('Password', { exact: true }).fill(DEMO_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page).toHaveURL(/\/dashboard$/);
+}
+
+test.describe('findings evidence workflow', () => {
+  test('list, detail, remediation control, summary API', async ({ page }) => {
+    await signInAsDemo(page);
+
+    await page.goto('/findings');
+    await expect(page.getByRole('heading', { name: 'Findings' })).toBeVisible();
+
+    const firstFinding = page.locator('a[href^="/findings/"]').first();
+    const count = await firstFinding.count();
+    test.skip(count === 0, 'No seeded findings in database');
+
+    await firstFinding.click();
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    const statusSelect = page.locator('#status-select');
+    await expect(statusSelect).toBeVisible();
+    await statusSelect.selectOption('ACKNOWLEDGED');
+    await page.getByRole('button', { name: 'Apply status & note' }).click();
+    await expect(page).toHaveURL(/\/findings\/[^/]+$/);
+    await expect(page.getByText('Remediation history')).toBeVisible();
+
+    const summaryStatus = await page.evaluate(async () => {
+      const r = await fetch('/api/findings/summary', { credentials: 'include' });
+      return { ok: r.ok, status: r.status };
+    });
+    expect(summaryStatus.ok).toBe(true);
+    expect(summaryStatus.status).toBe(200);
+  });
+});

--- a/apps/web/src/app/(dashboard)/findings/[findingId]/actions.ts
+++ b/apps/web/src/app/(dashboard)/findings/[findingId]/actions.ts
@@ -3,19 +3,40 @@
 import { redirect } from 'next/navigation';
 import { requireSession } from '@/lib/session';
 import { prisma } from '@/lib/db';
-import type { FindingStatus } from '@aros/db';
+import { resolveDashboardOrgMembership } from '@/lib/route-data-boundary';
+import { getRoutePlatformTruth } from '@/lib/platform-truth-cache';
+import { transitionFindingRemediationStatus } from '@/lib/findings/remediation-server';
 
 export async function updateFindingStatusAction(formData: FormData) {
-  await requireSession();
+  const user = await requireSession();
   const findingId = formData.get('findingId') as string;
-  const status = formData.get('status') as FindingStatus;
+  const status = formData.get('status') as string;
+  const note = (formData.get('note') as string | null) ?? null;
 
-  if (!findingId || !status) return;
+  if (!findingId || !status) {
+    redirect('/findings');
+  }
 
-  await prisma.canonicalFinding.update({
-    where: { id: findingId },
-    data: { status },
+  const platformTruth = await getRoutePlatformTruth();
+  const orgRes = await resolveDashboardOrgMembership(user.id, platformTruth);
+
+  if (orgRes.kind !== 'ok') {
+    redirect('/findings');
+  }
+
+  const result = await transitionFindingRemediationStatus({
+    prisma,
+    findingId,
+    organizationId: orgRes.organizationId,
+    userId: user.id,
+    userRole: orgRes.role,
+    nextStatus: status,
+    note,
   });
+
+  if (!result.ok) {
+    redirect(`/findings/${findingId}?remediation=${result.code}`);
+  }
 
   redirect(`/findings/${findingId}`);
 }

--- a/apps/web/src/app/(dashboard)/findings/[findingId]/finding-status-form.tsx
+++ b/apps/web/src/app/(dashboard)/findings/[findingId]/finding-status-form.tsx
@@ -2,34 +2,80 @@
 
 import { updateFindingStatusAction } from './actions';
 
+const STATUS_OPTIONS = [
+  { value: 'OPEN', label: 'Open' },
+  { value: 'ACKNOWLEDGED', label: 'Acknowledged' },
+  { value: 'IN_PROGRESS', label: 'In progress' },
+  { value: 'RESOLVED', label: 'Resolved' },
+  { value: 'MITIGATED', label: 'Mitigated' },
+  { value: 'FALSE_POSITIVE', label: 'False positive' },
+  { value: 'WONT_FIX', label: "Won't fix / accepted risk" },
+] as const;
+
 export function FindingStatusForm({
   findingId,
   defaultValue,
+  canManage,
+  defaultNote,
 }: {
   findingId: string;
   defaultValue: string;
+  canManage: boolean;
+  defaultNote: string | null;
 }) {
+  if (!canManage) {
+    return (
+      <div className="mt-1 space-y-1">
+        <p className="text-sm font-medium text-slate-800">{humanStatus(defaultValue)}</p>
+        {defaultNote && <p className="text-xs text-slate-600">Note: {defaultNote}</p>}
+        <p className="text-xs text-slate-500">Your role cannot change remediation status.</p>
+      </div>
+    );
+  }
+
   return (
-    <form action={updateFindingStatusAction} className="mt-1">
+    <form action={updateFindingStatusAction} className="mt-1 space-y-3">
       <input type="hidden" name="findingId" value={findingId} />
-      <label htmlFor="status-select" className="sr-only">
-        Finding status
-      </label>
-      <select
-        id="status-select"
-        name="status"
-        defaultValue={defaultValue}
-        className="input text-sm"
-        onChange={(e) => {
-          e.currentTarget.form?.requestSubmit();
-        }}
-      >
-        <option value="OPEN">Open</option>
-        <option value="IN_PROGRESS">In Progress</option>
-        <option value="FIXED">Fixed</option>
-        <option value="WONT_FIX">Won&apos;t Fix</option>
-        <option value="FALSE_POSITIVE">False Positive</option>
-      </select>
+      <div>
+        <label htmlFor="status-select" className="sr-only">
+          Finding status
+        </label>
+        <select
+          id="status-select"
+          name="status"
+          defaultValue={defaultValue}
+          className="input text-sm max-w-md"
+          onChange={(e) => {
+            e.currentTarget.form?.requestSubmit();
+          }}
+        >
+          {STATUS_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label htmlFor="status-note" className="block text-xs text-slate-500 mb-1">
+          Note (optional, stored on status change)
+        </label>
+        <textarea
+          id="status-note"
+          name="note"
+          rows={2}
+          className="input text-sm w-full max-w-xl"
+          placeholder="Reason for transition, owner, or acceptance reference"
+          defaultValue={defaultNote ?? ''}
+        />
+      </div>
+      <button type="submit" className="btn-secondary text-sm">
+        Apply status & note
+      </button>
     </form>
   );
+}
+
+function humanStatus(s: string) {
+  return STATUS_OPTIONS.find((o) => o.value === s)?.label ?? s.replace(/_/g, ' ').toLowerCase();
 }

--- a/apps/web/src/app/(dashboard)/findings/[findingId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/findings/[findingId]/page.tsx
@@ -8,13 +8,17 @@ import { getRoutePlatformTruth } from '@/lib/platform-truth-cache';
 import { resolveDashboardOrgMembership } from '@/lib/route-data-boundary';
 import { RouteReliabilityNotice } from '@/components/reliability/route-reliability-notice';
 import { hasPermission } from '@aros/config';
+import { deriveAutomationEvidenceFreshness } from '@aros/shared';
 
 export default async function FindingDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ findingId: string }>;
+  searchParams: Promise<{ remediation?: string }>;
 }) {
   const { findingId } = await params;
+  const sp = await searchParams;
   const user = await requireSession();
   const platformTruth = await getRoutePlatformTruth();
   const canViewSystem = await prisma.membership
@@ -52,7 +56,26 @@ export default async function FindingDetailPage({
 
   type FindingDetail = Prisma.CanonicalFindingGetPayload<{
     include: {
-      occurrences: { include: { page: { select: { id: true; url: true; title: true } } } };
+      site: { select: { id: true; name: true; domain: true } };
+      lastScanRun: { select: { id: true; status: true; completedAt: true; createdAt: true; errorMessage: true } };
+      statusEvents: {
+        orderBy: { createdAt: 'desc' };
+        take: 25;
+        include: { user: { select: { email: true; name: true } } };
+      };
+      occurrences: {
+        include: {
+          page: { select: { id: true; url: true; title: true } };
+          lastRawViolation: {
+            select: {
+              id: true;
+              createdAt: true;
+              elementContext: true;
+              scanRun: { select: { id: true; status: true; completedAt: true } };
+            };
+          };
+        };
+      };
       cluster: true;
       suggestions: true;
     };
@@ -69,8 +92,27 @@ export default async function FindingDetailPage({
         },
       },
       include: {
+        site: { select: { id: true, name: true, domain: true } },
+        lastScanRun: {
+          select: { id: true, status: true, completedAt: true, createdAt: true, errorMessage: true },
+        },
+        statusEvents: {
+          orderBy: { createdAt: 'desc' },
+          take: 25,
+          include: { user: { select: { email: true, name: true } } },
+        },
         occurrences: {
-          include: { page: { select: { id: true, url: true, title: true } } },
+          include: {
+            page: { select: { id: true, url: true, title: true } },
+            lastRawViolation: {
+              select: {
+                id: true,
+                createdAt: true,
+                elementContext: true,
+                scanRun: { select: { id: true, status: true, completedAt: true } },
+              },
+            },
+          },
           take: 50,
           orderBy: { lastSeenAt: 'desc' },
         },
@@ -96,6 +138,38 @@ export default async function FindingDetailPage({
 
   if (!finding) notFound();
 
+  const canManageFindings = hasPermission(orgRes.role, 'findings:manage');
+
+  const latestCompleted = await prisma.scanRun.findFirst({
+    where: {
+      status: 'COMPLETED',
+      completedAt: { not: null },
+      site: { workspace: { organizationId: orgRes.organizationId } },
+    },
+    orderBy: { completedAt: 'desc' },
+    select: { completedAt: true },
+  });
+
+  const automationFreshness =
+    finding.evidenceSource === 'AUTOMATED_AXE'
+      ? deriveAutomationEvidenceFreshness({
+          lastVerifiedAt: finding.lastVerifiedAt,
+          latestCompletedScanCompletedAt: latestCompleted?.completedAt ?? null,
+          jobPipelinesHealthy: platformTruth.flags.jobPipelinesHealthy,
+        })
+      : null;
+
+  const remediationError =
+    sp.remediation === 'forbidden'
+      ? 'You do not have permission to change remediation status.'
+      : sp.remediation === 'invalid_transition'
+        ? 'That status change is not allowed from the current state.'
+        : sp.remediation === 'invalid_status'
+          ? 'Unknown remediation status.'
+          : sp.remediation === 'not_found'
+            ? 'Finding not found in your organization.'
+            : null;
+
   return (
     <div className="space-y-6">
       <div>
@@ -105,6 +179,12 @@ export default async function FindingDetailPage({
           </Link>
           <span>/</span>
         </div>
+        {remediationError && (
+          <RouteReliabilityNotice variant="warning" title="Remediation update not applied">
+            <p>{remediationError}</p>
+          </RouteReliabilityNotice>
+        )}
+
         <div className="flex items-center gap-3">
           <span
             className={`badge ${
@@ -129,17 +209,90 @@ export default async function FindingDetailPage({
           <p className="text-sm font-medium text-slate-900 mt-1">{finding.ruleId}</p>
         </div>
         <div>
-          <p className="text-xs text-slate-500 uppercase tracking-wide">WCAG</p>
-          <p className="text-sm font-medium text-slate-900 mt-1">{finding.wcagTags.join(', ') || 'N/A'}</p>
+          <p className="text-xs text-slate-500 uppercase tracking-wide">Site</p>
+          <p className="text-sm font-medium text-slate-900 mt-1">{finding.site.name}</p>
+          <p className="text-xs text-slate-500">{finding.site.domain}</p>
+        </div>
+        <div>
+          <p className="text-xs text-slate-500 uppercase tracking-wide">WCAG tags (from scanner)</p>
+          <p className="text-sm font-medium text-slate-900 mt-1">{finding.wcagTags.join(', ') || 'None reported'}</p>
         </div>
         <div>
           <p className="text-xs text-slate-500 uppercase tracking-wide">Occurrences</p>
           <p className="text-sm font-medium text-slate-900 mt-1">{finding.occurrenceCount}</p>
         </div>
         <div>
-          <p className="text-xs text-slate-500 uppercase tracking-wide">Status</p>
-          <FindingStatusForm findingId={findingId} defaultValue={finding.status} />
+          <p className="text-xs text-slate-500 uppercase tracking-wide">Evidence source</p>
+          <p className="text-sm font-medium text-slate-900 mt-1">
+            {finding.evidenceSource === 'AUTOMATED_AXE'
+              ? 'Automated (axe-core scan)'
+              : finding.evidenceSource === 'MANUAL_REVIEW'
+                ? 'Manual review'
+                : 'Imported'}
+          </p>
         </div>
+        <div>
+          <p className="text-xs text-slate-500 uppercase tracking-wide">Automation evidence</p>
+          <p className="text-sm text-slate-700 mt-1">
+            {finding.evidenceSource !== 'AUTOMATED_AXE' ? (
+              <>This finding is not tied to automated axe runs. Stale/current labels apply to automated evidence only.</>
+            ) : automationFreshness === 'current' ? (
+              <>Last verified by scan at {finding.lastVerifiedAt?.toLocaleString() ?? 'unknown'}.</>
+            ) : automationFreshness === 'stale_newer_scan_exists' ? (
+              <>
+                <span className="text-amber-800 font-medium">Stale:</span> a newer completed scan exists than{' '}
+                {finding.lastVerifiedAt?.toLocaleString() ?? 'last verified time'}. Results may have changed.
+              </>
+            ) : automationFreshness === 'never_autoverified' ? (
+              <>No automated verification timestamp on record.</>
+            ) : automationFreshness === 'no_completed_scan' ? (
+              <>No completed scan found for this organization yet.</>
+            ) : (
+              <>
+                Job pipelines are degraded; treat automated evidence as potentially stale until workers recover.
+              </>
+            )}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-slate-500 uppercase tracking-wide">Last scan run (stored link)</p>
+          <p className="text-sm text-slate-700 mt-1">
+            {finding.lastScanRun ? (
+              <>
+                {finding.lastScanRun.status}
+                {finding.lastScanRun.completedAt
+                  ? ` · completed ${finding.lastScanRun.completedAt.toLocaleString()}`
+                  : ''}
+                {finding.lastScanRun.errorMessage ? ` · ${finding.lastScanRun.errorMessage}` : ''}
+              </>
+            ) : (
+              'Not linked to a scan run row'
+            )}
+          </p>
+        </div>
+        <div className="col-span-2 lg:col-span-4 border-t border-slate-100 pt-4">
+          <p className="text-xs text-slate-500 uppercase tracking-wide mb-2">Remediation</p>
+          <FindingStatusForm
+            findingId={findingId}
+            defaultValue={finding.status}
+            canManage={canManageFindings}
+            defaultNote={finding.statusNote}
+          />
+          <p className="text-xs text-slate-500 mt-2">
+            Resolved/mitigated findings stay in history. If a later automated scan detects the same issue again, status
+            reopens to Open unless marked false positive or won&apos;t fix. Operators should add a short note when closing
+            or accepting risk.
+          </p>
+        </div>
+      </div>
+
+      <div className="card">
+        <h2 className="text-lg font-semibold text-slate-900 mb-2">What the platform knows</h2>
+        <ul className="text-sm text-slate-600 list-disc pl-5 space-y-1">
+          <li>Rule id, severity from the scanner, and deduplicated occurrences per page.</li>
+          <li>Remediation status you set (audited) and optional operator notes.</li>
+          <li>We do not certify WCAG conformance; automated checks are incomplete by definition.</li>
+        </ul>
       </div>
 
       {finding.helpUrl && (
@@ -206,6 +359,7 @@ export default async function FindingDetailPage({
               <tr className="border-b border-slate-200">
                 <th className="pb-2 text-left font-medium text-slate-500">Page</th>
                 <th className="pb-2 text-left font-medium text-slate-500">Selector</th>
+                <th className="pb-2 text-left font-medium text-slate-500">Evidence</th>
                 <th className="pb-2 text-right font-medium text-slate-500">Last Seen</th>
               </tr>
             </thead>
@@ -221,6 +375,13 @@ export default async function FindingDetailPage({
                       {occ.selector.length > 60 ? occ.selector.slice(0, 60) + '...' : occ.selector}
                     </code>
                   </td>
+                  <td className="py-2 text-slate-600 max-w-md">
+                    {occ.lastRawViolation?.elementContext ? (
+                      <span className="text-xs">{occ.lastRawViolation.elementContext}</span>
+                    ) : (
+                      <span className="text-xs text-slate-400">No failure summary stored for this occurrence</span>
+                    )}
+                  </td>
                   <td className="py-2 text-right text-slate-500">{occ.lastSeenAt.toLocaleDateString()}</td>
                 </tr>
               ))}
@@ -228,6 +389,30 @@ export default async function FindingDetailPage({
           </table>
         </div>
       </div>
+
+      {finding.statusEvents.length > 0 && (
+        <div className="card">
+          <h2 className="text-lg font-semibold text-slate-900 mb-4">Remediation history</h2>
+          <ul className="space-y-2 text-sm">
+            {finding.statusEvents.map((ev) => (
+              <li key={ev.id} className="border-b border-slate-100 pb-2">
+                <span className="text-slate-500">{ev.createdAt.toLocaleString()}</span>
+                {' · '}
+                <span className="font-medium text-slate-800">
+                  {ev.fromStatus ?? '—'} → {ev.toStatus}
+                </span>
+                {ev.user && (
+                  <span className="text-slate-500">
+                    {' '}
+                    ({ev.user.name ?? ev.user.email})
+                  </span>
+                )}
+                {ev.note && <p className="text-slate-600 mt-1">{ev.note}</p>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/findings/page.tsx
+++ b/apps/web/src/app/(dashboard)/findings/page.tsx
@@ -1,7 +1,7 @@
 import { requireSession } from '@/lib/session';
 import { prisma } from '@/lib/db';
 import Link from 'next/link';
-import type { Prisma, Severity, FindingStatus } from '@aros/db';
+import type { Prisma, Severity, FindingStatus, EvidenceSource } from '@aros/db';
 import { getRoutePlatformTruth } from '@/lib/platform-truth-cache';
 import { resolveDashboardOrgMembership, runOrgScopedQuery } from '@/lib/route-data-boundary';
 import { RouteReliabilityNotice } from '@/components/reliability/route-reliability-notice';
@@ -11,6 +11,7 @@ type FindingListRow = Prisma.CanonicalFindingGetPayload<{
   include: {
     _count: { select: { occurrences: true } };
     cluster: { select: { id: true; name: true } };
+    site: { select: { id: true; name: true; domain: true } };
   };
 }>;
 
@@ -22,6 +23,7 @@ interface SearchParams {
   status?: string;
   siteId?: string;
   ruleId?: string;
+  evidenceSource?: string;
 }
 
 export default async function FindingsPage({
@@ -96,6 +98,9 @@ export default async function FindingsPage({
   if (params.ruleId) {
     where.ruleId = params.ruleId;
   }
+  if (params.evidenceSource && ['AUTOMATED_AXE', 'MANUAL_REVIEW', 'IMPORTED'].includes(params.evidenceSource)) {
+    where.evidenceSource = params.evidenceSource as EvidenceSource;
+  }
 
   const listResult = await runOrgScopedQuery(orgRes, async () => {
     const [findings, total] = await Promise.all([
@@ -107,6 +112,7 @@ export default async function FindingsPage({
         include: {
           _count: { select: { occurrences: true } },
           cluster: { select: { id: true, name: true } },
+          site: { select: { id: true, name: true, domain: true } },
         },
       }),
       prisma.canonicalFinding.count({ where }),
@@ -133,7 +139,9 @@ export default async function FindingsPage({
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-slate-900">Findings</h1>
-          <p className="text-slate-500 mt-1">{total} accessibility issues found</p>
+          <p className="text-slate-500 mt-1">
+            {total} deduplicated finding{total === 1 ? '' : 's'} in your organization (not a legal conformance score).
+          </p>
         </div>
       </div>
 
@@ -158,10 +166,28 @@ export default async function FindingsPage({
             <select id="status-filter" name="status" className="input" defaultValue={params.status ?? ''}>
               <option value="">All</option>
               <option value="OPEN">Open</option>
-              <option value="IN_PROGRESS">In Progress</option>
-              <option value="FIXED">Fixed</option>
-              <option value="WONT_FIX">Won&apos;t Fix</option>
-              <option value="FALSE_POSITIVE">False Positive</option>
+              <option value="ACKNOWLEDGED">Acknowledged</option>
+              <option value="IN_PROGRESS">In progress</option>
+              <option value="RESOLVED">Resolved</option>
+              <option value="MITIGATED">Mitigated</option>
+              <option value="FALSE_POSITIVE">False positive</option>
+              <option value="WONT_FIX">Won&apos;t fix / accepted risk</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="source-filter" className="label">
+              Evidence source
+            </label>
+            <select
+              id="source-filter"
+              name="evidenceSource"
+              className="input"
+              defaultValue={params.evidenceSource ?? ''}
+            >
+              <option value="">All</option>
+              <option value="AUTOMATED_AXE">Automated (axe)</option>
+              <option value="MANUAL_REVIEW">Manual review</option>
+              <option value="IMPORTED">Imported</option>
             </select>
           </div>
           <div className="flex items-end">
@@ -193,7 +219,7 @@ export default async function FindingsPage({
         <nav className="flex items-center justify-center gap-2" aria-label="Pagination">
           {page > 1 && (
             <Link
-              href={`/findings?page=${page - 1}&severity=${params.severity ?? ''}&status=${params.status ?? ''}`}
+              href={`/findings?page=${page - 1}&severity=${params.severity ?? ''}&status=${params.status ?? ''}&evidenceSource=${params.evidenceSource ?? ''}`}
               className="btn-secondary text-sm"
             >
               Previous
@@ -204,7 +230,7 @@ export default async function FindingsPage({
           </span>
           {page < totalPages && (
             <Link
-              href={`/findings?page=${page + 1}&severity=${params.severity ?? ''}&status=${params.status ?? ''}`}
+              href={`/findings?page=${page + 1}&severity=${params.severity ?? ''}&status=${params.status ?? ''}&evidenceSource=${params.evidenceSource ?? ''}`}
               className="btn-secondary text-sm"
             >
               Next
@@ -236,6 +262,7 @@ function FindingRow({ finding }: { finding: FindingListRow }) {
               {finding.impact.toLowerCase()}
             </span>
             <span className="text-xs text-slate-400">{finding.ruleId}</span>
+            <EvidenceSourceBadge source={finding.evidenceSource} />
             {finding.cluster && (
               <span className="badge bg-purple-100 text-purple-800">{finding.cluster.name}</span>
             )}
@@ -243,6 +270,9 @@ function FindingRow({ finding }: { finding: FindingListRow }) {
           <p className="text-sm font-medium text-slate-900">{finding.description}</p>
           <div className="flex items-center gap-4 mt-2 text-xs text-slate-500">
             <span>{finding._count.occurrences} occurrences</span>
+            <span>
+              Site: {finding.site.name}
+            </span>
             <span>First seen: {finding.firstSeenAt.toLocaleDateString()}</span>
             {finding.wcagTags.length > 0 && <span>WCAG: {finding.wcagTags.join(', ')}</span>}
           </div>
@@ -255,11 +285,23 @@ function FindingRow({ finding }: { finding: FindingListRow }) {
   );
 }
 
+function EvidenceSourceBadge({ source }: { source: string }) {
+  const label =
+    source === 'AUTOMATED_AXE' ? 'Automated' : source === 'MANUAL_REVIEW' ? 'Manual' : source === 'IMPORTED' ? 'Imported' : source;
+  return (
+    <span className="text-xs rounded px-1.5 py-0.5 bg-slate-100 text-slate-600" title="How this finding entered the system">
+      {label}
+    </span>
+  );
+}
+
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
     OPEN: 'bg-red-100 text-red-800',
+    ACKNOWLEDGED: 'bg-amber-100 text-amber-900',
     IN_PROGRESS: 'bg-blue-100 text-blue-800',
-    FIXED: 'bg-green-100 text-green-800',
+    RESOLVED: 'bg-green-100 text-green-800',
+    MITIGATED: 'bg-emerald-100 text-emerald-900',
     WONT_FIX: 'bg-slate-100 text-slate-600',
     FALSE_POSITIVE: 'bg-slate-100 text-slate-600',
   };

--- a/apps/web/src/app/(dashboard)/reports/actions.ts
+++ b/apps/web/src/app/(dashboard)/reports/actions.ts
@@ -51,8 +51,12 @@ export async function generateReportAction(formData: FormData) {
       },
       byStatus: {
         open: findings.filter((f) => f.status === 'OPEN').length,
+        acknowledged: findings.filter((f) => f.status === 'ACKNOWLEDGED').length,
         inProgress: findings.filter((f) => f.status === 'IN_PROGRESS').length,
-        fixed: findings.filter((f) => f.status === 'FIXED').length,
+        resolved: findings.filter((f) => f.status === 'RESOLVED').length,
+        mitigated: findings.filter((f) => f.status === 'MITIGATED').length,
+        falsePositive: findings.filter((f) => f.status === 'FALSE_POSITIVE').length,
+        wontFix: findings.filter((f) => f.status === 'WONT_FIX').length,
       },
     },
     findings: findings.map((f) => ({

--- a/apps/web/src/app/(dashboard)/reports/page.tsx
+++ b/apps/web/src/app/(dashboard)/reports/page.tsx
@@ -5,6 +5,7 @@ import { getRoutePlatformTruth } from '@/lib/platform-truth-cache';
 import { resolveDashboardOrgMembership, runOrgScopedQuery } from '@/lib/route-data-boundary';
 import { RouteReliabilityNotice } from '@/components/reliability/route-reliability-notice';
 import { hasPermission } from '@aros/config';
+import { buildFindingsOperationalSummary } from '@/lib/findings/reporting-summary';
 
 export const metadata = { title: 'Reports - AROS' };
 
@@ -52,35 +53,14 @@ export default async function ReportsPage() {
   }
 
   const statsResult = await runOrgScopedQuery(orgRes, async (orgId) => {
-    const [totalFindings, openFindings, fixedFindings, criticalFindings, sites] = await Promise.all([
-      prisma.canonicalFinding.count({
-        where: { occurrences: { some: { page: { site: { workspace: { organizationId: orgId } } } } } },
-      }),
-      prisma.canonicalFinding.count({
-        where: {
-          status: 'OPEN',
-          occurrences: { some: { page: { site: { workspace: { organizationId: orgId } } } } },
-        },
-      }),
-      prisma.canonicalFinding.count({
-        where: {
-          status: 'FIXED',
-          occurrences: { some: { page: { site: { workspace: { organizationId: orgId } } } } },
-        },
-      }),
-      prisma.canonicalFinding.count({
-        where: {
-          impact: 'CRITICAL',
-          status: 'OPEN',
-          occurrences: { some: { page: { site: { workspace: { organizationId: orgId } } } } },
-        },
-      }),
+    const [sites, opSummary] = await Promise.all([
       prisma.site.findMany({
         where: { workspace: { organizationId: orgId } },
         select: { id: true, name: true, domain: true },
       }),
+      buildFindingsOperationalSummary(prisma, orgId, platformTruth.flags.jobPipelinesHealthy),
     ]);
-    return { totalFindings, openFindings, fixedFindings, criticalFindings, sites };
+    return { opSummary, sites };
   });
 
   if (!statsResult.ok) {
@@ -94,7 +74,7 @@ export default async function ReportsPage() {
     );
   }
 
-  const { totalFindings, openFindings, fixedFindings, criticalFindings, sites } = statsResult.data;
+  const { opSummary, sites } = statsResult.data;
 
   return (
     <div className="space-y-6">
@@ -109,23 +89,60 @@ export default async function ReportsPage() {
         automated.
       </div>
 
+      {!platformTruth.flags.jobPipelinesHealthy && (
+        <RouteReliabilityNotice variant="warning" title="Background pipelines degraded" showSystemLink={canViewSystem}>
+          <p>
+            Scan queues or workers may be unavailable. Counts below still reflect stored data; automated evidence may be
+            stale until pipelines recover.
+          </p>
+        </RouteReliabilityNotice>
+      )}
+
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <div className="card">
-          <p className="text-sm text-slate-500">Total Findings</p>
-          <p className="text-2xl font-bold text-slate-900">{totalFindings}</p>
+          <p className="text-sm text-slate-500">Total findings (org)</p>
+          <p className="text-2xl font-bold text-slate-900">{opSummary.totals.findings}</p>
         </div>
         <div className="card">
           <p className="text-sm text-slate-500">Open</p>
-          <p className="text-2xl font-bold text-red-600">{openFindings}</p>
+          <p className="text-2xl font-bold text-red-600">{opSummary.totals.open}</p>
         </div>
         <div className="card">
-          <p className="text-sm text-slate-500">Fixed</p>
-          <p className="text-2xl font-bold text-green-600">{fixedFindings}</p>
+          <p className="text-sm text-slate-500">Resolved</p>
+          <p className="text-2xl font-bold text-green-600">{opSummary.totals.resolved}</p>
         </div>
         <div className="card">
-          <p className="text-sm text-slate-500">Critical Open</p>
-          <p className="text-2xl font-bold text-red-700">{criticalFindings}</p>
+          <p className="text-sm text-slate-500">Critical open</p>
+          <p className="text-2xl font-bold text-red-700">{opSummary.totals.criticalOpen}</p>
         </div>
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="card">
+          <p className="text-sm text-slate-500">Acknowledged</p>
+          <p className="text-2xl font-bold text-slate-900">{opSummary.totals.acknowledged}</p>
+        </div>
+        <div className="card">
+          <p className="text-sm text-slate-500">In progress</p>
+          <p className="text-2xl font-bold text-blue-600">{opSummary.totals.inProgress}</p>
+        </div>
+        <div className="card">
+          <p className="text-sm text-slate-500">Mitigated</p>
+          <p className="text-2xl font-bold text-emerald-700">{opSummary.totals.mitigated}</p>
+        </div>
+        <div className="card">
+          <p className="text-sm text-slate-500">Stale automated evidence</p>
+          <p className="text-2xl font-bold text-amber-700">{opSummary.staleAutomationCount}</p>
+        </div>
+      </div>
+
+      <div className="card text-sm text-slate-600 space-y-2">
+        <p className="font-medium text-slate-900">Evidence source mix</p>
+        <p>
+          Automated (axe): {opSummary.evidenceSourceMix.automatedAxe} · Manual review:{' '}
+          {opSummary.evidenceSourceMix.manualReview} · Imported: {opSummary.evidenceSourceMix.imported}
+        </p>
+        <p className="text-slate-500">{opSummary.automationFreshnessNote}</p>
       </div>
 
       <div className="card">

--- a/apps/web/src/app/api/findings/summary/route.ts
+++ b/apps/web/src/app/api/findings/summary/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { requireSession } from '@/lib/session';
+import { prisma } from '@/lib/db';
+import { hasPermission } from '@aros/config';
+import { collectPlatformHealth, buildRoutePlatformTruth } from '@aros/core-services';
+import { buildFindingsOperationalSummary } from '@/lib/findings/reporting-summary';
+
+export async function GET() {
+  try {
+    const user = await requireSession();
+    const membership = await prisma.membership.findFirst({
+      where: { userId: user.id },
+      select: { organizationId: true, role: true },
+    });
+    if (!membership) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    if (!hasPermission(membership.role, 'reports:view')) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const health = await collectPlatformHealth(prisma);
+    const truth = buildRoutePlatformTruth(health);
+
+    if (!truth.allowOrgScopedDbReads) {
+      return NextResponse.json(
+        {
+          error: 'degraded',
+          message: 'Operational summary unavailable while database or session store is unhealthy.',
+          userImpactSummary: truth.userImpactSummary,
+        },
+        { status: 503 }
+      );
+    }
+
+    const summary = await buildFindingsOperationalSummary(
+      prisma,
+      membership.organizationId,
+      truth.flags.jobPipelinesHealthy
+    );
+
+    return NextResponse.json({
+      summary,
+      platform: {
+        jobPipelinesHealthy: truth.flags.jobPipelinesHealthy,
+        workerRunning: truth.flags.workerRunning,
+        optionalSubsystemIssues: truth.optionalSubsystemIssues,
+      },
+    });
+  } catch (e) {
+    if (e instanceof Error && e.message === 'UNAUTHORIZED') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    console.error('[api/findings/summary]', e);
+    return NextResponse.json({ error: 'Failed to build summary' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/reports/route.ts
+++ b/apps/web/src/app/api/reports/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { requireSession } from '@/lib/session';
 import { prisma } from '@/lib/db';
+import { hasPermission } from '@aros/config';
+import { collectPlatformHealth, buildRoutePlatformTruth } from '@aros/core-services';
 
 export async function GET(request: Request) {
   try {
@@ -11,9 +13,13 @@ export async function GET(request: Request) {
 
     const membership = await prisma.membership.findFirst({
       where: { userId: user.id },
+      select: { organizationId: true, role: true },
     });
     if (!membership) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    if (!hasPermission(membership.role, 'reports:export')) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     const where: Record<string, unknown> = {
@@ -28,6 +34,9 @@ export async function GET(request: Request) {
         },
       },
     };
+
+    const health = await collectPlatformHealth(prisma);
+    const truth = buildRoutePlatformTruth(health);
 
     const findings = await prisma.canonicalFinding.findMany({
       where,
@@ -44,7 +53,12 @@ export async function GET(request: Request) {
       generatedAt: new Date().toISOString(),
       generatedBy: user.email,
       disclaimer:
-        'This report provides evidence of automated accessibility testing. It does not constitute a guarantee of WCAG conformance.',
+        'This report provides evidence of accessibility testing and operator workflow. It does not constitute a guarantee of WCAG conformance.',
+      platformTruth: {
+        jobPipelinesHealthy: truth.flags.jobPipelinesHealthy,
+        workerRunning: truth.flags.workerRunning,
+        optionalSubsystemIssues: truth.optionalSubsystemIssues,
+      },
       summary: {
         totalFindings: findings.length,
         bySeverity: {
@@ -53,17 +67,26 @@ export async function GET(request: Request) {
           moderate: findings.filter((f) => f.impact === 'MODERATE').length,
           minor: findings.filter((f) => f.impact === 'MINOR').length,
         },
+        byEvidenceSource: {
+          automatedAxe: findings.filter((f) => f.evidenceSource === 'AUTOMATED_AXE').length,
+          manualReview: findings.filter((f) => f.evidenceSource === 'MANUAL_REVIEW').length,
+          imported: findings.filter((f) => f.evidenceSource === 'IMPORTED').length,
+        },
       },
       findings: findings.map((f) => ({
         id: f.id,
         ruleId: f.ruleId,
         impact: f.impact,
         status: f.status,
+        evidenceSource: f.evidenceSource,
         description: f.description,
         wcagTags: f.wcagTags,
         occurrenceCount: f.occurrenceCount,
         firstSeenAt: f.firstSeenAt,
         lastSeenAt: f.lastSeenAt,
+        lastVerifiedAt: f.lastVerifiedAt,
+        lastScanRunId: f.lastScanRunId,
+        reopenedCount: f.reopenedCount,
         affectedPages: f.occurrences.map((o) => ({
           url: o.page.url,
           title: o.page.title,
@@ -93,6 +116,9 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
+    if (error instanceof Error && error.message === 'UNAUTHORIZED') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     console.error('Report generation error:', error);
     return NextResponse.json({ error: 'Failed to generate report' }, { status: 500 });
   }

--- a/apps/web/src/lib/findings/remediation-server.test.ts
+++ b/apps/web/src/lib/findings/remediation-server.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { transitionFindingRemediationStatus } from './remediation-server';
+
+function mockPrisma() {
+  const tx = vi.fn((ops: Promise<unknown>[]) => Promise.all(ops));
+  return {
+    canonicalFinding: {
+      findFirst: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    findingStatusEvent: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+    auditLog: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+    $transaction: tx,
+  } as unknown as import('@aros/db').PrismaClient;
+}
+
+describe('transitionFindingRemediationStatus', () => {
+  it('returns forbidden without findings:manage', async () => {
+    const prisma = mockPrisma();
+    const res = await transitionFindingRemediationStatus({
+      prisma,
+      findingId: 'f1',
+      organizationId: 'o1',
+      userId: 'u1',
+      userRole: 'REVIEWER',
+      nextStatus: 'ACKNOWLEDGED',
+    });
+    expect(res).toEqual({ ok: false, code: 'forbidden' });
+  });
+
+  it('returns not_found when finding not in org scope', async () => {
+    const prisma = mockPrisma();
+    (prisma.canonicalFinding.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const res = await transitionFindingRemediationStatus({
+      prisma,
+      findingId: 'f1',
+      organizationId: 'o1',
+      userId: 'u1',
+      userRole: 'OWNER',
+      nextStatus: 'ACKNOWLEDGED',
+    });
+    expect(res).toEqual({ ok: false, code: 'not_found' });
+  });
+
+  it('returns invalid_transition when disallowed', async () => {
+    const prisma = mockPrisma();
+    (prisma.canonicalFinding.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'f1',
+      status: 'FALSE_POSITIVE',
+      siteId: 's1',
+    });
+    const res = await transitionFindingRemediationStatus({
+      prisma,
+      findingId: 'f1',
+      organizationId: 'o1',
+      userId: 'u1',
+      userRole: 'OWNER',
+      nextStatus: 'RESOLVED',
+    });
+    expect(res).toEqual({ ok: false, code: 'invalid_transition' });
+  });
+
+  it('runs transaction on valid transition', async () => {
+    const prisma = mockPrisma();
+    (prisma.canonicalFinding.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'f1',
+      status: 'OPEN',
+      siteId: 's1',
+    });
+    const res = await transitionFindingRemediationStatus({
+      prisma,
+      findingId: 'f1',
+      organizationId: 'o1',
+      userId: 'u1',
+      userRole: 'OWNER',
+      nextStatus: 'ACKNOWLEDGED',
+      note: ' triage ',
+    });
+    expect(res).toEqual({ ok: true });
+    expect(prisma.$transaction).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/findings/remediation-server.ts
+++ b/apps/web/src/lib/findings/remediation-server.ts
@@ -1,0 +1,123 @@
+import type { PrismaClient, FindingStatus } from '@aros/db';
+import { hasPermission } from '@aros/config';
+import { canOperatorTransition, type FindingStatusValue } from '@aros/shared';
+
+export type RemediationTransitionResult =
+  | { ok: true }
+  | { ok: false; code: 'not_found' | 'forbidden' | 'invalid_transition' | 'invalid_status' };
+
+const ALL_STATUSES: FindingStatus[] = [
+  'OPEN',
+  'ACKNOWLEDGED',
+  'IN_PROGRESS',
+  'RESOLVED',
+  'MITIGATED',
+  'FALSE_POSITIVE',
+  'WONT_FIX',
+];
+
+function isFindingStatus(v: string): v is FindingStatus {
+  return ALL_STATUSES.includes(v as FindingStatus);
+}
+
+/**
+ * Scoped load: finding must have at least one occurrence under the org.
+ */
+export async function loadFindingScopedToOrg(
+  prisma: PrismaClient,
+  findingId: string,
+  organizationId: string
+) {
+  return prisma.canonicalFinding.findFirst({
+    where: {
+      id: findingId,
+      occurrences: {
+        some: { page: { site: { workspace: { organizationId } } } },
+      },
+    },
+    select: {
+      id: true,
+      status: true,
+      siteId: true,
+    },
+  });
+}
+
+export async function transitionFindingRemediationStatus(input: {
+  prisma: PrismaClient;
+  findingId: string;
+  organizationId: string;
+  userId: string;
+  userRole: import('@aros/db').MemberRole;
+  nextStatus: string;
+  note?: string | null;
+}): Promise<RemediationTransitionResult> {
+  if (!hasPermission(input.userRole, 'findings:manage')) {
+    return { ok: false, code: 'forbidden' };
+  }
+
+  if (!isFindingStatus(input.nextStatus)) {
+    return { ok: false, code: 'invalid_status' };
+  }
+
+  const finding = await loadFindingScopedToOrg(
+    input.prisma,
+    input.findingId,
+    input.organizationId
+  );
+
+  if (!finding) {
+    return { ok: false, code: 'not_found' };
+  }
+
+  const from = finding.status as FindingStatusValue;
+  const to = input.nextStatus as FindingStatusValue;
+
+  if (!canOperatorTransition(from, to)) {
+    return { ok: false, code: 'invalid_transition' };
+  }
+
+  if (from === to) {
+    return { ok: true };
+  }
+
+  const now = new Date();
+  const noteTrimmed = input.note?.trim() || null;
+
+  await input.prisma.$transaction([
+    input.prisma.canonicalFinding.update({
+      where: { id: finding.id },
+      data: {
+        status: input.nextStatus,
+        statusChangedAt: now,
+        statusChangedById: input.userId,
+        ...(noteTrimmed ? { statusNote: noteTrimmed } : {}),
+      },
+    }),
+    input.prisma.findingStatusEvent.create({
+      data: {
+        canonicalFindingId: finding.id,
+        fromStatus: from,
+        toStatus: input.nextStatus,
+        note: noteTrimmed,
+        userId: input.userId,
+      },
+    }),
+    input.prisma.auditLog.create({
+      data: {
+        organizationId: input.organizationId,
+        userId: input.userId,
+        action: 'finding.status_changed',
+        entityType: 'CanonicalFinding',
+        entityId: finding.id,
+        metadata: {
+          fromStatus: from,
+          toStatus: input.nextStatus,
+          siteId: finding.siteId,
+        },
+      },
+    }),
+  ]);
+
+  return { ok: true };
+}

--- a/apps/web/src/lib/findings/reporting-summary.ts
+++ b/apps/web/src/lib/findings/reporting-summary.ts
@@ -1,0 +1,135 @@
+import type { PrismaClient } from '@aros/db';
+
+const orgFindingWhere = (organizationId: string) => ({
+  occurrences: {
+    some: { page: { site: { workspace: { organizationId } } } },
+  },
+});
+
+export type FindingsOperationalSummary = {
+  generatedAt: string;
+  totals: {
+    findings: number;
+    open: number;
+    acknowledged: number;
+    inProgress: number;
+    resolved: number;
+    mitigated: number;
+    falsePositive: number;
+    wontFix: number;
+    criticalOpen: number;
+    seriousOpen: number;
+  };
+  severityCounts: { critical: number; serious: number; moderate: number; minor: number };
+  evidenceSourceMix: { automatedAxe: number; manualReview: number; imported: number };
+  staleAutomationCount: number;
+  automationFreshnessNote: string;
+};
+
+export async function buildFindingsOperationalSummary(
+  prisma: PrismaClient,
+  organizationId: string,
+  jobPipelinesHealthy: boolean
+): Promise<FindingsOperationalSummary> {
+  const base = orgFindingWhere(organizationId);
+
+  const [
+    totalFindings,
+    open,
+    acknowledged,
+    inProgress,
+    resolved,
+    mitigated,
+    falsePositive,
+    wontFix,
+    criticalOpen,
+    seriousOpen,
+    criticalAll,
+    seriousAll,
+    moderateAll,
+    minorAll,
+    automatedAxe,
+    manualReview,
+    imported,
+    latestScan,
+  ] = await Promise.all([
+    prisma.canonicalFinding.count({ where: base }),
+    prisma.canonicalFinding.count({ where: { ...base, status: 'OPEN' } }),
+    prisma.canonicalFinding.count({ where: { ...base, status: 'ACKNOWLEDGED' } }),
+    prisma.canonicalFinding.count({ where: { ...base, status: 'IN_PROGRESS' } }),
+    prisma.canonicalFinding.count({ where: { ...base, status: 'RESOLVED' } }),
+    prisma.canonicalFinding.count({ where: { ...base, status: 'MITIGATED' } }),
+    prisma.canonicalFinding.count({ where: { ...base, status: 'FALSE_POSITIVE' } }),
+    prisma.canonicalFinding.count({ where: { ...base, status: 'WONT_FIX' } }),
+    prisma.canonicalFinding.count({
+      where: { ...base, status: 'OPEN', impact: 'CRITICAL' },
+    }),
+    prisma.canonicalFinding.count({
+      where: { ...base, status: 'OPEN', impact: 'SERIOUS' },
+    }),
+    prisma.canonicalFinding.count({ where: { ...base, impact: 'CRITICAL' } }),
+    prisma.canonicalFinding.count({ where: { ...base, impact: 'SERIOUS' } }),
+    prisma.canonicalFinding.count({ where: { ...base, impact: 'MODERATE' } }),
+    prisma.canonicalFinding.count({ where: { ...base, impact: 'MINOR' } }),
+    prisma.canonicalFinding.count({ where: { ...base, evidenceSource: 'AUTOMATED_AXE' } }),
+    prisma.canonicalFinding.count({ where: { ...base, evidenceSource: 'MANUAL_REVIEW' } }),
+    prisma.canonicalFinding.count({ where: { ...base, evidenceSource: 'IMPORTED' } }),
+    prisma.scanRun.findFirst({
+      where: {
+        status: 'COMPLETED',
+        completedAt: { not: null },
+        site: { workspace: { organizationId } },
+      },
+      orderBy: { completedAt: 'desc' },
+      select: { completedAt: true },
+    }),
+  ]);
+
+  let staleAutomationCount = 0;
+  if (latestScan?.completedAt && jobPipelinesHealthy) {
+    staleAutomationCount = await prisma.canonicalFinding.count({
+      where: {
+        ...base,
+        evidenceSource: 'AUTOMATED_AXE',
+        OR: [{ lastVerifiedAt: null }, { lastVerifiedAt: { lt: latestScan.completedAt } }],
+      },
+    });
+  } else if (!jobPipelinesHealthy) {
+    staleAutomationCount = await prisma.canonicalFinding.count({
+      where: { ...base, evidenceSource: 'AUTOMATED_AXE' },
+    });
+  }
+
+  const automationFreshnessNote = !jobPipelinesHealthy
+    ? 'Job pipelines are degraded; automated evidence may be stale until workers and queues are healthy.'
+    : !latestScan?.completedAt
+      ? 'No completed scan run found for this organization; automated verification timestamps may be missing.'
+      : staleAutomationCount > 0
+        ? `${staleAutomationCount} finding(s) have not been re-verified by the latest completed scan.`
+        : 'Automated findings are at least as fresh as the latest completed scan, where lastVerifiedAt is set.';
+
+  return {
+    generatedAt: new Date().toISOString(),
+    totals: {
+      findings: totalFindings,
+      open,
+      acknowledged,
+      inProgress,
+      resolved,
+      mitigated,
+      falsePositive,
+      wontFix,
+      criticalOpen,
+      seriousOpen,
+    },
+    severityCounts: {
+      critical: criticalAll,
+      serious: seriousAll,
+      moderate: moderateAll,
+      minor: minorAll,
+    },
+    evidenceSourceMix: { automatedAxe, manualReview, imported },
+    staleAutomationCount,
+    automationFreshnessNote,
+  };
+}

--- a/apps/worker/src/jobs/scan.ts
+++ b/apps/worker/src/jobs/scan.ts
@@ -1,7 +1,12 @@
 import { Job, Queue } from 'bullmq';
 import { prisma } from '@aros/db';
 import { chromium, type Browser } from 'playwright';
-import { bullmqConnectionOptions, createFingerprint } from '@aros/shared';
+import {
+  bullmqConnectionOptions,
+  createFingerprint,
+  shouldReopenOnAutomatedDetection,
+  type FindingStatusValue,
+} from '@aros/shared';
 
 interface ScanJobData {
   scanRunId: string;
@@ -94,8 +99,9 @@ export async function handleScanJob(job: Job<ScanJobData>) {
 
             const impact = severityMap[violation.impact ?? 'moderate'] ?? 'MODERATE';
 
-            // Store raw violation
-            await prisma.rawViolation.create({
+            const now = new Date();
+
+            const raw = await prisma.rawViolation.create({
               data: {
                 scanRunId,
                 pageId: pageRecord.id,
@@ -111,27 +117,47 @@ export async function handleScanJob(job: Job<ScanJobData>) {
               },
             });
 
-            // Upsert canonical finding
-            await prisma.canonicalFinding.upsert({
+            const existing = await prisma.canonicalFinding.findUnique({
               where: { fingerprint },
-              create: {
-                siteId,
-                ruleId: violation.id,
-                impact,
-                description: violation.help ?? violation.description ?? '',
-                helpUrl: violation.helpUrl,
-                wcagTags: violation.tags?.filter((t: string) => t.startsWith('wcag')) ?? [],
-                fingerprint,
-                status: 'OPEN',
-                occurrenceCount: 1,
-              },
-              update: {
-                lastSeenAt: new Date(),
-                occurrenceCount: { increment: 1 },
-              },
             });
 
-            // Upsert occurrence
+            if (!existing) {
+              await prisma.canonicalFinding.create({
+                data: {
+                  siteId,
+                  ruleId: violation.id,
+                  impact,
+                  description: violation.help ?? violation.description ?? '',
+                  helpUrl: violation.helpUrl,
+                  wcagTags: violation.tags?.filter((t: string) => t.startsWith('wcag')) ?? [],
+                  fingerprint,
+                  evidenceSource: 'AUTOMATED_AXE',
+                  status: 'OPEN',
+                  occurrenceCount: 1,
+                  lastScanRunId: scanRunId,
+                  lastVerifiedAt: now,
+                },
+              });
+            } else {
+              const st = existing.status as FindingStatusValue;
+              const reopenAutomated =
+                shouldReopenOnAutomatedDetection(st) &&
+                (st === 'RESOLVED' || st === 'MITIGATED');
+
+              await prisma.canonicalFinding.update({
+                where: { id: existing.id },
+                data: {
+                  lastSeenAt: now,
+                  occurrenceCount: { increment: 1 },
+                  lastScanRunId: scanRunId,
+                  lastVerifiedAt: now,
+                  ...(reopenAutomated
+                    ? { status: 'OPEN', reopenedCount: { increment: 1 } }
+                    : {}),
+                },
+              });
+            }
+
             const canonicalFinding = await prisma.canonicalFinding.findUnique({
               where: { fingerprint },
             });
@@ -139,30 +165,25 @@ export async function handleScanJob(job: Job<ScanJobData>) {
             if (canonicalFinding) {
               await prisma.findingOccurrence.upsert({
                 where: {
-                  id: `${canonicalFinding.id}-${pageRecord.id}`,
+                  canonicalFindingId_pageId: {
+                    canonicalFindingId: canonicalFinding.id,
+                    pageId: pageRecord.id,
+                  },
                 },
                 create: {
                   canonicalFindingId: canonicalFinding.id,
                   pageId: pageRecord.id,
                   selector,
                   elementHtml: elementHtml.slice(0, 2000),
+                  lastRawViolationId: raw.id,
                 },
                 update: {
-                  lastSeenAt: new Date(),
+                  lastSeenAt: now,
                   resolved: false,
+                  selector,
+                  elementHtml: elementHtml.slice(0, 2000),
+                  lastRawViolationId: raw.id,
                 },
-              }).catch(() => {
-                // May fail on unique constraint for new occurrences; use create as fallback
-                return prisma.findingOccurrence.create({
-                  data: {
-                    canonicalFindingId: canonicalFinding.id,
-                    pageId: pageRecord.id,
-                    selector,
-                    elementHtml: elementHtml.slice(0, 2000),
-                  },
-                }).catch(() => {
-                  // Already exists, skip
-                });
               });
             }
 

--- a/docs/ACCESSIBILITY_EVIDENCE_MODEL.md
+++ b/docs/ACCESSIBILITY_EVIDENCE_MODEL.md
@@ -1,0 +1,40 @@
+# Accessibility evidence model (AROS)
+
+This document describes what the product **actually stores** today. It is not a compliance certification.
+
+## Layers
+
+1. **Scan run** (`ScanRun`): one execution of the automated scanner for a site. Has `status` (`PENDING` | `RUNNING` | `COMPLETED` | `FAILED`), timestamps, and counters.
+2. **Raw violation** (`RawViolation`): one axe rule hit on one page inside a scan. Stores selector, HTML snippet, WCAG tags, fingerprint, optional failure summary (`elementContext`).
+3. **Canonical finding** (`CanonicalFinding`): deduplicated finding per site fingerprint (rule + selector signature + element shape). Aggregates occurrence count and remediation state.
+4. **Finding occurrence** (`FindingOccurrence`): one row per (canonical finding, page). Links to the latest raw row via `lastRawViolationId` for evidence drill-down.
+
+## Evidence source
+
+`CanonicalFinding.evidenceSource`:
+
+- `AUTOMATED_AXE` — produced by the worker scan job (axe-core).
+- `MANUAL_REVIEW` — reserved for human-entered or review-backed findings (not yet written by default flows).
+- `IMPORTED` — reserved for external imports.
+
+Automated findings set `lastVerifiedAt` and `lastScanRunId` when the worker records a hit.
+
+## Severity and “confidence”
+
+- **Severity** (`impact`): mapped from axe impact (`CRITICAL` | `SERIOUS` | `MODERATE` | `MINOR`). This is scanner-reported, not a legal severity.
+- **Confidence** on remediation *suggestions* is a separate float on `RemediationSuggestion`, not on the finding itself. Do not treat suggestion confidence as WCAG certainty.
+
+## Stale vs current (automated only)
+
+For `evidenceSource === AUTOMATED_AXE`, the UI compares `lastVerifiedAt` to the latest **completed** `ScanRun` in the organization. If a newer completed scan exists, automated evidence is labeled **stale** until this finding is touched again by a scan. If job pipelines are degraded, evidence is treated as potentially stale.
+
+Manual/imported findings do not use this comparison.
+
+## Adding a new scanner
+
+1. Write violations into `RawViolation` (or a parallel table if the shape differs materially).
+2. Upsert `CanonicalFinding` with a stable `fingerprint` and set `evidenceSource` to a distinct enum value (extend `EvidenceSource` in Prisma if needed).
+3. Upsert `FindingOccurrence` with `@@unique([canonicalFindingId, pageId])`.
+4. Update worker health / pipeline messaging if the scanner depends on optional services.
+
+Verification: `npm run db:generate`, run worker scan job against a test site, confirm list/detail show source and raw linkage.

--- a/docs/FINDINGS_AND_REPORTING_TRUTH.md
+++ b/docs/FINDINGS_AND_REPORTING_TRUTH.md
@@ -1,0 +1,42 @@
+# Findings and reporting — what we claim
+
+## What reports and summaries show
+
+- **Counts** derived from `CanonicalFinding` rows scoped to the user’s organization (via occurrence → site → workspace).
+- **Severity counts**: distribution of `impact` across findings in scope.
+- **Remediation counts**: distribution of `status`.
+- **Evidence source mix**: counts by `evidenceSource`.
+- **Stale automated count**: findings with `AUTOMATED_AXE` where `lastVerifiedAt` is null or older than the latest **completed** org scan, unless job pipelines are degraded (then all automated findings count as stale for messaging).
+
+## What we do **not** show
+
+- No composite “accessibility score” — the product does not compute one.
+- No certification or legal conformance statement in exports; disclaimers are included in UI and JSON/CSV payloads.
+
+## APIs
+
+- `GET /api/findings/summary` — JSON operational summary; requires `reports:view`. Returns `503` with a safe envelope if org-scoped DB reads are blocked by platform health.
+- `GET /api/reports` — export; requires `reports:export`. Includes `platformTruth` flags so consumers know if workers/pipelines were healthy at generation time.
+
+## Degraded behavior
+
+- If the database or session store is down, dashboard findings routes show `RouteReliabilityNotice` and skip Prisma where configured.
+- If Redis/workers are down, UI surfaces pipeline degradation; stored findings still render.
+
+## Local smoke
+
+```bash
+npm install
+npm run db:generate
+# With DATABASE_URL set:
+npm run db:push && npm run db:seed
+npm run dev
+```
+
+1. Sign in as `demo@aros.dev` / `demo1234`.
+2. Open `/findings` — list shows site, source badge, statuses.
+3. Open a finding — evidence context, automation freshness, remediation form (as OWNER).
+4. Open `/reports` — operational summary and stale note.
+5. `curl -b cookies.txt http://localhost:3000/api/findings/summary` (after auth) — JSON summary.
+
+Full gate: `npm run verify`.

--- a/docs/REMEDIATION_LIFECYCLE.md
+++ b/docs/REMEDIATION_LIFECYCLE.md
@@ -1,0 +1,45 @@
+# Remediation lifecycle
+
+## States (`FindingStatus`)
+
+| State | Meaning |
+|-------|--------|
+| `OPEN` | Active; needs triage or fix. |
+| `ACKNOWLEDGED` | Seen; not necessarily fixed. |
+| `IN_PROGRESS` | Work underway. |
+| `RESOLVED` | Operator believes fixed; may reopen on automated re-detection. |
+| `MITIGATED` | Risk reduced but not eliminated; may reopen on automated re-detection. |
+| `FALSE_POSITIVE` | Not a real issue; **not** reopened automatically by scans. |
+| `WONT_FIX` | Accepted risk; **not** reopened automatically by scans. |
+
+Allowed operator transitions are enforced in `@aros/shared` (`canOperatorTransition`) and the server (`transitionFindingRemediationStatus`). `FALSE_POSITIVE` and `WONT_FIX` only transition to `OPEN` or `ACKNOWLEDGED` without an intermediate step.
+
+## Who can change status
+
+- Members with `findings:manage` (see `packages/config/src/permissions.ts`).
+- The server action scopes the finding to the user’s organization via occurrences → page → site → workspace.
+
+## Audit trail
+
+Each successful transition appends:
+
+1. `FindingStatusEvent` (append-only): `fromStatus`, `toStatus`, optional `note`, `userId`, `createdAt`.
+2. `AuditLog` row: `finding.status_changed` with metadata `{ fromStatus, toStatus, siteId }`.
+
+Historical raw violations are **not** deleted when status changes.
+
+## Reopen on recheck
+
+When the scan worker sees an existing fingerprint again:
+
+- If status is `RESOLVED` or `MITIGATED`, it sets status to `OPEN` and increments `reopenedCount`.
+- If status is `FALSE_POSITIVE` or `WONT_FIX`, status is unchanged.
+
+## Optional note
+
+Operators can attach a short `statusNote` on the finding detail form. It is updated when a transition is submitted with a note.
+
+## Verification
+
+- Unit: `packages/shared/src/__tests__/finding-lifecycle.test.ts`, `apps/web/src/lib/findings/remediation-server.test.ts`
+- E2E (with DB seed): `npm run test:e2e --workspace=apps/web` (includes `e2e/findings-workflow.spec.ts` when data exists)

--- a/packages/db/prisma/migrations/20250323100000_finding_evidence_lifecycle/migration.sql
+++ b/packages/db/prisma/migrations/20250323100000_finding_evidence_lifecycle/migration.sql
@@ -1,0 +1,72 @@
+-- Evidence source + scan linkage + occurrence uniqueness + FindingStatus enum refresh
+
+ALTER TABLE "canonical_findings" ADD CONSTRAINT "canonical_findings_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "sites"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TYPE "EvidenceSource" AS ENUM ('AUTOMATED_AXE', 'MANUAL_REVIEW', 'IMPORTED');
+
+ALTER TABLE "canonical_findings" ADD COLUMN "evidenceSource" "EvidenceSource" NOT NULL DEFAULT 'AUTOMATED_AXE';
+ALTER TABLE "canonical_findings" ADD COLUMN "lastScanRunId" TEXT;
+ALTER TABLE "canonical_findings" ADD COLUMN "lastVerifiedAt" TIMESTAMP(3);
+ALTER TABLE "canonical_findings" ADD COLUMN "statusChangedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "canonical_findings" ADD COLUMN "statusChangedById" TEXT;
+ALTER TABLE "canonical_findings" ADD COLUMN "statusNote" TEXT;
+ALTER TABLE "canonical_findings" ADD COLUMN "reopenedCount" INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE "canonical_findings" ADD CONSTRAINT "canonical_findings_statusChangedById_fkey" FOREIGN KEY ("statusChangedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "canonical_findings" ADD CONSTRAINT "canonical_findings_lastScanRunId_fkey" FOREIGN KEY ("lastScanRunId") REFERENCES "scan_runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "canonical_findings_lastScanRunId_idx" ON "canonical_findings"("lastScanRunId");
+CREATE INDEX "canonical_findings_evidenceSource_idx" ON "canonical_findings"("evidenceSource");
+
+-- Replace FindingStatus enum (map FIXED -> RESOLVED)
+CREATE TYPE "FindingStatus_new" AS ENUM ('OPEN', 'ACKNOWLEDGED', 'IN_PROGRESS', 'RESOLVED', 'MITIGATED', 'FALSE_POSITIVE', 'WONT_FIX');
+
+ALTER TABLE "canonical_findings" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "canonical_findings" ALTER COLUMN "status" TYPE "FindingStatus_new" USING (
+  CASE "status"::text
+    WHEN 'FIXED' THEN 'RESOLVED'::"FindingStatus_new"
+    ELSE ("status"::text)::"FindingStatus_new"
+  END
+);
+ALTER TABLE "canonical_findings" ALTER COLUMN "status" SET DEFAULT 'OPEN'::"FindingStatus_new";
+
+DROP TYPE "FindingStatus";
+ALTER TYPE "FindingStatus_new" RENAME TO "FindingStatus";
+
+-- Occurrence: optional evidence pointer + stable uniqueness
+ALTER TABLE "finding_occurrences" ADD COLUMN "lastRawViolationId" TEXT;
+
+ALTER TABLE "finding_occurrences" ADD CONSTRAINT "finding_occurrences_lastRawViolationId_fkey" FOREIGN KEY ("lastRawViolationId") REFERENCES "raw_violations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Keep one row per (canonical finding, page); prefer latest lastSeenAt
+DELETE FROM "finding_occurrences" a
+USING "finding_occurrences" b
+WHERE a."canonicalFindingId" = b."canonicalFindingId"
+  AND a."pageId" = b."pageId"
+  AND (
+    a."lastSeenAt" < b."lastSeenAt"
+    OR (a."lastSeenAt" = b."lastSeenAt" AND a."id" > b."id")
+  );
+
+CREATE UNIQUE INDEX "finding_occurrences_canonicalFindingId_pageId_key" ON "finding_occurrences"("canonicalFindingId", "pageId");
+
+CREATE INDEX "finding_occurrences_lastRawViolationId_idx" ON "finding_occurrences"("lastRawViolationId");
+
+-- Append-only remediation / status audit trail
+CREATE TABLE "finding_status_events" (
+    "id" TEXT NOT NULL,
+    "canonicalFindingId" TEXT NOT NULL,
+    "fromStatus" "FindingStatus",
+    "toStatus" "FindingStatus" NOT NULL,
+    "note" TEXT,
+    "userId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "finding_status_events_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "finding_status_events_canonicalFindingId_idx" ON "finding_status_events"("canonicalFindingId");
+CREATE INDEX "finding_status_events_createdAt_idx" ON "finding_status_events"("createdAt");
+
+ALTER TABLE "finding_status_events" ADD CONSTRAINT "finding_status_events_canonicalFindingId_fkey" FOREIGN KEY ("canonicalFindingId") REFERENCES "canonical_findings"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "finding_status_events" ADD CONSTRAINT "finding_status_events_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -23,6 +23,8 @@ model User {
   reviewTasks    ReviewTask[]    @relation("assignee")
   auditLogs      AuditLog[]
   sessions       Session[]
+  findingStatusChanges CanonicalFinding[] @relation("findingStatusChangedBy")
+  findingStatusEvents  FindingStatusEvent[]
 
   @@map("users")
 }
@@ -125,6 +127,7 @@ model Site {
   scanRuns     ScanRun[]
   issueClusters IssueCluster[]
   githubRepoMapping GitHubRepoMapping?
+  canonicalFindings CanonicalFinding[]
 
   @@index([workspaceId])
   @@map("sites")
@@ -247,6 +250,7 @@ model ScanRun {
   site      Site           @relation(fields: [siteId], references: [id], onDelete: Cascade)
   crawlRun  CrawlRun?      @relation(fields: [crawlRunId], references: [id])
   violations RawViolation[]
+  findingsLastVerified CanonicalFinding[]
 
   @@index([siteId])
   @@index([crawlRunId])
@@ -278,6 +282,7 @@ model RawViolation {
 
   scanRun  ScanRun @relation(fields: [scanRunId], references: [id], onDelete: Cascade)
   page     Page    @relation(fields: [pageId], references: [id], onDelete: Cascade)
+  occurrenceLinks FindingOccurrence[]
 
   @@index([scanRunId])
   @@index([pageId])
@@ -286,27 +291,43 @@ model RawViolation {
   @@map("raw_violations")
 }
 
+enum EvidenceSource {
+  AUTOMATED_AXE
+  MANUAL_REVIEW
+  IMPORTED
+}
+
 enum FindingStatus {
   OPEN
+  ACKNOWLEDGED
   IN_PROGRESS
-  FIXED
-  WONT_FIX
+  RESOLVED
+  MITIGATED
   FALSE_POSITIVE
+  WONT_FIX
 }
 
 model CanonicalFinding {
   id              String        @id @default(cuid())
   siteId          String
+  site            Site          @relation(fields: [siteId], references: [id], onDelete: Cascade)
   ruleId          String
   impact          Severity
   description     String
   helpUrl         String?
   wcagTags        String[]      @default([])
   fingerprint     String        @unique
+  evidenceSource  EvidenceSource @default(AUTOMATED_AXE)
   status          FindingStatus @default(OPEN)
   firstSeenAt     DateTime      @default(now())
   lastSeenAt      DateTime      @default(now())
+  lastVerifiedAt  DateTime?
+  lastScanRunId   String?
   occurrenceCount Int           @default(1)
+  reopenedCount   Int           @default(0)
+  statusChangedAt DateTime      @default(now())
+  statusChangedById String?
+  statusNote      String?
   createdAt       DateTime      @default(now())
   updatedAt       DateTime      @updatedAt
 
@@ -314,12 +335,17 @@ model CanonicalFinding {
   cluster       IssueCluster?       @relation(fields: [clusterId], references: [id])
   clusterId     String?
   suggestions   RemediationSuggestion[]
+  lastScanRun   ScanRun?            @relation(fields: [lastScanRunId], references: [id])
+  statusChangedBy User?             @relation("findingStatusChangedBy", fields: [statusChangedById], references: [id])
+  statusEvents  FindingStatusEvent[]
 
   @@index([siteId])
   @@index([ruleId])
   @@index([status])
   @@index([impact])
   @@index([clusterId])
+  @@index([lastScanRunId])
+  @@index([evidenceSource])
   @@map("canonical_findings")
 }
 
@@ -333,13 +359,35 @@ model FindingOccurrence {
   firstSeenAt       DateTime @default(now())
   lastSeenAt        DateTime @default(now())
   resolved          Boolean  @default(false)
+  lastRawViolationId String?
 
   finding CanonicalFinding @relation(fields: [canonicalFindingId], references: [id], onDelete: Cascade)
   page    Page             @relation(fields: [pageId], references: [id], onDelete: Cascade)
+  lastRawViolation RawViolation? @relation(fields: [lastRawViolationId], references: [id])
 
+  @@unique([canonicalFindingId, pageId])
   @@index([canonicalFindingId])
   @@index([pageId])
+  @@index([lastRawViolationId])
   @@map("finding_occurrences")
+}
+
+/// Append-only audit of remediation status transitions (operator workflow).
+model FindingStatusEvent {
+  id                 String         @id @default(cuid())
+  canonicalFindingId String
+  fromStatus         FindingStatus?
+  toStatus           FindingStatus
+  note               String?
+  userId             String?
+  createdAt          DateTime       @default(now())
+
+  finding CanonicalFinding @relation(fields: [canonicalFindingId], references: [id], onDelete: Cascade)
+  user    User?            @relation(fields: [userId], references: [id])
+
+  @@index([canonicalFindingId])
+  @@index([createdAt])
+  @@map("finding_status_events")
 }
 
 // ─── CLUSTERING ──────────────────────────────────────────────

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -220,18 +220,24 @@ async function main() {
         description: fd.description,
         wcagTags: fd.wcagTags,
         fingerprint,
+        evidenceSource: 'AUTOMATED_AXE',
         status: 'OPEN',
         occurrenceCount: fd.pageIndices.length,
+        lastScanRunId: scanRun.id,
+        lastVerifiedAt: scanRun.completedAt ?? new Date(),
       },
-      update: { occurrenceCount: fd.pageIndices.length },
+      update: {
+        occurrenceCount: fd.pageIndices.length,
+        lastScanRunId: scanRun.id,
+        lastVerifiedAt: scanRun.completedAt ?? new Date(),
+      },
     });
 
-    // Create raw violations and occurrences
     for (const idx of fd.pageIndices) {
       const page = pages[idx];
       if (!page) continue;
 
-      await prisma.rawViolation.create({
+      const raw = await prisma.rawViolation.create({
         data: {
           scanRunId: scanRun.id,
           pageId: page.id,
@@ -241,19 +247,25 @@ async function main() {
           wcagTags: fd.wcagTags,
           selector: fd.selector,
           elementHtml: fd.html,
+          elementContext: `Demo failure context for ${fd.ruleId} on ${page.path}`,
           fingerprint,
         },
       });
 
-      await prisma.findingOccurrence.create({
-        data: {
+      await prisma.findingOccurrence.upsert({
+        where: {
+          canonicalFindingId_pageId: { canonicalFindingId: finding.id, pageId: page.id },
+        },
+        create: {
           canonicalFindingId: finding.id,
           pageId: page.id,
           selector: fd.selector,
           elementHtml: fd.html,
+          lastRawViolationId: raw.id,
         },
-      }).catch(() => {
-        // Ignore duplicates
+        update: {
+          lastRawViolationId: raw.id,
+        },
       });
     }
   }

--- a/packages/shared/src/__tests__/finding-lifecycle.test.ts
+++ b/packages/shared/src/__tests__/finding-lifecycle.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canOperatorTransition,
+  deriveAutomationEvidenceFreshness,
+  shouldReopenOnAutomatedDetection,
+} from '../finding-lifecycle';
+
+describe('canOperatorTransition', () => {
+  it('allows same state', () => {
+    expect(canOperatorTransition('OPEN', 'OPEN')).toBe(true);
+  });
+
+  it('allows OPEN -> ACKNOWLEDGED', () => {
+    expect(canOperatorTransition('OPEN', 'ACKNOWLEDGED')).toBe(true);
+  });
+
+  it('blocks FALSE_POSITIVE -> RESOLVED without going through OPEN', () => {
+    expect(canOperatorTransition('FALSE_POSITIVE', 'RESOLVED')).toBe(false);
+  });
+
+  it('allows FALSE_POSITIVE -> OPEN', () => {
+    expect(canOperatorTransition('FALSE_POSITIVE', 'OPEN')).toBe(true);
+  });
+});
+
+describe('shouldReopenOnAutomatedDetection', () => {
+  it('reopens RESOLVED when violation returns', () => {
+    expect(shouldReopenOnAutomatedDetection('RESOLVED')).toBe(true);
+  });
+
+  it('does not reopen WONT_FIX', () => {
+    expect(shouldReopenOnAutomatedDetection('WONT_FIX')).toBe(false);
+  });
+
+  it('does not reopen FALSE_POSITIVE', () => {
+    expect(shouldReopenOnAutomatedDetection('FALSE_POSITIVE')).toBe(false);
+  });
+});
+
+describe('deriveAutomationEvidenceFreshness', () => {
+  const t = (iso: string) => new Date(iso);
+
+  it('returns pipeline_degraded when pipelines unhealthy', () => {
+    expect(
+      deriveAutomationEvidenceFreshness({
+        lastVerifiedAt: t('2025-01-02T00:00:00Z'),
+        latestCompletedScanCompletedAt: t('2025-01-01T00:00:00Z'),
+        jobPipelinesHealthy: false,
+      })
+    ).toBe('pipeline_degraded');
+  });
+
+  it('returns stale when a newer completed scan exists than lastVerifiedAt', () => {
+    expect(
+      deriveAutomationEvidenceFreshness({
+        lastVerifiedAt: t('2025-01-01T00:00:00Z'),
+        latestCompletedScanCompletedAt: t('2025-01-02T00:00:00Z'),
+        jobPipelinesHealthy: true,
+      })
+    ).toBe('stale_newer_scan_exists');
+  });
+
+  it('returns current when lastVerifiedAt is after latest scan', () => {
+    expect(
+      deriveAutomationEvidenceFreshness({
+        lastVerifiedAt: t('2025-01-03T00:00:00Z'),
+        latestCompletedScanCompletedAt: t('2025-01-02T00:00:00Z'),
+        jobPipelinesHealthy: true,
+      })
+    ).toBe('current');
+  });
+});

--- a/packages/shared/src/finding-lifecycle.ts
+++ b/packages/shared/src/finding-lifecycle.ts
@@ -1,0 +1,67 @@
+/**
+ * Remediation lifecycle for canonical findings (matches Prisma FindingStatus).
+ * Single source of truth for allowed transitions and reopen behavior.
+ */
+
+export const FINDING_STATUSES = [
+  'OPEN',
+  'ACKNOWLEDGED',
+  'IN_PROGRESS',
+  'RESOLVED',
+  'MITIGATED',
+  'FALSE_POSITIVE',
+  'WONT_FIX',
+] as const;
+
+export type FindingStatusValue = (typeof FINDING_STATUSES)[number];
+
+/** Transitions the product allows operators to apply from each state. */
+export const OPERATOR_ALLOWED_TRANSITIONS: Record<FindingStatusValue, FindingStatusValue[]> = {
+  OPEN: ['ACKNOWLEDGED', 'IN_PROGRESS', 'RESOLVED', 'MITIGATED', 'FALSE_POSITIVE', 'WONT_FIX'],
+  ACKNOWLEDGED: ['OPEN', 'IN_PROGRESS', 'RESOLVED', 'MITIGATED', 'FALSE_POSITIVE', 'WONT_FIX'],
+  IN_PROGRESS: ['OPEN', 'ACKNOWLEDGED', 'RESOLVED', 'MITIGATED', 'FALSE_POSITIVE', 'WONT_FIX'],
+  RESOLVED: ['OPEN', 'ACKNOWLEDGED', 'IN_PROGRESS', 'MITIGATED', 'FALSE_POSITIVE', 'WONT_FIX'],
+  MITIGATED: ['OPEN', 'ACKNOWLEDGED', 'IN_PROGRESS', 'RESOLVED', 'FALSE_POSITIVE', 'WONT_FIX'],
+  FALSE_POSITIVE: ['OPEN', 'ACKNOWLEDGED'],
+  WONT_FIX: ['OPEN', 'ACKNOWLEDGED'],
+};
+
+export function canOperatorTransition(
+  from: FindingStatusValue,
+  to: FindingStatusValue
+): boolean {
+  if (from === to) return true;
+  return OPERATOR_ALLOWED_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/** When automated scan detects the issue again, reopen unless closed as FP or accepted risk. */
+export function shouldReopenOnAutomatedDetection(status: FindingStatusValue): boolean {
+  return status !== 'FALSE_POSITIVE' && status !== 'WONT_FIX';
+}
+
+export type AutomationEvidenceFreshness =
+  | 'current'
+  | 'stale_newer_scan_exists'
+  | 'never_autoverified'
+  | 'no_completed_scan'
+  | 'pipeline_degraded';
+
+export function deriveAutomationEvidenceFreshness(input: {
+  lastVerifiedAt: Date | null;
+  latestCompletedScanCompletedAt: Date | null;
+  jobPipelinesHealthy: boolean;
+}): AutomationEvidenceFreshness {
+  if (!input.jobPipelinesHealthy) {
+    return 'pipeline_degraded';
+  }
+  if (!input.latestCompletedScanCompletedAt) {
+    return 'no_completed_scan';
+  }
+  if (!input.lastVerifiedAt) {
+    return 'never_autoverified';
+  }
+  if (input.lastVerifiedAt.getTime() < input.latestCompletedScanCompletedAt.getTime()) {
+    return 'stale_newer_scan_exists';
+  }
+  return 'current';
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,3 +11,12 @@ export type { PaginatedResult, PaginationParams } from './pagination';
 export { paginationSchema, buildPaginationMeta } from './pagination';
 export { wcagCriteriaMap, getWcagLevel } from './wcag';
 export { bullmqConnectionOptions } from './redis-connection';
+export {
+  FINDING_STATUSES,
+  OPERATOR_ALLOWED_TRANSITIONS,
+  canOperatorTransition,
+  shouldReopenOnAutomatedDetection,
+  deriveAutomationEvidenceFreshness,
+  type FindingStatusValue,
+  type AutomationEvidenceFreshness,
+} from './finding-lifecycle';

--- a/packages/ui/src/status-badge.tsx
+++ b/packages/ui/src/status-badge.tsx
@@ -6,8 +6,10 @@ interface StatusBadgeProps {
 
 const styles: Record<string, string> = {
   OPEN: 'bg-red-100 text-red-800',
+  ACKNOWLEDGED: 'bg-amber-100 text-amber-900',
   IN_PROGRESS: 'bg-blue-100 text-blue-800',
-  FIXED: 'bg-green-100 text-green-800',
+  RESOLVED: 'bg-green-100 text-green-800',
+  MITIGATED: 'bg-emerald-100 text-emerald-900',
   WONT_FIX: 'bg-slate-100 text-slate-600',
   FALSE_POSITIVE: 'bg-slate-100 text-slate-600',
   PENDING: 'bg-amber-100 text-amber-800',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a minimal, auditable accessibility evidence and remediation workflow across Prisma, the scan worker, and operator UI/APIs.

## Changes

- **Schema**: `EvidenceSource`, expanded `FindingStatus` (ACKNOWLEDGED, RESOLVED, MITIGATED, etc.), `lastVerifiedAt` / `lastScanRunId`, `reopenedCount`, remediation metadata, `FindingStatusEvent` audit table, stable `@@unique([canonicalFindingId, pageId])` on occurrences, `lastRawViolationId` for evidence drill-down, explicit `Site` relation on `CanonicalFinding`.
- **Worker scan**: Writes raw violations first; upserts occurrences by composite key; updates verification fields; reopens `RESOLVED`/`MITIGATED` on automated re-detection unless `FALSE_POSITIVE` or `WONT_FIX`.
- **Web**: Org-scoped remediation transitions with `findings:manage`, shared transition graph (`@aros/shared`), `FindingStatusEvent` + `AuditLog`, finding list/detail UX (source, site, stale automation semantics, history), reporting summary helper, `GET /api/findings/summary`, stricter `GET /api/reports` (`reports:export` + `platformTruth` in payload).
- **Tests/docs**: Vitest for lifecycle + remediation server; Playwright `e2e/findings-workflow.spec.ts`; `docs/ACCESSIBILITY_EVIDENCE_MODEL.md`, `docs/REMEDIATION_LIFECYCLE.md`, `docs/FINDINGS_AND_REPORTING_TRUTH.md`.

## Migration

Apply `packages/db/prisma/migrations/20250323100000_finding_evidence_lifecycle/migration.sql` (maps legacy `FIXED` → `RESOLVED`). After deploy: `npm run db:generate` and migrate/push per environment.

## Verification

`npm run verify` (lint, typecheck, test, build) passed locally.

E2E findings flow requires DB with seed (`npm run db:push && npm run db:seed`); spec skips if no findings rows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0a9d666-38f4-46f1-aea7-8e7bc2aac967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0a9d666-38f4-46f1-aea7-8e7bc2aac967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

