### PR TITLE
Real scan orchestration: enqueue after crawl + operator verify

### DIFF
--- a/apps/web/src/app/(dashboard)/sites/[siteId]/actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/actions.ts
@@ -74,8 +74,26 @@ export async function startCrawlAction(formData: FormData) {
       attempts: 3,
       backoff: { type: 'exponential', delay: 5000 },
     });
-  } catch {
-    // Will be picked up by worker polling
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Queue add failed';
+    await prisma.crawlRun.update({
+      where: { id: crawlRun.id },
+      data: {
+        status: 'FAILED',
+        errorMessage: `Crawl queue unavailable: ${message}`,
+        completedAt: new Date(),
+      },
+    });
+    await prisma.auditLog.create({
+      data: {
+        organizationId: site.workspace.organizationId,
+        userId: user.id,
+        action: 'crawl.enqueue_failed',
+        entityType: 'CrawlRun',
+        entityId: crawlRun.id,
+        metadata: { siteId, message },
+      },
+    });
   }
 
   redirect(`/sites/${siteId}`);

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
@@ -2,7 +2,11 @@ import { notFound } from 'next/navigation';
 import { requireSession } from '@/lib/session';
 import { prisma } from '@/lib/db';
 import Link from 'next/link';
+import { hasPermission } from '@aros/config';
 import { startCrawlAction } from './actions';
+import { ScanNowButton } from './scan-now-button';
+import { scanSiteInitialState } from './scan-action-state';
+import { startSiteScanAction } from './scan-actions';
 
 export async function generateMetadata({ params }: { params: Promise<{ siteId: string }> }) {
   const { siteId } = await params;
@@ -35,7 +39,10 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
     notFound();
   }
 
-  const [recentCrawls, recentScans, findings] = await Promise.all([
+  const membership = site.workspace.organization.memberships[0];
+  const canStartScan = hasPermission(membership.role, 'scan:start');
+
+  const [recentCrawls, recentScans, findings, activeScan, pageCountForScan] = await Promise.all([
     prisma.crawlRun.findMany({
       where: { siteId },
       orderBy: { createdAt: 'desc' },
@@ -54,6 +61,12 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
       orderBy: { impact: 'asc' },
       take: 20,
     }),
+    prisma.scanRun.findFirst({
+      where: { siteId, status: { in: ['PENDING', 'RUNNING'] } },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, status: true, createdAt: true },
+    }),
+    prisma.page.count({ where: { siteId } }),
   ]);
 
   const findingsBySeverity = {
@@ -76,13 +89,30 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
           <h1 className="text-2xl font-bold text-slate-900">{site.name}</h1>
           <p className="text-slate-500 mt-0.5">{site.domain}</p>
         </div>
-        <div className="flex gap-3">
+        <div className="flex flex-wrap items-start gap-3">
           <form action={startCrawlAction}>
             <input type="hidden" name="siteId" value={siteId} />
             <button type="submit" className="btn-primary">
               Start Crawl
             </button>
           </form>
+          {canStartScan ? (
+            <ScanNowButton
+              action={startSiteScanAction}
+              initialState={scanSiteInitialState}
+              siteId={siteId}
+              disabled={pageCountForScan === 0 || Boolean(activeScan)}
+              blockedHint={
+                activeScan
+                  ? activeScan.status === 'PENDING'
+                    ? 'Verification is already queued for this site.'
+                    : 'Verification is already running for this site.'
+                  : pageCountForScan === 0
+                    ? 'Run a crawl first so there are pages to verify.'
+                    : null
+              }
+            />
+          ) : null}
           <Link href={`/sites/${siteId}/settings`} className="btn-secondary">
             Settings
           </Link>
@@ -230,7 +260,9 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
           </Link>
         </h2>
         {findings.length === 0 ? (
-          <p className="text-sm text-slate-500">No open findings. Run a scan to discover issues.</p>
+          <p className="text-sm text-slate-500">
+            No open findings. Queue a verification scan (or wait for one after crawl) to discover issues.
+          </p>
         ) : (
           <ul className="space-y-2" role="list">
             {findings.slice(0, 10).map((finding) => (

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/scan-action-state.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/scan-action-state.ts
@@ -1,0 +1,20 @@
+export type ScanSiteActionState = {
+  status:
+    | 'idle'
+    | 'queued'
+    | 'already_pending'
+    | 'already_running'
+    | 'deduped'
+    | 'no_pages'
+    | 'queue_unavailable'
+    | 'permission_denied'
+    | 'error';
+  message: string | null;
+  variant: 'neutral' | 'error';
+};
+
+export const scanSiteInitialState: ScanSiteActionState = {
+  status: 'idle',
+  message: null,
+  variant: 'neutral',
+};

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
@@ -1,0 +1,92 @@
+'use server';
+
+import { enqueueSiteScan } from '@aros/core-services/scan-enqueue';
+import { ApiError } from '@aros/shared';
+import { prisma } from '@/lib/db';
+import { requireSiteAccess } from '@/lib/auth-guard';
+import type { ScanSiteActionState } from './scan-action-state';
+
+export async function startSiteScanAction(
+  _prev: ScanSiteActionState,
+  formData: FormData
+): Promise<ScanSiteActionState> {
+  const siteId = formData.get('siteId') as string;
+  if (!siteId) {
+    return { status: 'error', message: 'Missing site.', variant: 'error' };
+  }
+
+  try {
+    const ctx = await requireSiteAccess(siteId, 'scan:start');
+    const result = await enqueueSiteScan(
+      { prisma },
+      {
+        siteId: ctx.siteId,
+        organizationId: ctx.organizationId,
+        crawlRunId: null,
+        trigger: 'operator',
+        userId: ctx.user.id,
+      }
+    );
+
+    if (result.ok) {
+      if (result.kind === 'queued') {
+        return {
+          status: 'queued',
+          message: 'Queued for verification. Evidence refreshes when the worker finishes this scan.',
+          variant: 'neutral',
+        };
+      }
+      if (result.kind === 'already_active') {
+        const pending = result.status === 'PENDING';
+        return {
+          status: pending ? 'already_pending' : 'already_running',
+          message: pending
+            ? 'Verification is already queued for this site.'
+            : 'Verification is already running for this site.',
+          variant: 'neutral',
+        };
+      }
+      return {
+        status: 'deduped',
+        message: 'This crawl was already covered by a completed scan.',
+        variant: 'neutral',
+      };
+    }
+
+    if (result.kind === 'invalid_target') {
+      if (result.reason === 'no_pages') {
+        return {
+          status: 'no_pages',
+          message: 'Run a crawl first so there are pages to verify.',
+          variant: 'error',
+        };
+      }
+      return { status: 'error', message: 'Site not found.', variant: 'error' };
+    }
+
+    if (result.kind === 'queue_unavailable') {
+      return {
+        status: 'queue_unavailable',
+        message:
+          'Verification queue is unavailable; nothing was queued. Check Redis and workers, then try again.',
+        variant: 'error',
+      };
+    }
+
+    return {
+      status: 'error',
+      message: result.message || 'Could not queue verification.',
+      variant: 'error',
+    };
+  } catch (e) {
+    if (e instanceof ApiError && e.statusCode === 403) {
+      return { status: 'permission_denied', message: 'You do not have permission to start scans.', variant: 'error' };
+    }
+    if (e instanceof ApiError && e.statusCode === 404) {
+      return { status: 'error', message: 'Site not found.', variant: 'error' };
+    }
+    const msg = e instanceof Error ? e.message : 'Request failed';
+    return { status: 'error', message: msg, variant: 'error' };
+  }
+}
+

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/scan-now-button.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/scan-now-button.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useFormState, useFormStatus } from 'react-dom';
+import type { ScanSiteActionState } from './scan-action-state';
+
+function SubmitLabel({ state }: { state: ScanSiteActionState }) {
+  const { pending } = useFormStatus();
+  if (pending) return 'Queuing…';
+  if (state.status === 'already_pending' || state.status === 'already_running') return 'Verification in progress';
+  return 'Queue verification scan';
+}
+
+export function ScanNowButton({
+  action,
+  initialState,
+  disabled,
+  blockedHint,
+  siteId,
+}: {
+  action: (prev: ScanSiteActionState, formData: FormData) => Promise<ScanSiteActionState>;
+  initialState: ScanSiteActionState;
+  disabled: boolean;
+  blockedHint?: string | null;
+  siteId: string;
+}) {
+  const [state, formAction] = useFormState(action, initialState);
+  const hint = state.message ?? blockedHint;
+
+  return (
+    <div className="space-y-1">
+      <form action={formAction}>
+        <input type="hidden" name="siteId" value={siteId} readOnly />
+        <button type="submit" className="btn-secondary" disabled={disabled}>
+          <SubmitLabel state={state} />
+        </button>
+      </form>
+      {hint ? (
+        <p className={`text-xs ${state.variant === 'error' ? 'text-red-700' : 'text-slate-600'}`}>{hint}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/worker/src/jobs/crawl.ts
+++ b/apps/worker/src/jobs/crawl.ts
@@ -1,5 +1,6 @@
 import { Job } from 'bullmq';
 import { prisma } from '@aros/db';
+import { enqueueSiteScan } from '@aros/core-services';
 import { chromium, type Browser, type Page } from 'playwright';
 
 interface CrawlJobData {
@@ -29,7 +30,10 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
     data: { status: 'RUNNING', startedAt: new Date() },
   });
 
-  const site = await prisma.site.findUnique({ where: { id: siteId } });
+  const site = await prisma.site.findUnique({
+    where: { id: siteId },
+    include: { workspace: { select: { organizationId: true } } },
+  });
   if (!site) {
     await prisma.crawlRun.update({
       where: { id: crawlRunId },
@@ -216,6 +220,56 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
     });
 
     console.log(`[Crawl] Completed crawl ${crawlRunId}: ${pagesCrawled} pages crawled`);
+
+    if (pagesCrawled > 0 && site.workspace) {
+      const scanResult = await enqueueSiteScan(
+        { prisma },
+        {
+          siteId,
+          organizationId: site.workspace.organizationId,
+          crawlRunId,
+          trigger: 'crawl.completed',
+          userId: null,
+        }
+      );
+      if (scanResult.ok) {
+        if (scanResult.kind === 'queued') {
+          console.log(
+            `[Crawl] Post-crawl scan queued: scanRun=${scanResult.scanRunId} job=${scanResult.bullmqJobId}`
+          );
+        } else if (scanResult.kind === 'deduped') {
+          console.log(`[Crawl] Post-crawl scan skipped (already completed for crawl): ${scanResult.scanRunId}`);
+        } else {
+          console.log(
+            `[Crawl] Post-crawl scan coalesced: ${scanResult.scanRunId} status=${scanResult.status}`
+          );
+        }
+      } else if (scanResult.kind === 'queue_unavailable') {
+        console.error(
+          `[Crawl] Post-crawl scan enqueue failed (queue): scanRun=${scanResult.scanRunId} ${scanResult.message}`
+        );
+        await prisma.auditLog
+          .create({
+            data: {
+              organizationId: site.workspace.organizationId,
+              action: 'scan.enqueue_failed',
+              entityType: 'CrawlRun',
+              entityId: crawlRunId,
+              metadata: {
+                siteId,
+                scanRunId: scanResult.scanRunId,
+                reason: 'queue_unavailable',
+                message: scanResult.message,
+              },
+            },
+          })
+          .catch(() => undefined);
+      } else if (scanResult.kind === 'invalid_target') {
+        console.warn(`[Crawl] Post-crawl scan skipped: ${scanResult.reason}`);
+      } else {
+        console.error(`[Crawl] Post-crawl scan failed: ${scanResult.message}`);
+      }
+    }
   } catch (err) {
     console.error(`[Crawl] Crawl ${crawlRunId} failed:`, err);
     await prisma.crawlRun.update({

--- a/packages/core-services/package.json
+++ b/packages/core-services/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./scan-enqueue": "./src/scan-enqueue.ts"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/core-services/src/index.ts
+++ b/packages/core-services/src/index.ts
@@ -4,6 +4,13 @@ export { toPublicHealthSummary } from './public-summary';
 export { buildRoutePlatformTruth } from './route-platform-truth';
 export type { RoutePlatformTruth, RoutePlatformShellBlocker } from './route-platform-truth';
 export { recordWorkerHeartbeat } from './heartbeat';
+export {
+  enqueueSiteScan,
+  SCAN_QUEUE_NAME,
+  type EnqueueSiteScanParams,
+  type EnqueueSiteScanResult,
+  type ScanEnqueueTrigger,
+} from './scan-enqueue';
 export { checkPostgres, checkRedisPing, getQueueDepths } from './checks';
 export {
   isWorkerHeartbeatStale,

--- a/packages/core-services/src/scan-enqueue.test.ts
+++ b/packages/core-services/src/scan-enqueue.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { enqueueSiteScan } from './scan-enqueue';
+import type { PrismaClient } from '@aros/db';
+
+function mockPrisma(overrides: Record<string, unknown> = {}) {
+  return {
+    site: { findFirst: vi.fn() },
+    page: { count: vi.fn() },
+    scanRun: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    auditLog: { create: vi.fn() },
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+describe('enqueueSiteScan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('queues when site has pages and queue succeeds', async () => {
+    const add = vi.fn().mockResolvedValue({ id: 'job' });
+    const close = vi.fn().mockResolvedValue(undefined);
+    const prisma = mockPrisma();
+    vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
+    vi.mocked(prisma.page.count).mockResolvedValue(2 as never);
+    vi.mocked(prisma.scanRun.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.scanRun.create).mockResolvedValue({ id: 'sr1' } as never);
+    vi.mocked(prisma.auditLog.create).mockResolvedValue({} as never);
+
+    const result = await enqueueSiteScan(
+      { prisma, queue: { add, close } },
+      { siteId: 's1', organizationId: 'o1', trigger: 'operator', userId: 'u1' }
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      kind: 'queued',
+      scanRunId: 'sr1',
+      bullmqJobId: 'scanRun:sr1',
+    });
+    expect(add).toHaveBeenCalledWith(
+      'scan',
+      { scanRunId: 'sr1', siteId: 's1' },
+      expect.objectContaining({ jobId: 'scanRun:sr1' })
+    );
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid_target when site not in org', async () => {
+    const prisma = mockPrisma();
+    vi.mocked(prisma.site.findFirst).mockResolvedValue(null);
+
+    const result = await enqueueSiteScan(
+      { prisma, queue: { add: vi.fn(), close: vi.fn() } },
+      { siteId: 's1', organizationId: 'o1', trigger: 'operator' }
+    );
+
+    expect(result).toEqual({ ok: false, kind: 'invalid_target', reason: 'site_not_found' });
+  });
+
+  it('returns invalid_target when no pages', async () => {
+    const prisma = mockPrisma();
+    vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
+    vi.mocked(prisma.page.count).mockResolvedValue(0 as never);
+
+    const result = await enqueueSiteScan(
+      { prisma, queue: { add: vi.fn(), close: vi.fn() } },
+      { siteId: 's1', organizationId: 'o1', trigger: 'operator' }
+    );
+
+    expect(result).toEqual({ ok: false, kind: 'invalid_target', reason: 'no_pages' });
+  });
+
+  it('dedupes when crawl already has completed scan', async () => {
+    const prisma = mockPrisma();
+    vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
+    vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.scanRun.findFirst).mockResolvedValue({ id: 'prev' } as never);
+
+    const result = await enqueueSiteScan(
+      { prisma, queue: { add: vi.fn(), close: vi.fn() } },
+      { siteId: 's1', organizationId: 'o1', crawlRunId: 'c1', trigger: 'crawl.completed' }
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      kind: 'deduped',
+      reason: 'crawl_already_scanned',
+      scanRunId: 'prev',
+    });
+  });
+
+  it('coalesces when pending scan exists for site', async () => {
+    const prisma = mockPrisma();
+    vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
+    vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.scanRun.findFirst).mockResolvedValue({ id: 'active', status: 'PENDING' } as never);
+
+    const result = await enqueueSiteScan(
+      { prisma, queue: { add: vi.fn(), close: vi.fn() } },
+      { siteId: 's1', organizationId: 'o1', trigger: 'operator' }
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      kind: 'already_active',
+      scanRunId: 'active',
+      status: 'PENDING',
+    });
+  });
+
+  it('marks scan failed and returns queue_unavailable when add throws', async () => {
+    const add = vi.fn().mockRejectedValue(new Error('Redis down'));
+    const close = vi.fn().mockResolvedValue(undefined);
+    const prisma = mockPrisma();
+    vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
+    vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.scanRun.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.scanRun.create).mockResolvedValue({ id: 'sr-fail' } as never);
+    const update = vi.fn().mockResolvedValue({} as never);
+    vi.mocked(prisma.scanRun.update).mockImplementation(update);
+
+    const result = await enqueueSiteScan(
+      { prisma, queue: { add, close } },
+      { siteId: 's1', organizationId: 'o1', trigger: 'operator' }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      kind: 'queue_unavailable',
+      scanRunId: 'sr-fail',
+    });
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'sr-fail' },
+        data: expect.objectContaining({ status: 'FAILED' }),
+      })
+    );
+  });
+});

--- a/packages/core-services/src/scan-enqueue.ts
+++ b/packages/core-services/src/scan-enqueue.ts
@@ -1,0 +1,225 @@
+import { Queue } from 'bullmq';
+import type { PrismaClient, ScanStatus } from '@aros/db';
+import { bullmqConnectionOptions } from '@aros/shared';
+
+export const SCAN_QUEUE_NAME = 'scan' as const;
+
+export type ScanEnqueueTrigger = 'crawl.completed' | 'operator' | 'api';
+
+export interface EnqueueSiteScanParams {
+  siteId: string;
+  organizationId: string;
+  /** When set, used for idempotency against repeated crawl-completion signals. */
+  crawlRunId?: string | null;
+  trigger: ScanEnqueueTrigger;
+  userId?: string | null;
+}
+
+export type EnqueueSiteScanResult =
+  | {
+      ok: true;
+      kind: 'queued';
+      scanRunId: string;
+      bullmqJobId: string;
+    }
+  | {
+      ok: true;
+      kind: 'already_active';
+      scanRunId: string;
+      status: ScanStatus;
+    }
+  | {
+      ok: true;
+      kind: 'deduped';
+      reason: 'crawl_already_scanned';
+      scanRunId: string;
+    }
+  | {
+      ok: false;
+      kind: 'invalid_target';
+      reason: 'site_not_found' | 'no_pages';
+    }
+  | {
+      ok: false;
+      kind: 'queue_unavailable';
+      message: string;
+      scanRunId: string;
+    }
+  | {
+      ok: false;
+      kind: 'internal_error';
+      message: string;
+    };
+
+const ACTIVE_STATUSES: ScanStatus[] = ['PENDING', 'RUNNING'];
+
+function scanQueue() {
+  return new Queue(SCAN_QUEUE_NAME, { connection: bullmqConnectionOptions() });
+}
+
+export interface EnqueueSiteScanDeps {
+  prisma: PrismaClient;
+  queue?: Pick<Queue, 'add' | 'close'>;
+}
+
+/**
+ * Canonical path: create ScanRun (PENDING), then persist BullMQ job. Tenant scope must be validated by caller.
+ */
+export async function enqueueSiteScan(
+  deps: EnqueueSiteScanDeps,
+  params: EnqueueSiteScanParams
+): Promise<EnqueueSiteScanResult> {
+  const { prisma } = deps;
+  const { siteId, organizationId, crawlRunId, trigger, userId } = params;
+
+  try {
+    const site = await prisma.site.findFirst({
+      where: {
+        id: siteId,
+        workspace: { organizationId },
+      },
+      select: { id: true },
+    });
+    if (!site) {
+      return { ok: false, kind: 'invalid_target', reason: 'site_not_found' };
+    }
+
+    const pageCount = await prisma.page.count({ where: { siteId } });
+    if (pageCount === 0) {
+      return { ok: false, kind: 'invalid_target', reason: 'no_pages' };
+    }
+
+    if (crawlRunId) {
+      const completedForCrawl = await prisma.scanRun.findFirst({
+        where: { crawlRunId, status: 'COMPLETED' },
+        select: { id: true },
+      });
+      if (completedForCrawl) {
+        return {
+          ok: true,
+          kind: 'deduped',
+          reason: 'crawl_already_scanned',
+          scanRunId: completedForCrawl.id,
+        };
+      }
+
+      const activeForCrawl = await prisma.scanRun.findFirst({
+        where: { crawlRunId, status: { in: ACTIVE_STATUSES } },
+        select: { id: true, status: true },
+      });
+      if (activeForCrawl) {
+        return {
+          ok: true,
+          kind: 'already_active',
+          scanRunId: activeForCrawl.id,
+          status: activeForCrawl.status,
+        };
+      }
+    }
+
+    const activeForSite = await prisma.scanRun.findFirst({
+      where: { siteId, status: { in: ACTIVE_STATUSES } },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, status: true },
+    });
+    if (activeForSite) {
+      return {
+        ok: true,
+        kind: 'already_active',
+        scanRunId: activeForSite.id,
+        status: activeForSite.status,
+      };
+    }
+
+    const scanRun = await prisma.scanRun.create({
+      data: {
+        siteId,
+        crawlRunId: crawlRunId ?? undefined,
+        status: 'PENDING',
+      },
+    });
+
+    const jobPayload = { scanRunId: scanRun.id, siteId };
+    const bullmqJobId = `scanRun:${scanRun.id}`;
+    const queueInstance = deps.queue ?? scanQueue();
+    const shouldClose = !deps.queue;
+
+    try {
+      await queueInstance.add('scan', jobPayload, {
+        jobId: bullmqJobId,
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5000 },
+      });
+    } catch (e) {
+      if (shouldClose) {
+        await queueInstance.close().catch(() => undefined);
+      }
+      const message = e instanceof Error ? e.message : 'Queue add failed';
+      await prisma.scanRun
+        .update({
+          where: { id: scanRun.id },
+          data: {
+            status: 'FAILED',
+            errorMessage: `Queue unavailable: ${message}`,
+            completedAt: new Date(),
+          },
+        })
+        .catch(() => undefined);
+      console.error('[enqueueSiteScan] queue add failed', {
+        siteId,
+        scanRunId: scanRun.id,
+        trigger,
+        message,
+      });
+      return {
+        ok: false,
+        kind: 'queue_unavailable',
+        message,
+        scanRunId: scanRun.id,
+      };
+    }
+
+    if (shouldClose) {
+      await queueInstance.close().catch(() => undefined);
+    }
+
+    await prisma.auditLog
+      .create({
+        data: {
+          organizationId,
+          userId: userId ?? undefined,
+          action: 'scan.queued',
+          entityType: 'ScanRun',
+          entityId: scanRun.id,
+          metadata: {
+            siteId,
+            trigger,
+            crawlRunId: crawlRunId ?? null,
+            bullmqJobId,
+          },
+        },
+      })
+      .catch((err) => {
+        console.error('[enqueueSiteScan] audit log failed', err);
+      });
+
+    console.log('[enqueueSiteScan] queued', {
+      siteId,
+      scanRunId: scanRun.id,
+      trigger,
+      crawlRunId: crawlRunId ?? null,
+      bullmqJobId,
+    });
+
+    return {
+      ok: true,
+      kind: 'queued',
+      scanRunId: scanRun.id,
+      bullmqJobId,
+    };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Unknown error';
+    console.error('[enqueueSiteScan] failed', { siteId, message });
+    return { ok: false, kind: 'internal_error', message };
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements end-to-end scan job persistence and queue insertion: the worker enqueues verification scans after successful crawls (when pages were discovered), and operators can queue a site-wide scan from the site detail page with honest UI states.

## Changes

- **`enqueueSiteScan`** in `@aros/core-services`: creates `ScanRun` (PENDING), adds BullMQ job with idempotent `jobId: scanRun:<scanRunId>`, dedupes per crawl completion and coalesces pending/running scans per site, marks `ScanRun` FAILED if Redis/queue add fails (returns `queue_unavailable`, no throw).
- **Worker crawl job**: after `COMPLETED` with `pagesCrawled > 0`, calls `enqueueSiteScan`; crawl completion never throws on scan enqueue failure; audit `scan.enqueue_failed` when queue fails.
- **Web**: server action `startSiteScanAction` (permission `scan:start`) + client button; success only after real queue write; disables when no pages or active scan; truthful copy ("Queued for verification…").
- **Crawl start action**: if crawl queue add fails, marks `CrawlRun` FAILED and writes audit (removes silent "will be picked up" behavior).

## Dedupe / idempotency

- BullMQ `jobId` = `scanRun:<id>` prevents duplicate jobs for the same run.
- Per-site: if PENDING/RUNNING scan exists, returns coalesced result (no new row).
- Per-crawl (post-crawl path): if a COMPLETED scan already references `crawlRunId`, skips enqueue.

## Verification

- `npm run verify` (lint, typecheck, tests, web build)
- `npm run build:worker`

## Notes

- `@aros/core-services/package.json` adds `exports["./scan-enqueue"]` so the web scan action can import BullMQ only where needed; worker continues to use `@aros/core-services` main entry.
- Full Redis + worker smoke (consume job, update findings) requires local/CI infra not exercised here beyond unit tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-094dc3aa-c98b-4ffc-9df1-f281034218b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-094dc3aa-c98b-4ffc-9df1-f281034218b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

