### PR TITLE
Crawl→scan orchestration truth, settings UI, lazy queue for build

### DIFF
--- a/apps/web/src/app/(dashboard)/sites/[siteId]/actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { requireSession } from '@/lib/session';
 import { prisma } from '@/lib/db';
-import { crawlQueue, type CrawlJobData } from '@/lib/queue';
+import { getCrawlQueue, type CrawlJobData } from '@/lib/queue';
 
 export async function startCrawlAction(formData: FormData) {
   const user = await requireSession();
@@ -70,7 +70,7 @@ export async function startCrawlAction(formData: FormData) {
         ],
       },
     };
-    await crawlQueue.add('crawl', jobData, {
+    await getCrawlQueue().add('crawl', jobData, {
       attempts: 3,
       backoff: { type: 'exponential', delay: 5000 },
     });

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
@@ -10,6 +10,8 @@ import { startSiteScanAction } from './scan-actions';
 import {
   getPostCrawlScanEnqueueFailureHint,
   getSiteVerificationStatus,
+  postCrawlKickoffOperatorSummary,
+  scanEnqueueFailureOperatorHint,
 } from '@/lib/sites/verification-status';
 
 export async function generateMetadata({ params }: { params: Promise<{ siteId: string }> }) {
@@ -45,12 +47,23 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
 
   const membership = site.workspace.organization.memberships[0];
   const canStartScan = hasPermission(membership.role, 'scan:start');
+  const canManageSite = hasPermission(membership.role, 'site:manage');
 
   const [recentCrawls, recentScans, findings, pageCountForScan, verificationExtras] = await Promise.all([
     prisma.crawlRun.findMany({
       where: { siteId },
       orderBy: { createdAt: 'desc' },
       take: 10,
+      select: {
+        id: true,
+        status: true,
+        pagesCrawled: true,
+        startedAt: true,
+        completedAt: true,
+        postCrawlScanKickoffStatus: true,
+        postCrawlScanKickoffReasonCode: true,
+        postCrawlScanKickoffDetail: true,
+      },
     }),
     prisma.scanRun.findMany({
       where: { siteId },
@@ -125,11 +138,11 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
         </div>
       ) : null}
       {verificationStatus?.status === 'failed_enqueue' ? (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">
-          <span className="font-medium">Verification failed to queue.</span>{' '}
-          {verificationStatus.errorHint
-            ? verificationStatus.errorHint.replace(/^Queue unavailable:\s*/i, '')
-            : 'Check Redis and workers, then use Queue verification scan.'}
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
+          <span className="font-medium">Verification could not be queued.</span>{' '}
+          {scanEnqueueFailureOperatorHint(verificationStatus.enqueueFailureCode)}
+          {verificationStatus.errorDetail ? ` ${verificationStatus.errorDetail}` : ''} Use Queue verification scan once
+          Redis and workers are healthy.
         </div>
       ) : null}
       {postCrawlEnqueueHint.show && postCrawlEnqueueHint.message ? (
@@ -167,9 +180,11 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
               }
             />
           ) : null}
-          <Link href={`/sites/${siteId}/settings`} className="btn-secondary">
-            Settings
-          </Link>
+          {canManageSite ? (
+            <Link href={`/sites/${siteId}/settings`} className="btn-secondary">
+              Settings
+            </Link>
+          ) : null}
         </div>
       </div>
 
@@ -216,39 +231,53 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
                 <tr className="border-b border-slate-200">
                   <th className="pb-2 text-left font-medium text-slate-500">Status</th>
                   <th className="pb-2 text-right font-medium text-slate-500">Pages</th>
+                  <th className="pb-2 text-left font-medium text-slate-500">After crawl</th>
                   <th className="pb-2 text-right font-medium text-slate-500">Started</th>
                   <th className="pb-2 text-right font-medium text-slate-500">Completed</th>
                 </tr>
               </thead>
               <tbody>
-                {recentCrawls.map((crawl) => (
-                  <tr key={crawl.id} className="border-b border-slate-100">
-                    <td className="py-2">
-                      <span
-                        className={`badge ${
-                          crawl.status === 'COMPLETED'
-                            ? 'bg-green-100 text-green-800'
-                            : crawl.status === 'RUNNING'
-                            ? 'bg-blue-100 text-blue-800'
-                            : crawl.status === 'FAILED'
-                            ? 'bg-red-100 text-red-800'
-                            : 'bg-slate-100 text-slate-800'
-                        }`}
-                      >
-                        {crawl.status.toLowerCase()}
-                      </span>
-                    </td>
-                    <td className="py-2 text-right text-slate-600">
-                      {crawl.pagesCrawled}
-                    </td>
-                    <td className="py-2 text-right text-slate-500">
-                      {crawl.startedAt?.toLocaleString() ?? '-'}
-                    </td>
-                    <td className="py-2 text-right text-slate-500">
-                      {crawl.completedAt?.toLocaleString() ?? '-'}
-                    </td>
-                  </tr>
-                ))}
+                {recentCrawls.map((crawl) => {
+                  const afterSummary =
+                    crawl.status === 'COMPLETED'
+                      ? postCrawlKickoffOperatorSummary(
+                          crawl.postCrawlScanKickoffStatus,
+                          crawl.postCrawlScanKickoffReasonCode,
+                          crawl.postCrawlScanKickoffDetail
+                        )
+                      : null;
+                  return (
+                    <tr key={crawl.id} className="border-b border-slate-100">
+                      <td className="py-2">
+                        <span
+                          className={`badge ${
+                            crawl.status === 'COMPLETED'
+                              ? 'bg-green-100 text-green-800'
+                              : crawl.status === 'RUNNING'
+                                ? 'bg-blue-100 text-blue-800'
+                                : crawl.status === 'FAILED'
+                                  ? 'bg-red-100 text-red-800'
+                                  : 'bg-slate-100 text-slate-800'
+                          }`}
+                        >
+                          {crawl.status.toLowerCase()}
+                        </span>
+                      </td>
+                      <td className="py-2 text-right text-slate-600">{crawl.pagesCrawled}</td>
+                      <td className="py-2 text-left text-slate-600 text-xs max-w-xs">
+                        {afterSummary ?? (
+                          <span className="text-slate-400">—</span>
+                        )}
+                      </td>
+                      <td className="py-2 text-right text-slate-500">
+                        {crawl.startedAt?.toLocaleString() ?? '-'}
+                      </td>
+                      <td className="py-2 text-right text-slate-500">
+                        {crawl.completedAt?.toLocaleString() ?? '-'}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.test.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { updateAutoScanAfterCrawlAction } from './actions';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    crawlConfig: { update: vi.fn() },
+    auditLog: { create: vi.fn() },
+  },
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/auth-guard', () => ({
+  requireSiteAccess: vi.fn(),
+}));
+
+import { prisma } from '@/lib/db';
+import { requireSiteAccess } from '@/lib/auth-guard';
+
+describe('updateAutoScanAfterCrawlAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireSiteAccess).mockResolvedValue({
+      user: { id: 'u1', email: 'a@b.c', name: null },
+      organizationId: 'o1',
+      role: 'ADMIN',
+      siteId: 's1',
+      workspaceId: 'w1',
+    } as never);
+    vi.mocked(prisma.crawlConfig.update).mockResolvedValue({} as never);
+    vi.mocked(prisma.auditLog.create).mockResolvedValue({} as never);
+  });
+
+  it('persists autoScanAfterCrawl false when checkbox off', async () => {
+    const fd = new FormData();
+    fd.set('siteId', 's1');
+    const result = await updateAutoScanAfterCrawlAction(undefined, fd);
+    expect(result).toEqual({ ok: true });
+    expect(prisma.crawlConfig.update).toHaveBeenCalledWith({
+      where: { siteId: 's1' },
+      data: { autoScanAfterCrawl: false },
+    });
+  });
+
+  it('persists autoScanAfterCrawl true when checkbox on', async () => {
+    const fd = new FormData();
+    fd.set('siteId', 's1');
+    fd.set('autoScanAfterCrawl', 'on');
+    const result = await updateAutoScanAfterCrawlAction(undefined, fd);
+    expect(result).toEqual({ ok: true });
+    expect(prisma.crawlConfig.update).toHaveBeenCalledWith({
+      where: { siteId: 's1' },
+      data: { autoScanAfterCrawl: true },
+    });
+  });
+});

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.ts
@@ -1,0 +1,47 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { prisma } from '@/lib/db';
+import { requireSiteAccess } from '@/lib/auth-guard';
+
+export type AutoScanSettingsState = { ok: true } | { ok: false; error: string };
+
+export async function updateAutoScanAfterCrawlAction(
+  _prev: AutoScanSettingsState | undefined,
+  formData: FormData
+): Promise<AutoScanSettingsState> {
+  const siteId = formData.get('siteId') as string;
+  if (!siteId) {
+    return { ok: false, error: 'Missing site.' };
+  }
+
+  try {
+    const ctx = await requireSiteAccess(siteId, 'site:manage');
+    const enabled = formData.get('autoScanAfterCrawl') === 'on';
+
+    await prisma.crawlConfig.update({
+      where: { siteId: ctx.siteId },
+      data: { autoScanAfterCrawl: enabled },
+    });
+
+    await prisma.auditLog
+      .create({
+        data: {
+          organizationId: ctx.organizationId,
+          userId: ctx.user.id,
+          action: 'crawl.auto_scan_after_crawl.updated',
+          entityType: 'CrawlConfig',
+          entityId: ctx.siteId,
+          metadata: { autoScanAfterCrawl: enabled },
+        },
+      })
+      .catch(() => undefined);
+
+    revalidatePath(`/sites/${siteId}`);
+    revalidatePath(`/sites/${siteId}/settings`);
+    return { ok: true };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Could not save settings.';
+    return { ok: false, error: msg };
+  }
+}

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/auto-scan-form.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/auto-scan-form.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useActionState } from 'react';
+import { updateAutoScanAfterCrawlAction } from './actions';
+
+export function AutoScanAfterCrawlForm({
+  siteId,
+  initialEnabled,
+}: {
+  siteId: string;
+  initialEnabled: boolean;
+}) {
+  const [state, formAction, pending] = useActionState(updateAutoScanAfterCrawlAction, undefined);
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <input type="hidden" name="siteId" value={siteId} />
+      <label className="flex items-start gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          name="autoScanAfterCrawl"
+          defaultChecked={initialEnabled}
+          className="mt-1 h-4 w-4 rounded border-slate-300"
+        />
+        <span className="text-sm text-slate-700">
+          <span className="font-medium text-slate-900">Queue verification after crawl</span>
+          <span className="block text-slate-500 mt-1">
+            When enabled, a successful crawl that discovers pages attempts to enqueue a verification scan automatically.
+            The crawl can still finish even if the scan cannot be queued. Redis, workers, and queue health affect whether
+            the follow-on scan actually starts.
+          </span>
+        </span>
+      </label>
+      <div className="flex items-center gap-3">
+        <button type="submit" className="btn-primary" disabled={pending}>
+          {pending ? 'Saving…' : 'Save'}
+        </button>
+        {state?.ok === true ? <span className="text-sm text-green-700">Saved.</span> : null}
+        {state?.ok === false ? (
+          <span className="text-sm text-red-700" role="alert">
+            {state.error}
+          </span>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/page.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { requireSession } from '@/lib/session';
+import { prisma } from '@/lib/db';
+import { hasPermission } from '@aros/config';
+import { AutoScanAfterCrawlForm } from './auto-scan-form';
+
+export async function generateMetadata({ params }: { params: Promise<{ siteId: string }> }) {
+  const { siteId } = await params;
+  const site = await prisma.site.findUnique({ where: { id: siteId }, select: { name: true } });
+  return { title: site ? `${site.name} settings - AROS` : 'Site settings - AROS' };
+}
+
+export default async function SiteSettingsPage({ params }: { params: Promise<{ siteId: string }> }) {
+  const { siteId } = await params;
+  const user = await requireSession();
+
+  const site = await prisma.site.findUnique({
+    where: { id: siteId },
+    include: {
+      crawlConfig: true,
+      workspace: {
+        include: {
+          organization: {
+            include: {
+              memberships: { where: { userId: user.id }, take: 1 },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!site || site.workspace.organization.memberships.length === 0) {
+    notFound();
+  }
+
+  const membership = site.workspace.organization.memberships[0];
+  if (!hasPermission(membership.role, 'site:manage')) {
+    notFound();
+  }
+
+  const autoScanAfterCrawl = site.crawlConfig?.autoScanAfterCrawl !== false;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-8">
+      <div>
+        <div className="flex items-center gap-2 text-sm text-slate-500 mb-1">
+          <Link href="/sites" className="hover:text-brand-600">
+            Sites
+          </Link>
+          <span>/</span>
+          <Link href={`/sites/${siteId}`} className="hover:text-brand-600">
+            {site.name}
+          </Link>
+          <span>/</span>
+          <span>Settings</span>
+        </div>
+        <h1 className="text-2xl font-bold text-slate-900">Crawl &amp; verification</h1>
+        <p className="text-slate-500 mt-1 text-sm">Controls how this site is crawled and what happens next.</p>
+      </div>
+
+      <div className="card space-y-4">
+        <h2 className="text-lg font-semibold text-slate-900">After crawl</h2>
+        <AutoScanAfterCrawlForm siteId={siteId} initialEnabled={autoScanAfterCrawl} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/sites/new/actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/new/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { requireSession } from '@/lib/session';
 import { prisma } from '@/lib/db';
-import { crawlQueue, type CrawlJobData } from '@/lib/queue';
+import { getCrawlQueue, type CrawlJobData } from '@/lib/queue';
 
 interface AddSiteState {
   error: string | null;
@@ -131,7 +131,7 @@ export async function addSiteAction(
         ],
       },
     };
-    await crawlQueue.add('crawl', jobData, {
+    await getCrawlQueue().add('crawl', jobData, {
       attempts: 3,
       backoff: { type: 'exponential', delay: 5000 },
     });

--- a/apps/web/src/lib/queue.test.ts
+++ b/apps/web/src/lib/queue.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const QueueMock = vi.fn().mockImplementation(() => ({
+  add: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: QueueMock,
+}));
+
+vi.mock('@aros/shared', () => ({
+  bullmqConnectionOptions: () => ({ url: 'redis://test:6379', maxRetriesPerRequest: null }),
+  getSharedScanQueue: vi.fn().mockReturnValue({ add: vi.fn(), close: vi.fn() }),
+}));
+
+describe('queue lazy init', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    QueueMock.mockClear();
+  });
+
+  it('does not construct BullMQ Queue on module import', async () => {
+    expect(QueueMock).not.toHaveBeenCalled();
+    await import('./queue');
+    expect(QueueMock).not.toHaveBeenCalled();
+  });
+
+  it('constructs crawl queue only when getCrawlQueue is called', async () => {
+    const { getCrawlQueue } = await import('./queue');
+    getCrawlQueue();
+    expect(QueueMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/queue.ts
+++ b/apps/web/src/lib/queue.ts
@@ -1,13 +1,42 @@
 import { Queue } from 'bullmq';
 import { bullmqConnectionOptions, getSharedScanQueue } from '@aros/shared';
 
-const connection = bullmqConnectionOptions();
+let crawlQueueInstance: Queue | null = null;
+let clusterQueueInstance: Queue | null = null;
+let remediationQueueInstance: Queue | null = null;
 
-export const crawlQueue = new Queue('crawl', { connection });
-/** Shared BullMQ queue instance (same Redis connection pattern as crawl/cluster). */
-export const scanQueue = getSharedScanQueue();
-export const clusterQueue = new Queue('cluster', { connection });
-export const remediationQueue = new Queue('remediation', { connection });
+function connection() {
+  return bullmqConnectionOptions();
+}
+
+/**
+ * Lazy BullMQ queue handles so importing this module during Next.js static analysis
+ * does not open Redis connections (avoids build-time ECONNREFUSED noise).
+ */
+export function getCrawlQueue(): Queue {
+  if (!crawlQueueInstance) {
+    crawlQueueInstance = new Queue('crawl', { connection: connection() });
+  }
+  return crawlQueueInstance;
+}
+
+export function getScanQueue(): Queue {
+  return getSharedScanQueue();
+}
+
+export function getClusterQueue(): Queue {
+  if (!clusterQueueInstance) {
+    clusterQueueInstance = new Queue('cluster', { connection: connection() });
+  }
+  return clusterQueueInstance;
+}
+
+export function getRemediationQueue(): Queue {
+  if (!remediationQueueInstance) {
+    remediationQueueInstance = new Queue('remediation', { connection: connection() });
+  }
+  return remediationQueueInstance;
+}
 
 export interface CrawlJobData {
   crawlRunId: string;

--- a/apps/web/src/lib/sites/verification-status.test.ts
+++ b/apps/web/src/lib/sites/verification-status.test.ts
@@ -1,10 +1,27 @@
 import { describe, expect, it, vi } from 'vitest';
-import { getPostCrawlScanEnqueueFailureHint, getSiteVerificationStatus } from './verification-status';
+import {
+  getPostCrawlScanEnqueueFailureHint,
+  getSiteVerificationStatus,
+  postCrawlKickoffOperatorSummary,
+} from './verification-status';
 import type { PrismaClient } from '@aros/db';
 
 function mockPrisma(scanRun: { findFirst: ReturnType<typeof vi.fn> }) {
   return { scanRun } as unknown as PrismaClient;
 }
+
+describe('postCrawlKickoffOperatorSummary', () => {
+  it('describes skipped by setting', () => {
+    const s = postCrawlKickoffOperatorSummary('SKIPPED_BY_SETTING', null, null);
+    expect(s).toContain('disabled');
+  });
+
+  it('describes queue unavailable with reason', () => {
+    const s = postCrawlKickoffOperatorSummary('QUEUE_UNAVAILABLE', 'QUEUE_UNAVAILABLE', 'ECONNREFUSED');
+    expect(s).toContain('could not be queued');
+    expect(s).toContain('ECONNREFUSED');
+  });
+});
 
 describe('getSiteVerificationStatus', () => {
   it('returns pending when latest active scan is PENDING', async () => {
@@ -21,7 +38,7 @@ describe('getSiteVerificationStatus', () => {
     expect(findFirst).toHaveBeenCalledTimes(1);
   });
 
-  it('returns failed_enqueue when no active scan but queue-failed run exists', async () => {
+  it('returns failed_enqueue when enqueueFailureCode is set', async () => {
     const findFirst = vi
       .fn()
       .mockResolvedValueOnce(null)
@@ -29,6 +46,7 @@ describe('getSiteVerificationStatus', () => {
         id: 'sr-fail',
         createdAt: new Date('2025-01-02T00:00:00Z'),
         errorMessage: 'Queue unavailable: Redis down',
+        enqueueFailureCode: 'QUEUE_UNAVAILABLE',
       });
     const row = await getSiteVerificationStatus(mockPrisma({ findFirst }), {
       siteId: 's1',
@@ -37,7 +55,8 @@ describe('getSiteVerificationStatus', () => {
     expect(row).toMatchObject({
       status: 'failed_enqueue',
       scanRunId: 'sr-fail',
-      errorHint: 'Queue unavailable: Redis down',
+      enqueueFailureCode: 'QUEUE_UNAVAILABLE',
+      errorDetail: 'Redis down',
     });
   });
 
@@ -51,24 +70,28 @@ describe('getSiteVerificationStatus', () => {
       status: 'idle',
       scanRunId: null,
       createdAt: null,
-      errorHint: null,
+      enqueueFailureCode: null,
+      errorDetail: null,
     });
     expect(findFirst).toHaveBeenCalledTimes(2);
   });
 });
 
 describe('getPostCrawlScanEnqueueFailureHint', () => {
-  it('shows hint when latest completed crawl has failed queue scan and no recovery', async () => {
+  it('shows hint when latest crawl has canonical kickoff failure and no recovery', async () => {
     const completedAt = new Date('2025-01-10T12:00:00Z');
     const prisma = {
       crawlRun: {
-        findFirst: vi.fn().mockResolvedValue({ id: 'c1', completedAt }),
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'c1',
+          completedAt,
+          postCrawlScanKickoffStatus: 'QUEUE_UNAVAILABLE',
+          postCrawlScanKickoffReasonCode: 'QUEUE_UNAVAILABLE',
+          postCrawlScanKickoffDetail: 'ECONNREFUSED',
+        }),
       },
       scanRun: {
-        findFirst: vi
-          .fn()
-          .mockResolvedValueOnce({ id: 'sr-bad' })
-          .mockResolvedValueOnce(null),
+        findFirst: vi.fn().mockResolvedValueOnce(null),
       },
     } as unknown as PrismaClient;
 
@@ -77,20 +100,44 @@ describe('getPostCrawlScanEnqueueFailureHint', () => {
       organizationId: 'o1',
     });
     expect(hint.show).toBe(true);
+    expect(hint.kickoffStatus).toBe('QUEUE_UNAVAILABLE');
     expect(hint.message).toContain('could not be queued');
+  });
+
+  it('hides hint when kickoff succeeded', async () => {
+    const prisma = {
+      crawlRun: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'c1',
+          completedAt: new Date(),
+          postCrawlScanKickoffStatus: 'ENQUEUED',
+          postCrawlScanKickoffReasonCode: null,
+          postCrawlScanKickoffDetail: null,
+        }),
+      },
+    } as unknown as PrismaClient;
+
+    const hint = await getPostCrawlScanEnqueueFailureHint(prisma, {
+      siteId: 's1',
+      organizationId: 'o1',
+    });
+    expect(hint.show).toBe(false);
   });
 
   it('hides hint when a newer completed scan exists', async () => {
     const completedAt = new Date('2025-01-10T12:00:00Z');
     const prisma = {
       crawlRun: {
-        findFirst: vi.fn().mockResolvedValue({ id: 'c1', completedAt }),
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'c1',
+          completedAt,
+          postCrawlScanKickoffStatus: 'QUEUE_UNAVAILABLE',
+          postCrawlScanKickoffReasonCode: 'QUEUE_UNAVAILABLE',
+          postCrawlScanKickoffDetail: null,
+        }),
       },
       scanRun: {
-        findFirst: vi
-          .fn()
-          .mockResolvedValueOnce({ id: 'sr-bad' })
-          .mockResolvedValueOnce({ id: 'sr-ok' }),
+        findFirst: vi.fn().mockResolvedValueOnce({ id: 'sr-ok' }),
       },
     } as unknown as PrismaClient;
 

--- a/apps/web/src/lib/sites/verification-status.ts
+++ b/apps/web/src/lib/sites/verification-status.ts
@@ -1,11 +1,72 @@
-import type { PrismaClient } from '@aros/db';
+import type {
+  PostCrawlScanKickoffStatus,
+  PrismaClient,
+  ScanEnqueueFailureCode,
+} from '@aros/db';
 
 export type SiteVerificationRow = {
   status: 'idle' | 'pending' | 'running' | 'failed_enqueue';
   scanRunId: string | null;
   createdAt: Date | null;
-  errorHint: string | null;
+  /** Canonical enqueue failure code when status is failed_enqueue */
+  enqueueFailureCode: ScanEnqueueFailureCode | null;
+  /** Operator-facing detail (underlying error text when available) */
+  errorDetail: string | null;
 };
+
+const KICKOFF_FAILURE_STATUSES: PostCrawlScanKickoffStatus[] = [
+  'QUEUE_UNAVAILABLE',
+  'QUEUE_REJECTED',
+  'DISPATCH_UNAVAILABLE',
+  'KICKOFF_FAILED_UNKNOWN',
+];
+
+function stripQueueUnavailablePrefix(message: string): string {
+  return message.replace(/^Queue unavailable:\s*/i, '').trim();
+}
+
+export function scanEnqueueFailureOperatorHint(code: ScanEnqueueFailureCode | null): string {
+  switch (code) {
+    case 'QUEUE_UNAVAILABLE':
+      return 'The verification queue could not be reached (often Redis or network).';
+    case 'QUEUE_REJECTED':
+      return 'The queue rejected the job (for example policy or resource limits).';
+    case 'DISPATCH_UNAVAILABLE':
+      return 'Dispatch to workers failed; check worker and queue configuration.';
+    case 'KICKOFF_FAILED_UNKNOWN':
+    default:
+      return 'Verification could not be queued for an unexpected reason.';
+  }
+}
+
+export function postCrawlKickoffOperatorSummary(
+  status: PostCrawlScanKickoffStatus,
+  reasonCode: ScanEnqueueFailureCode | null,
+  detail: string | null
+): string | null {
+  switch (status) {
+    case 'NOT_REQUESTED':
+    case 'REQUESTED':
+      return null;
+    case 'ENQUEUED':
+      return 'After this crawl, a verification scan was queued successfully.';
+    case 'SKIPPED_BY_SETTING':
+      return (
+        detail ??
+        'Automatic verification after crawl is disabled in crawl settings; start a scan manually when ready.'
+      );
+    case 'QUEUE_UNAVAILABLE':
+    case 'QUEUE_REJECTED':
+    case 'DISPATCH_UNAVAILABLE':
+    case 'KICKOFF_FAILED_UNKNOWN': {
+      const base = scanEnqueueFailureOperatorHint(reasonCode);
+      const tail = detail?.trim() ? ` (${detail.trim()})` : '';
+      return `Crawl finished, but automatic verification could not be queued. ${base}${tail}`;
+    }
+    default:
+      return null;
+  }
+}
 
 /**
  * Operator-facing scan lifecycle from persisted ScanRun + audit (no BullMQ reads).
@@ -31,7 +92,8 @@ export async function getSiteVerificationStatus(
       status: active.status === 'PENDING' ? 'pending' : 'running',
       scanRunId: active.id,
       createdAt: active.createdAt,
-      errorHint: null,
+      enqueueFailureCode: null,
+      errorDetail: null,
     };
   }
 
@@ -39,32 +101,52 @@ export async function getSiteVerificationStatus(
     where: {
       siteId,
       status: 'FAILED',
-      errorMessage: { startsWith: 'Queue unavailable:' },
       site: { workspace: { organizationId } },
+      OR: [
+        { enqueueFailureCode: { not: null } },
+        { errorMessage: { startsWith: 'Queue unavailable:' } },
+      ],
     },
     orderBy: { createdAt: 'desc' },
-    select: { id: true, createdAt: true, errorMessage: true },
+    select: {
+      id: true,
+      createdAt: true,
+      errorMessage: true,
+      enqueueFailureCode: true,
+    },
   });
 
   if (failedEnqueue) {
+    const code = failedEnqueue.enqueueFailureCode ?? 'QUEUE_UNAVAILABLE';
+    const errorDetail = failedEnqueue.errorMessage
+      ? stripQueueUnavailablePrefix(failedEnqueue.errorMessage)
+      : null;
     return {
       status: 'failed_enqueue',
       scanRunId: failedEnqueue.id,
       createdAt: failedEnqueue.createdAt,
-      errorHint: failedEnqueue.errorMessage,
+      enqueueFailureCode: code,
+      errorDetail,
     };
   }
 
-  return { status: 'idle', scanRunId: null, createdAt: null, errorHint: null };
+  return {
+    status: 'idle',
+    scanRunId: null,
+    createdAt: null,
+    enqueueFailureCode: null,
+    errorDetail: null,
+  };
 }
 
 export type PostCrawlEnqueueFailureHint = {
   show: boolean;
   message: string | null;
+  kickoffStatus: PostCrawlScanKickoffStatus | null;
 };
 
 /**
- * Surface a truthful follow-up when post-crawl auto-scan enqueue failed and nothing has recovered yet.
+ * Surface a truthful follow-up when post-crawl auto-scan kickoff failed and nothing has recovered yet.
  */
 export async function getPostCrawlScanEnqueueFailureHint(
   prisma: PrismaClient,
@@ -80,25 +162,23 @@ export async function getPostCrawlScanEnqueueFailureHint(
       site: { workspace: { organizationId } },
     },
     orderBy: { completedAt: 'desc' },
-    select: { id: true, completedAt: true },
+    select: {
+      id: true,
+      completedAt: true,
+      postCrawlScanKickoffStatus: true,
+      postCrawlScanKickoffReasonCode: true,
+      postCrawlScanKickoffDetail: true,
+    },
   });
 
   if (!latestCrawl?.completedAt) {
-    return { show: false, message: null };
+    return { show: false, message: null, kickoffStatus: null };
   }
 
-  const failedForCrawl = await prisma.scanRun.findFirst({
-    where: {
-      siteId,
-      crawlRunId: latestCrawl.id,
-      status: 'FAILED',
-      errorMessage: { startsWith: 'Queue unavailable:' },
-    },
-    select: { id: true },
-  });
+  const kickoffStatus = latestCrawl.postCrawlScanKickoffStatus;
 
-  if (!failedForCrawl) {
-    return { show: false, message: null };
+  if (!KICKOFF_FAILURE_STATUSES.includes(kickoffStatus)) {
+    return { show: false, message: null, kickoffStatus };
   }
 
   const recovered = await prisma.scanRun.findFirst({
@@ -120,12 +200,20 @@ export async function getPostCrawlScanEnqueueFailureHint(
   });
 
   if (recovered) {
-    return { show: false, message: null };
+    return { show: false, message: null, kickoffStatus };
   }
+
+  const message = postCrawlKickoffOperatorSummary(
+    kickoffStatus,
+    latestCrawl.postCrawlScanKickoffReasonCode,
+    latestCrawl.postCrawlScanKickoffDetail
+  );
 
   return {
     show: true,
     message:
-      'Automatic verification could not be queued after the latest crawl (verification queue unavailable). Start a verification scan once Redis and workers are healthy.',
+      message ??
+      'Crawl finished, but automatic verification could not be queued. Start a verification scan manually once Redis and workers are healthy.',
+    kickoffStatus,
   };
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     exclude: ['**/node_modules/**', '**/e2e/**', '**/dist/**', '**/.next/**'],
   },

--- a/apps/worker/src/jobs/crawl.ts
+++ b/apps/worker/src/jobs/crawl.ts
@@ -1,6 +1,6 @@
 import { Job } from 'bullmq';
-import { prisma } from '@aros/db';
-import { enqueueSiteScan } from '@aros/core-services';
+import { prisma, type PostCrawlScanKickoffStatus, type ScanEnqueueFailureCode } from '@aros/db';
+import { classifyScanEnqueueFailure, enqueueSiteScan } from '@aros/core-services';
 import { chromium, type Browser, type Page } from 'playwright';
 
 interface CrawlJobData {
@@ -226,7 +226,37 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
 
     const autoScanAfterCrawl = site.crawlConfig?.autoScanAfterCrawl !== false;
 
-    if (pagesCrawled > 0 && site.workspace && autoScanAfterCrawl) {
+    async function persistKickoff(data: {
+      postCrawlScanKickoffStatus: PostCrawlScanKickoffStatus;
+      postCrawlScanKickoffReasonCode?: ScanEnqueueFailureCode | null;
+      postCrawlScanKickoffDetail?: string | null;
+      postCrawlScanKickoffScanRunId?: string | null;
+    }) {
+      await prisma.crawlRun.update({
+        where: { id: crawlRunId },
+        data: {
+          postCrawlScanKickoffStatus: data.postCrawlScanKickoffStatus,
+          postCrawlScanKickoffReasonCode: data.postCrawlScanKickoffReasonCode ?? null,
+          postCrawlScanKickoffDetail: data.postCrawlScanKickoffDetail ?? null,
+          postCrawlScanKickoffScanRunId: data.postCrawlScanKickoffScanRunId ?? null,
+        },
+      });
+    }
+
+    if (!site.workspace || pagesCrawled === 0) {
+      await persistKickoff({
+        postCrawlScanKickoffStatus: 'NOT_REQUESTED',
+        postCrawlScanKickoffDetail:
+          pagesCrawled === 0 ? 'No pages crawled; auto-scan not attempted.' : null,
+      });
+    } else if (!autoScanAfterCrawl) {
+      console.log(`[Crawl] Post-crawl scan skipped (autoScanAfterCrawl disabled) crawlRun=${crawlRunId}`);
+      await persistKickoff({
+        postCrawlScanKickoffStatus: 'SKIPPED_BY_SETTING',
+        postCrawlScanKickoffDetail: 'Automatic verification after crawl is off in site crawl settings.',
+      });
+    } else {
+      await persistKickoff({ postCrawlScanKickoffStatus: 'REQUESTED' });
       const scanResult = await enqueueSiteScan(
         { prisma },
         {
@@ -249,10 +279,23 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
             `[Crawl] Post-crawl scan coalesced: ${scanResult.scanRunId} status=${scanResult.status}`
           );
         }
+        await persistKickoff({
+          postCrawlScanKickoffStatus: 'ENQUEUED',
+          postCrawlScanKickoffScanRunId: scanResult.scanRunId,
+          postCrawlScanKickoffReasonCode: null,
+          postCrawlScanKickoffDetail: null,
+        });
       } else if (scanResult.kind === 'queue_unavailable') {
+        const reasonCode = classifyScanEnqueueFailure(scanResult.message);
         console.error(
           `[Crawl] Post-crawl scan enqueue failed (queue): scanRun=${scanResult.scanRunId} ${scanResult.message}`
         );
+        await persistKickoff({
+          postCrawlScanKickoffStatus: 'QUEUE_UNAVAILABLE',
+          postCrawlScanKickoffReasonCode: reasonCode,
+          postCrawlScanKickoffDetail: scanResult.message,
+          postCrawlScanKickoffScanRunId: scanResult.scanRunId,
+        });
         await prisma.auditLog
           .create({
             data: {
@@ -264,18 +307,30 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
                 siteId,
                 scanRunId: scanResult.scanRunId,
                 reason: 'queue_unavailable',
+                enqueueFailureCode: reasonCode,
                 message: scanResult.message,
               },
             },
           })
           .catch(() => undefined);
       } else if (scanResult.kind === 'invalid_target') {
+        const detail =
+          scanResult.reason === 'no_pages'
+            ? 'No pages in database to verify.'
+            : 'Site could not be resolved for scan enqueue.';
         console.warn(`[Crawl] Post-crawl scan skipped: ${scanResult.reason}`);
+        await persistKickoff({
+          postCrawlScanKickoffStatus: 'NOT_REQUESTED',
+          postCrawlScanKickoffDetail: detail,
+        });
       } else {
         console.error(`[Crawl] Post-crawl scan failed: ${scanResult.message}`);
+        await persistKickoff({
+          postCrawlScanKickoffStatus: 'KICKOFF_FAILED_UNKNOWN',
+          postCrawlScanKickoffReasonCode: 'KICKOFF_FAILED_UNKNOWN',
+          postCrawlScanKickoffDetail: scanResult.message,
+        });
       }
-    } else if (pagesCrawled > 0 && site.workspace && !autoScanAfterCrawl) {
-      console.log(`[Crawl] Post-crawl scan skipped (autoScanAfterCrawl disabled) crawlRun=${crawlRunId}`);
     }
   } catch (err) {
     console.error(`[Crawl] Crawl ${crawlRunId} failed:`, err);

--- a/packages/core-services/src/index.ts
+++ b/packages/core-services/src/index.ts
@@ -11,6 +11,7 @@ export {
   type EnqueueSiteScanResult,
   type ScanEnqueueTrigger,
 } from './scan-enqueue';
+export { classifyScanEnqueueFailure } from './scan-enqueue-failure-code';
 export { checkPostgres, checkRedisPing, getQueueDepths } from './checks';
 export {
   isWorkerHeartbeatStale,

--- a/packages/core-services/src/scan-enqueue-failure-code.test.ts
+++ b/packages/core-services/src/scan-enqueue-failure-code.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { classifyScanEnqueueFailure } from './scan-enqueue-failure-code';
+
+describe('classifyScanEnqueueFailure', () => {
+  it('classifies connection refused as queue unavailable', () => {
+    expect(classifyScanEnqueueFailure('connect ECONNREFUSED 127.0.0.1:6379')).toBe('QUEUE_UNAVAILABLE');
+  });
+
+  it('classifies redis-related errors as queue unavailable', () => {
+    expect(classifyScanEnqueueFailure('Redis connection to host:6379 failed')).toBe('QUEUE_UNAVAILABLE');
+    expect(classifyScanEnqueueFailure('Redis down')).toBe('QUEUE_UNAVAILABLE');
+  });
+
+  it('classifies OOM style messages as queue rejected', () => {
+    expect(classifyScanEnqueueFailure('OOM command not allowed')).toBe('QUEUE_REJECTED');
+  });
+
+  it('defaults unknown messages to kickoff failed unknown', () => {
+    expect(classifyScanEnqueueFailure('Something weird')).toBe('KICKOFF_FAILED_UNKNOWN');
+  });
+});

--- a/packages/core-services/src/scan-enqueue-failure-code.ts
+++ b/packages/core-services/src/scan-enqueue-failure-code.ts
@@ -1,0 +1,23 @@
+import type { ScanEnqueueFailureCode } from '@aros/db';
+
+/**
+ * Maps enqueue-time errors to a persisted, operator-facing code (not UI string matching).
+ */
+export function classifyScanEnqueueFailure(message: string): ScanEnqueueFailureCode {
+  const m = message.toLowerCase();
+
+  if (m.includes('oom') || m.includes('maxmemory') || m.includes('command rejected')) {
+    return 'QUEUE_REJECTED';
+  }
+
+  if (
+    m.includes('econnrefused') ||
+    m.includes('enotfound') ||
+    m.includes('etimedout') ||
+    m.includes('redis')
+  ) {
+    return 'QUEUE_UNAVAILABLE';
+  }
+
+  return 'KICKOFF_FAILED_UNKNOWN';
+}

--- a/packages/core-services/src/scan-enqueue.test.ts
+++ b/packages/core-services/src/scan-enqueue.test.ts
@@ -133,7 +133,10 @@ describe('enqueueSiteScan', () => {
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 'sr-fail' },
-        data: expect.objectContaining({ status: 'FAILED' }),
+        data: expect.objectContaining({
+          status: 'FAILED',
+          enqueueFailureCode: 'QUEUE_UNAVAILABLE',
+        }),
       })
     );
   });

--- a/packages/core-services/src/scan-enqueue.ts
+++ b/packages/core-services/src/scan-enqueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from 'bullmq';
 import type { PrismaClient, ScanStatus } from '@aros/db';
 import { getSharedScanQueue, SCAN_QUEUE_NAME } from '@aros/shared';
+import { classifyScanEnqueueFailure } from './scan-enqueue-failure-code';
 
 export { SCAN_QUEUE_NAME };
 
@@ -155,11 +156,13 @@ export async function enqueueSiteScan(
         await queueInstance.close().catch(() => undefined);
       }
       const message = e instanceof Error ? e.message : 'Queue add failed';
+      const enqueueFailureCode = classifyScanEnqueueFailure(message);
       await prisma.scanRun
         .update({
           where: { id: scanRun.id },
           data: {
             status: 'FAILED',
+            enqueueFailureCode,
             errorMessage: `Queue unavailable: ${message}`,
             completedAt: new Date(),
           },

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -165,6 +165,26 @@ enum CrawlStatus {
   CANCELLED
 }
 
+/** Outcome of attempting to start a verification scan after a crawl completes (worker-written). */
+enum PostCrawlScanKickoffStatus {
+  NOT_REQUESTED
+  REQUESTED
+  ENQUEUED
+  SKIPPED_BY_SETTING
+  QUEUE_UNAVAILABLE
+  QUEUE_REJECTED
+  DISPATCH_UNAVAILABLE
+  KICKOFF_FAILED_UNKNOWN
+}
+
+/** Structured reason when a ScanRun never left the queue (enqueue-time failure). */
+enum ScanEnqueueFailureCode {
+  QUEUE_UNAVAILABLE
+  QUEUE_REJECTED
+  DISPATCH_UNAVAILABLE
+  KICKOFF_FAILED_UNKNOWN
+}
+
 model CrawlRun {
   id            String      @id @default(cuid())
   siteId        String
@@ -176,6 +196,11 @@ model CrawlRun {
   completedAt   DateTime?
   errorMessage  String?
   metadata      Json?
+  /** Canonical post-crawl auto-scan attempt outcome (distinct from crawl success/failure). */
+  postCrawlScanKickoffStatus      PostCrawlScanKickoffStatus @default(NOT_REQUESTED)
+  postCrawlScanKickoffReasonCode  ScanEnqueueFailureCode?
+  postCrawlScanKickoffDetail      String?
+  postCrawlScanKickoffScanRunId   String?
   createdAt     DateTime    @default(now())
 
   site      Site       @relation(fields: [siteId], references: [id], onDelete: Cascade)
@@ -247,6 +272,8 @@ model ScanRun {
   startedAt     DateTime?
   completedAt   DateTime?
   errorMessage  String?
+  /** Set when the run failed before a worker claimed it (e.g. BullMQ add failed). */
+  enqueueFailureCode ScanEnqueueFailureCode?
   createdAt     DateTime   @default(now())
 
   site      Site           @relation(fields: [siteId], references: [id], onDelete: Cascade)

--- a/packages/shared/src/scan-queue.ts
+++ b/packages/shared/src/scan-queue.ts
@@ -9,6 +9,7 @@ let sharedScanQueue: Queue | null = null;
 /**
  * Singleton scan queue for producers (Next.js server, core-services).
  * Avoids opening a new Redis connection on every enqueue.
+ * Lazily constructs the Queue so static import chains (e.g. Next build) do not connect to Redis.
  */
 export function getSharedScanQueue(): Queue {
   if (!sharedScanQueue) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Persist canonical **post-crawl scan kickoff** outcome on `CrawlRun` (`PostCrawlScanKickoffStatus` + optional reason/detail/linked scan id).
- Persist **enqueue-time failure** on `ScanRun` via `ScanEnqueueFailureCode` (set when BullMQ `add` fails); keep `errorMessage` for detail.
- Worker updates crawl kickoff fields after completion; `enqueueSiteScan` writes `enqueueFailureCode`.
- Site **Settings** at `/sites/[siteId]/settings` (`site:manage`): toggle `autoScanAfterCrawl` with audit `crawl.auto_scan_after_crawl.updated`.
- UI reads **canonical** fields for post-crawl banner and crawl table “After crawl” column; failed-enqueue banner uses code + detail (not string prefix).
- **Lazy** BullMQ queue construction in `apps/web/src/lib/queue.ts` so importing the module during build does not open Redis.

## Schema

Run `npm run db:push` (or your migration workflow) so new columns/enums exist before deploy.

## Verification

`npm run verify` (lint, typecheck, test, build) passes locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c6be470-9bcb-4714-8e1f-e2a929105254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c6be470-9bcb-4714-8e1f-e2a929105254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

