### PR TITLE
Scan orchestration: shared scan queue, auto-scan policy, truthful site verification UI

### DIFF
--- a/apps/web/src/app/(dashboard)/findings/[findingId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/findings/[findingId]/page.tsx
@@ -244,7 +244,10 @@ export default async function FindingDetailPage({
                 {finding.lastVerifiedAt?.toLocaleString() ?? 'last verified time'}. Results may have changed.
               </>
             ) : automationFreshness === 'never_autoverified' ? (
-              <>No automated verification timestamp on record.</>
+              <>
+                Last auto-verified: never — this record has not been touched by a completed automated scan yet. Queue a
+                verification scan (or wait for one after crawl) to refresh evidence.
+              </>
             ) : automationFreshness === 'no_completed_scan' ? (
               <>No completed scan found for this organization yet.</>
             ) : (

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
@@ -7,6 +7,10 @@ import { startCrawlAction } from './actions';
 import { ScanNowButton } from './scan-now-button';
 import { scanSiteInitialState } from './scan-action-state';
 import { startSiteScanAction } from './scan-actions';
+import {
+  getPostCrawlScanEnqueueFailureHint,
+  getSiteVerificationStatus,
+} from '@/lib/sites/verification-status';
 
 export async function generateMetadata({ params }: { params: Promise<{ siteId: string }> }) {
   const { siteId } = await params;
@@ -42,7 +46,7 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
   const membership = site.workspace.organization.memberships[0];
   const canStartScan = hasPermission(membership.role, 'scan:start');
 
-  const [recentCrawls, recentScans, findings, activeScan, pageCountForScan] = await Promise.all([
+  const [recentCrawls, recentScans, findings, pageCountForScan, verificationExtras] = await Promise.all([
     prisma.crawlRun.findMany({
       where: { siteId },
       orderBy: { createdAt: 'desc' },
@@ -61,13 +65,42 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
       orderBy: { impact: 'asc' },
       take: 20,
     }),
-    prisma.scanRun.findFirst({
-      where: { siteId, status: { in: ['PENDING', 'RUNNING'] } },
-      orderBy: { createdAt: 'desc' },
-      select: { id: true, status: true, createdAt: true },
-    }),
     prisma.page.count({ where: { siteId } }),
+    (async () => {
+      try {
+        const [verificationStatus, postCrawlEnqueueHint] = await Promise.all([
+          getSiteVerificationStatus(prisma, {
+            siteId,
+            organizationId: site.workspace.organizationId,
+          }),
+          getPostCrawlScanEnqueueFailureHint(prisma, {
+            siteId,
+            organizationId: site.workspace.organizationId,
+          }),
+        ]);
+        return { verificationStatus, postCrawlEnqueueHint, verificationLoadError: null as string | null };
+      } catch (e) {
+        const message = e instanceof Error ? e.message : 'Could not load verification status';
+        console.error('[site detail] verification status query failed', e);
+        return {
+          verificationStatus: null,
+          postCrawlEnqueueHint: { show: false, message: null },
+          verificationLoadError: message,
+        };
+      }
+    })(),
   ]);
+
+  const { verificationStatus, postCrawlEnqueueHint, verificationLoadError } = verificationExtras;
+
+  const scanBlocked =
+    verificationStatus?.status === 'pending' || verificationStatus?.status === 'running';
+  const scanBlockedHint =
+    verificationStatus?.status === 'pending'
+      ? 'Verification is already queued for this site.'
+      : verificationStatus?.status === 'running'
+        ? 'Verification is already running for this site.'
+        : null;
 
   const findingsBySeverity = {
     critical: findings.filter((f) => f.impact === 'CRITICAL').length,
@@ -78,6 +111,32 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
 
   return (
     <div className="space-y-6">
+      {verificationLoadError ? (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          Could not load live verification queue status ({verificationLoadError}). Scan history below still reflects stored
+          runs.
+        </div>
+      ) : null}
+      {verificationStatus?.status === 'pending' || verificationStatus?.status === 'running' ? (
+        <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+          {verificationStatus.status === 'pending' ? 'Verification pending' : 'Verification in progress'}: automated evidence
+          refreshes when this scan finishes (queued at{' '}
+          {verificationStatus.createdAt?.toLocaleString() ?? 'unknown'}).
+        </div>
+      ) : null}
+      {verificationStatus?.status === 'failed_enqueue' ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">
+          <span className="font-medium">Verification failed to queue.</span>{' '}
+          {verificationStatus.errorHint
+            ? verificationStatus.errorHint.replace(/^Queue unavailable:\s*/i, '')
+            : 'Check Redis and workers, then use Queue verification scan.'}
+        </div>
+      ) : null}
+      {postCrawlEnqueueHint.show && postCrawlEnqueueHint.message ? (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          {postCrawlEnqueueHint.message}
+        </div>
+      ) : null}
       <div className="flex items-start justify-between">
         <div>
           <div className="flex items-center gap-2 text-sm text-slate-500 mb-1">
@@ -101,15 +160,10 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
               action={startSiteScanAction}
               initialState={scanSiteInitialState}
               siteId={siteId}
-              disabled={pageCountForScan === 0 || Boolean(activeScan)}
+              disabled={pageCountForScan === 0 || Boolean(scanBlocked)}
               blockedHint={
-                activeScan
-                  ? activeScan.status === 'PENDING'
-                    ? 'Verification is already queued for this site.'
-                    : 'Verification is already running for this site.'
-                  : pageCountForScan === 0
-                    ? 'Run a crawl first so there are pages to verify.'
-                    : null
+                scanBlockedHint ??
+                (pageCountForScan === 0 ? 'Run a crawl first so there are pages to verify.' : null)
               }
             />
           ) : null}

--- a/apps/web/src/lib/queue.ts
+++ b/apps/web/src/lib/queue.ts
@@ -1,10 +1,11 @@
 import { Queue } from 'bullmq';
-import { bullmqConnectionOptions } from '@aros/shared';
+import { bullmqConnectionOptions, getSharedScanQueue } from '@aros/shared';
 
 const connection = bullmqConnectionOptions();
 
 export const crawlQueue = new Queue('crawl', { connection });
-export const scanQueue = new Queue('scan', { connection });
+/** Shared BullMQ queue instance (same Redis connection pattern as crawl/cluster). */
+export const scanQueue = getSharedScanQueue();
 export const clusterQueue = new Queue('cluster', { connection });
 export const remediationQueue = new Queue('remediation', { connection });
 

--- a/apps/web/src/lib/sites/verification-status.test.ts
+++ b/apps/web/src/lib/sites/verification-status.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getPostCrawlScanEnqueueFailureHint, getSiteVerificationStatus } from './verification-status';
+import type { PrismaClient } from '@aros/db';
+
+function mockPrisma(scanRun: { findFirst: ReturnType<typeof vi.fn> }) {
+  return { scanRun } as unknown as PrismaClient;
+}
+
+describe('getSiteVerificationStatus', () => {
+  it('returns pending when latest active scan is PENDING', async () => {
+    const findFirst = vi.fn().mockResolvedValue({
+      id: 'sr1',
+      status: 'PENDING',
+      createdAt: new Date('2025-01-01T00:00:00Z'),
+    });
+    const row = await getSiteVerificationStatus(mockPrisma({ findFirst }), {
+      siteId: 's1',
+      organizationId: 'o1',
+    });
+    expect(row).toMatchObject({ status: 'pending', scanRunId: 'sr1' });
+    expect(findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns failed_enqueue when no active scan but queue-failed run exists', async () => {
+    const findFirst = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'sr-fail',
+        createdAt: new Date('2025-01-02T00:00:00Z'),
+        errorMessage: 'Queue unavailable: Redis down',
+      });
+    const row = await getSiteVerificationStatus(mockPrisma({ findFirst }), {
+      siteId: 's1',
+      organizationId: 'o1',
+    });
+    expect(row).toMatchObject({
+      status: 'failed_enqueue',
+      scanRunId: 'sr-fail',
+      errorHint: 'Queue unavailable: Redis down',
+    });
+  });
+
+  it('returns idle when no active or failed-enqueue rows', async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const row = await getSiteVerificationStatus(mockPrisma({ findFirst }), {
+      siteId: 's1',
+      organizationId: 'o1',
+    });
+    expect(row).toEqual({
+      status: 'idle',
+      scanRunId: null,
+      createdAt: null,
+      errorHint: null,
+    });
+    expect(findFirst).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getPostCrawlScanEnqueueFailureHint', () => {
+  it('shows hint when latest completed crawl has failed queue scan and no recovery', async () => {
+    const completedAt = new Date('2025-01-10T12:00:00Z');
+    const prisma = {
+      crawlRun: {
+        findFirst: vi.fn().mockResolvedValue({ id: 'c1', completedAt }),
+      },
+      scanRun: {
+        findFirst: vi
+          .fn()
+          .mockResolvedValueOnce({ id: 'sr-bad' })
+          .mockResolvedValueOnce(null),
+      },
+    } as unknown as PrismaClient;
+
+    const hint = await getPostCrawlScanEnqueueFailureHint(prisma, {
+      siteId: 's1',
+      organizationId: 'o1',
+    });
+    expect(hint.show).toBe(true);
+    expect(hint.message).toContain('could not be queued');
+  });
+
+  it('hides hint when a newer completed scan exists', async () => {
+    const completedAt = new Date('2025-01-10T12:00:00Z');
+    const prisma = {
+      crawlRun: {
+        findFirst: vi.fn().mockResolvedValue({ id: 'c1', completedAt }),
+      },
+      scanRun: {
+        findFirst: vi
+          .fn()
+          .mockResolvedValueOnce({ id: 'sr-bad' })
+          .mockResolvedValueOnce({ id: 'sr-ok' }),
+      },
+    } as unknown as PrismaClient;
+
+    const hint = await getPostCrawlScanEnqueueFailureHint(prisma, {
+      siteId: 's1',
+      organizationId: 'o1',
+    });
+    expect(hint.show).toBe(false);
+  });
+});

--- a/apps/web/src/lib/sites/verification-status.ts
+++ b/apps/web/src/lib/sites/verification-status.ts
@@ -1,0 +1,131 @@
+import type { PrismaClient } from '@aros/db';
+
+export type SiteVerificationRow = {
+  status: 'idle' | 'pending' | 'running' | 'failed_enqueue';
+  scanRunId: string | null;
+  createdAt: Date | null;
+  errorHint: string | null;
+};
+
+/**
+ * Operator-facing scan lifecycle from persisted ScanRun + audit (no BullMQ reads).
+ */
+export async function getSiteVerificationStatus(
+  prisma: PrismaClient,
+  params: { siteId: string; organizationId: string }
+): Promise<SiteVerificationRow> {
+  const { siteId, organizationId } = params;
+
+  const active = await prisma.scanRun.findFirst({
+    where: {
+      siteId,
+      status: { in: ['PENDING', 'RUNNING'] },
+      site: { workspace: { organizationId } },
+    },
+    orderBy: { createdAt: 'desc' },
+    select: { id: true, status: true, createdAt: true },
+  });
+
+  if (active) {
+    return {
+      status: active.status === 'PENDING' ? 'pending' : 'running',
+      scanRunId: active.id,
+      createdAt: active.createdAt,
+      errorHint: null,
+    };
+  }
+
+  const failedEnqueue = await prisma.scanRun.findFirst({
+    where: {
+      siteId,
+      status: 'FAILED',
+      errorMessage: { startsWith: 'Queue unavailable:' },
+      site: { workspace: { organizationId } },
+    },
+    orderBy: { createdAt: 'desc' },
+    select: { id: true, createdAt: true, errorMessage: true },
+  });
+
+  if (failedEnqueue) {
+    return {
+      status: 'failed_enqueue',
+      scanRunId: failedEnqueue.id,
+      createdAt: failedEnqueue.createdAt,
+      errorHint: failedEnqueue.errorMessage,
+    };
+  }
+
+  return { status: 'idle', scanRunId: null, createdAt: null, errorHint: null };
+}
+
+export type PostCrawlEnqueueFailureHint = {
+  show: boolean;
+  message: string | null;
+};
+
+/**
+ * Surface a truthful follow-up when post-crawl auto-scan enqueue failed and nothing has recovered yet.
+ */
+export async function getPostCrawlScanEnqueueFailureHint(
+  prisma: PrismaClient,
+  params: { siteId: string; organizationId: string }
+): Promise<PostCrawlEnqueueFailureHint> {
+  const { siteId, organizationId } = params;
+
+  const latestCrawl = await prisma.crawlRun.findFirst({
+    where: {
+      siteId,
+      status: 'COMPLETED',
+      pagesCrawled: { gt: 0 },
+      site: { workspace: { organizationId } },
+    },
+    orderBy: { completedAt: 'desc' },
+    select: { id: true, completedAt: true },
+  });
+
+  if (!latestCrawl?.completedAt) {
+    return { show: false, message: null };
+  }
+
+  const failedForCrawl = await prisma.scanRun.findFirst({
+    where: {
+      siteId,
+      crawlRunId: latestCrawl.id,
+      status: 'FAILED',
+      errorMessage: { startsWith: 'Queue unavailable:' },
+    },
+    select: { id: true },
+  });
+
+  if (!failedForCrawl) {
+    return { show: false, message: null };
+  }
+
+  const recovered = await prisma.scanRun.findFirst({
+    where: {
+      siteId,
+      site: { workspace: { organizationId } },
+      OR: [
+        {
+          status: 'COMPLETED',
+          completedAt: { gte: latestCrawl.completedAt },
+        },
+        {
+          status: { in: ['PENDING', 'RUNNING'] },
+          createdAt: { gte: latestCrawl.completedAt },
+        },
+      ],
+    },
+    select: { id: true },
+  });
+
+  if (recovered) {
+    return { show: false, message: null };
+  }
+
+  return {
+    show: true,
+    message:
+      'Automatic verification could not be queued after the latest crawl (verification queue unavailable). Start a verification scan once Redis and workers are healthy.',
+  };
+}

--- a/apps/worker/src/jobs/crawl.ts
+++ b/apps/worker/src/jobs/crawl.ts
@@ -32,7 +32,10 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
 
   const site = await prisma.site.findUnique({
     where: { id: siteId },
-    include: { workspace: { select: { organizationId: true } } },
+    include: {
+      workspace: { select: { organizationId: true } },
+      crawlConfig: { select: { autoScanAfterCrawl: true } },
+    },
   });
   if (!site) {
     await prisma.crawlRun.update({
@@ -221,7 +224,9 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
 
     console.log(`[Crawl] Completed crawl ${crawlRunId}: ${pagesCrawled} pages crawled`);
 
-    if (pagesCrawled > 0 && site.workspace) {
+    const autoScanAfterCrawl = site.crawlConfig?.autoScanAfterCrawl !== false;
+
+    if (pagesCrawled > 0 && site.workspace && autoScanAfterCrawl) {
       const scanResult = await enqueueSiteScan(
         { prisma },
         {
@@ -269,6 +274,8 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
       } else {
         console.error(`[Crawl] Post-crawl scan failed: ${scanResult.message}`);
       }
+    } else if (pagesCrawled > 0 && site.workspace && !autoScanAfterCrawl) {
+      console.log(`[Crawl] Post-crawl scan skipped (autoScanAfterCrawl disabled) crawlRun=${crawlRunId}`);
     }
   } catch (err) {
     console.error(`[Crawl] Crawl ${crawlRunId} failed:`, err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8889,6 +8889,7 @@
       "name": "@aros/shared",
       "version": "0.1.0",
       "dependencies": {
+        "bullmq": "^5.31.0",
         "zod": "^3.24.0"
       },
       "devDependencies": {

--- a/packages/core-services/src/scan-enqueue.test.ts
+++ b/packages/core-services/src/scan-enqueue.test.ts
@@ -90,7 +90,7 @@ describe('enqueueSiteScan', () => {
     });
   });
 
-  it('coalesces when pending scan exists for site', async () => {
+  it('coalesces when pending scan exists for site (operator, no crawlRunId)', async () => {
     const prisma = mockPrisma();
     vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
     vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
@@ -136,5 +136,25 @@ describe('enqueueSiteScan', () => {
         data: expect.objectContaining({ status: 'FAILED' }),
       })
     );
+  });
+
+  it('allows a new operator scan when only a completed scan exists for the site', async () => {
+    const add = vi.fn().mockResolvedValue({ id: 'job' });
+    const prisma = mockPrisma();
+    vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
+    vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.scanRun.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    vi.mocked(prisma.scanRun.create).mockResolvedValue({ id: 'sr-new' } as never);
+    vi.mocked(prisma.auditLog.create).mockResolvedValue({} as never);
+
+    const result = await enqueueSiteScan(
+      { prisma, queue: { add, close: vi.fn() } },
+      { siteId: 's1', organizationId: 'o1', trigger: 'operator' }
+    );
+
+    expect(result).toMatchObject({ ok: true, kind: 'queued', scanRunId: 'sr-new' });
+    expect(add).toHaveBeenCalled();
   });
 });

--- a/packages/core-services/src/scan-enqueue.ts
+++ b/packages/core-services/src/scan-enqueue.ts
@@ -1,8 +1,8 @@
 import { Queue } from 'bullmq';
 import type { PrismaClient, ScanStatus } from '@aros/db';
-import { bullmqConnectionOptions } from '@aros/shared';
+import { getSharedScanQueue, SCAN_QUEUE_NAME } from '@aros/shared';
 
-export const SCAN_QUEUE_NAME = 'scan' as const;
+export { SCAN_QUEUE_NAME };
 
 export type ScanEnqueueTrigger = 'crawl.completed' | 'operator' | 'api';
 
@@ -54,7 +54,7 @@ export type EnqueueSiteScanResult =
 const ACTIVE_STATUSES: ScanStatus[] = ['PENDING', 'RUNNING'];
 
 function scanQueue() {
-  return new Queue(SCAN_QUEUE_NAME, { connection: bullmqConnectionOptions() });
+  return getSharedScanQueue();
 }
 
 export interface EnqueueSiteScanDeps {

--- a/packages/db/prisma/migrations/20250323120000_crawl_auto_scan_policy/migration.sql
+++ b/packages/db/prisma/migrations/20250323120000_crawl_auto_scan_policy/migration.sql
@@ -1,0 +1,2 @@
+-- Optional policy: enqueue verification scan after successful crawl (default on for existing sites)
+ALTER TABLE "crawl_configs" ADD COLUMN "autoScanAfterCrawl" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -143,6 +143,8 @@ model CrawlConfig {
   excludePatterns   String[] @default([])
   respectRobots     Boolean  @default(true)
   renderJavaScript  Boolean  @default(true)
+  /** When true, worker enqueues a site scan after a crawl completes with pages. */
+  autoScanAfterCrawl Boolean @default(true)
   viewports         Json     @default("[{\"width\":1280,\"height\":720},{\"width\":375,\"height\":812}]")
   scheduleCron      String?
   authConfig        Json?

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "bullmq": "^5.31.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export type { PaginatedResult, PaginationParams } from './pagination';
 export { paginationSchema, buildPaginationMeta } from './pagination';
 export { wcagCriteriaMap, getWcagLevel } from './wcag';
 export { bullmqConnectionOptions } from './redis-connection';
+export { SCAN_QUEUE_NAME, getSharedScanQueue } from './scan-queue';
 export {
   FINDING_STATUSES,
   OPERATOR_ALLOWED_TRANSITIONS,

--- a/packages/shared/src/scan-queue.ts
+++ b/packages/shared/src/scan-queue.ts
@@ -1,0 +1,18 @@
+import { Queue } from 'bullmq';
+import { bullmqConnectionOptions } from './redis-connection';
+
+/** BullMQ queue name for site verification scans (must match worker consumer). */
+export const SCAN_QUEUE_NAME = 'scan' as const;
+
+let sharedScanQueue: Queue | null = null;
+
+/**
+ * Singleton scan queue for producers (Next.js server, core-services).
+ * Avoids opening a new Redis connection on every enqueue.
+ */
+export function getSharedScanQueue(): Queue {
+  if (!sharedScanQueue) {
+    sharedScanQueue = new Queue(SCAN_QUEUE_NAME, { connection: bullmqConnectionOptions() });
+  }
+  return sharedScanQueue;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens end-to-end scan enqueue by reusing a single BullMQ scan queue connection for producers, adds an opt-out for post-crawl auto-scan via `CrawlConfig.autoScanAfterCrawl`, and surfaces truthful verification state on the site detail page (pending/running, failed queue enqueue, post-crawl enqueue failure follow-up).

## Changes

- **`@aros/shared`**: `getSharedScanQueue()` singleton + `SCAN_QUEUE_NAME`; `bullmq` dependency for shared producers.
- **`enqueueSiteScan`**: uses shared queue instead of constructing a new `Queue` per call (reduces connection churn; same job payload / `jobId` contract).
- **`CrawlConfig`**: `autoScanAfterCrawl` boolean (default `true`); migration `20250323120000_crawl_auto_scan_policy`.
- **Worker crawl job**: skips post-crawl `enqueueSiteScan` when `autoScanAfterCrawl` is false.
- **Site page**: org-scoped banners from persisted `ScanRun` + audit-style hint when latest completed crawl had a queue-unavailable scan failure and nothing recovered; graceful degradation if status queries throw.
- **Finding detail**: clearer copy for `never_autoverified` (“Last auto-verified: never…”).
- **Tests**: `enqueueSiteScan` case for operator enqueue after only completed scans; `verification-status` unit tests.

## Rollout

Apply DB migration (or `db:push` in dev) so `autoScanAfterCrawl` exists. Existing sites default to `true` (current behavior).

## Verified

`npm run verify` (lint, typecheck, tests, build). Prisma client generation required before typecheck (`npm run db:generate`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d79ab2b0-3d4e-4146-b106-5767dbe738d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d79ab2b0-3d4e-4146-b106-5767dbe738d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

