### PR TITLE
Orchestration truth: build-safe health checks, shared kickoff persist, retry scan kickoff

### DIFF
--- a/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
@@ -6,7 +6,7 @@ import { hasPermission } from '@aros/config';
 import { startCrawlAction } from './actions';
 import { ScanNowButton } from './scan-now-button';
 import { scanSiteInitialState } from './scan-action-state';
-import { startSiteScanAction } from './scan-actions';
+import { retryPostCrawlScanKickoffAction, startSiteScanAction } from './scan-actions';
 import {
   getPostCrawlScanEnqueueFailureHint,
   getSiteVerificationStatus,
@@ -97,7 +97,13 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
         console.error('[site detail] verification status query failed', e);
         return {
           verificationStatus: null,
-          postCrawlEnqueueHint: { show: false, message: null },
+          postCrawlEnqueueHint: {
+            show: false,
+            message: null,
+            kickoffStatus: null,
+            relatedScanRunId: null,
+            crawlRunId: null,
+          },
           verificationLoadError: message,
         };
       }
@@ -105,6 +111,17 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
   ]);
 
   const { verificationStatus, postCrawlEnqueueHint, verificationLoadError } = verificationExtras;
+
+  const postCrawlKickoffFailed =
+    postCrawlEnqueueHint.show &&
+    postCrawlEnqueueHint.kickoffStatus != null &&
+    ['QUEUE_UNAVAILABLE', 'QUEUE_REJECTED', 'DISPATCH_UNAVAILABLE', 'KICKOFF_FAILED_UNKNOWN'].includes(
+      postCrawlEnqueueHint.kickoffStatus
+    );
+  const showSiteFailedEnqueueBanner =
+    verificationStatus?.status === 'failed_enqueue' &&
+    (!postCrawlKickoffFailed ||
+      verificationStatus.scanRunId !== postCrawlEnqueueHint.relatedScanRunId);
 
   const scanBlocked =
     verificationStatus?.status === 'pending' || verificationStatus?.status === 'running';
@@ -137,17 +154,26 @@ export default async function SiteDetailPage({ params }: { params: Promise<{ sit
           {verificationStatus.createdAt?.toLocaleString() ?? 'unknown'}).
         </div>
       ) : null}
-      {verificationStatus?.status === 'failed_enqueue' ? (
+      {showSiteFailedEnqueueBanner ? (
         <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
           <span className="font-medium">Verification could not be queued.</span>{' '}
           {scanEnqueueFailureOperatorHint(verificationStatus.enqueueFailureCode)}
-          {verificationStatus.errorDetail ? ` ${verificationStatus.errorDetail}` : ''} Use Queue verification scan once
-          Redis and workers are healthy.
+          {verificationStatus.errorDetail ? ` ${verificationStatus.errorDetail}` : ''} Use Queue verification scan once Redis
+          and workers are healthy.
         </div>
       ) : null}
       {postCrawlEnqueueHint.show && postCrawlEnqueueHint.message ? (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
-          {postCrawlEnqueueHint.message}
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 space-y-3">
+          <p>{postCrawlEnqueueHint.message}</p>
+          {canStartScan && postCrawlKickoffFailed && postCrawlEnqueueHint.crawlRunId ? (
+            <form action={retryPostCrawlScanKickoffAction}>
+              <input type="hidden" name="siteId" value={siteId} />
+              <input type="hidden" name="crawlRunId" value={postCrawlEnqueueHint.crawlRunId} />
+              <button type="submit" className="btn-secondary text-sm">
+                Retry scan kickoff
+              </button>
+            </form>
+          ) : null}
         </div>
       ) : null}
       <div className="flex items-start justify-between">

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
@@ -1,6 +1,10 @@
 'use server';
 
-import { enqueueSiteScan } from '@aros/core-services/scan-enqueue';
+import { redirect } from 'next/navigation';
+import {
+  enqueueSiteScan,
+  persistPostCrawlScanKickoffAfterEnqueue,
+} from '@aros/core-services';
 import { ApiError } from '@aros/shared';
 import { prisma } from '@/lib/db';
 import { requireSiteAccess } from '@/lib/auth-guard';
@@ -88,5 +92,91 @@ export async function startSiteScanAction(
     const msg = e instanceof Error ? e.message : 'Request failed';
     return { status: 'error', message: msg, variant: 'error' };
   }
+}
+
+/** Re-attempt scan enqueue for a completed crawl; updates the same canonical kickoff fields as the worker. */
+export async function retryPostCrawlScanKickoffAction(formData: FormData) {
+  const siteId = formData.get('siteId') as string;
+  const crawlRunId = formData.get('crawlRunId') as string;
+  if (!siteId || !crawlRunId) {
+    redirect(siteId ? `/sites/${siteId}` : '/sites');
+  }
+
+  try {
+    const ctx = await requireSiteAccess(siteId, 'scan:start');
+    const crawl = await prisma.crawlRun.findFirst({
+      where: {
+        id: crawlRunId,
+        siteId: ctx.siteId,
+        status: 'COMPLETED',
+        pagesCrawled: { gt: 0 },
+        site: { workspace: { organizationId: ctx.organizationId } },
+      },
+      select: { id: true },
+    });
+    if (!crawl) {
+      redirect(`/sites/${siteId}`);
+    }
+
+    await prisma.crawlRun.update({
+      where: { id: crawlRunId },
+      data: { postCrawlScanKickoffStatus: 'REQUESTED' },
+    });
+
+    const result = await enqueueSiteScan(
+      { prisma },
+      {
+        siteId: ctx.siteId,
+        organizationId: ctx.organizationId,
+        crawlRunId,
+        trigger: 'operator',
+        userId: ctx.user.id,
+      }
+    );
+
+    await persistPostCrawlScanKickoffAfterEnqueue(prisma, crawlRunId, result);
+
+    if (result.ok && result.kind === 'queued') {
+      await prisma.auditLog
+        .create({
+          data: {
+            organizationId: ctx.organizationId,
+            userId: ctx.user.id,
+            action: 'scan.queued',
+            entityType: 'CrawlRun',
+            entityId: crawlRunId,
+            metadata: { siteId: ctx.siteId, crawlRunId, trigger: 'operator_retry' },
+          },
+        })
+        .catch(() => undefined);
+    }
+
+    if (!result.ok && result.kind === 'queue_unavailable') {
+      await prisma.auditLog
+        .create({
+          data: {
+            organizationId: ctx.organizationId,
+            userId: ctx.user.id,
+            action: 'scan.enqueue_failed',
+            entityType: 'CrawlRun',
+            entityId: crawlRunId,
+            metadata: {
+              siteId: ctx.siteId,
+              scanRunId: result.scanRunId,
+              reason: 'queue_unavailable',
+              trigger: 'operator_retry',
+            },
+          },
+        })
+        .catch(() => undefined);
+    }
+  } catch (e) {
+    if (e instanceof ApiError && (e.statusCode === 403 || e.statusCode === 404)) {
+      redirect(`/sites/${siteId}`);
+    }
+    throw e;
+  }
+
+  redirect(`/sites/${siteId}`);
 }
 

--- a/apps/web/src/lib/route-data-boundary.test.ts
+++ b/apps/web/src/lib/route-data-boundary.test.ts
@@ -13,6 +13,7 @@ vi.mock('./db', () => ({
 function truth(allow: boolean): RoutePlatformTruth {
   return {
     checkedAt: 'x',
+    liveInfraProbes: 'live',
     shellBlocker: allow ? 'none' : 'critical_dependency_down',
     allowOrgScopedDbReads: allow,
     readiness: allow ? 'ready' : 'blocked',

--- a/apps/web/src/lib/sites/verification-status.test.ts
+++ b/apps/web/src/lib/sites/verification-status.test.ts
@@ -75,6 +75,18 @@ describe('getSiteVerificationStatus', () => {
     });
     expect(findFirst).toHaveBeenCalledTimes(2);
   });
+
+  it('ignores legacy failed scans without enqueueFailureCode', async () => {
+    const findFirst = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    const row = await getSiteVerificationStatus(mockPrisma({ findFirst }), {
+      siteId: 's1',
+      organizationId: 'o1',
+    });
+    expect(row.status).toBe('idle');
+  });
 });
 
 describe('getPostCrawlScanEnqueueFailureHint', () => {
@@ -88,6 +100,7 @@ describe('getPostCrawlScanEnqueueFailureHint', () => {
           postCrawlScanKickoffStatus: 'QUEUE_UNAVAILABLE',
           postCrawlScanKickoffReasonCode: 'QUEUE_UNAVAILABLE',
           postCrawlScanKickoffDetail: 'ECONNREFUSED',
+          postCrawlScanKickoffScanRunId: null,
         }),
       },
       scanRun: {
@@ -102,6 +115,8 @@ describe('getPostCrawlScanEnqueueFailureHint', () => {
     expect(hint.show).toBe(true);
     expect(hint.kickoffStatus).toBe('QUEUE_UNAVAILABLE');
     expect(hint.message).toContain('could not be queued');
+    expect(hint.crawlRunId).toBe('c1');
+    expect(hint.relatedScanRunId).toBeNull();
   });
 
   it('hides hint when kickoff succeeded', async () => {
@@ -113,6 +128,7 @@ describe('getPostCrawlScanEnqueueFailureHint', () => {
           postCrawlScanKickoffStatus: 'ENQUEUED',
           postCrawlScanKickoffReasonCode: null,
           postCrawlScanKickoffDetail: null,
+          postCrawlScanKickoffScanRunId: null,
         }),
       },
     } as unknown as PrismaClient;
@@ -134,6 +150,7 @@ describe('getPostCrawlScanEnqueueFailureHint', () => {
           postCrawlScanKickoffStatus: 'QUEUE_UNAVAILABLE',
           postCrawlScanKickoffReasonCode: 'QUEUE_UNAVAILABLE',
           postCrawlScanKickoffDetail: null,
+          postCrawlScanKickoffScanRunId: null,
         }),
       },
       scanRun: {

--- a/apps/web/src/lib/sites/verification-status.ts
+++ b/apps/web/src/lib/sites/verification-status.ts
@@ -102,10 +102,7 @@ export async function getSiteVerificationStatus(
       siteId,
       status: 'FAILED',
       site: { workspace: { organizationId } },
-      OR: [
-        { enqueueFailureCode: { not: null } },
-        { errorMessage: { startsWith: 'Queue unavailable:' } },
-      ],
+      enqueueFailureCode: { not: null },
     },
     orderBy: { createdAt: 'desc' },
     select: {
@@ -117,10 +114,9 @@ export async function getSiteVerificationStatus(
   });
 
   if (failedEnqueue) {
-    const code = failedEnqueue.enqueueFailureCode ?? 'QUEUE_UNAVAILABLE';
-    const errorDetail = failedEnqueue.errorMessage
-      ? stripQueueUnavailablePrefix(failedEnqueue.errorMessage)
-      : null;
+    const code = failedEnqueue.enqueueFailureCode!;
+    const raw = failedEnqueue.errorMessage?.trim() ?? '';
+    const errorDetail = raw ? stripQueueUnavailablePrefix(raw) || raw : null;
     return {
       status: 'failed_enqueue',
       scanRunId: failedEnqueue.id,
@@ -143,6 +139,9 @@ export type PostCrawlEnqueueFailureHint = {
   show: boolean;
   message: string | null;
   kickoffStatus: PostCrawlScanKickoffStatus | null;
+  /** ScanRun created for a failed enqueue, if any (dedupes with site-level failed_enqueue banner). */
+  relatedScanRunId: string | null;
+  crawlRunId: string | null;
 };
 
 /**
@@ -168,17 +167,18 @@ export async function getPostCrawlScanEnqueueFailureHint(
       postCrawlScanKickoffStatus: true,
       postCrawlScanKickoffReasonCode: true,
       postCrawlScanKickoffDetail: true,
+      postCrawlScanKickoffScanRunId: true,
     },
   });
 
   if (!latestCrawl?.completedAt) {
-    return { show: false, message: null, kickoffStatus: null };
+    return { show: false, message: null, kickoffStatus: null, relatedScanRunId: null, crawlRunId: null };
   }
 
   const kickoffStatus = latestCrawl.postCrawlScanKickoffStatus;
 
   if (!KICKOFF_FAILURE_STATUSES.includes(kickoffStatus)) {
-    return { show: false, message: null, kickoffStatus };
+    return { show: false, message: null, kickoffStatus, relatedScanRunId: null, crawlRunId: null };
   }
 
   const recovered = await prisma.scanRun.findFirst({
@@ -200,7 +200,7 @@ export async function getPostCrawlScanEnqueueFailureHint(
   });
 
   if (recovered) {
-    return { show: false, message: null, kickoffStatus };
+    return { show: false, message: null, kickoffStatus, relatedScanRunId: null, crawlRunId: null };
   }
 
   const message = postCrawlKickoffOperatorSummary(
@@ -215,5 +215,7 @@ export async function getPostCrawlScanEnqueueFailureHint(
       message ??
       'Crawl finished, but automatic verification could not be queued. Start a verification scan manually once Redis and workers are healthy.',
     kickoffStatus,
+    relatedScanRunId: latestCrawl.postCrawlScanKickoffScanRunId ?? null,
+    crawlRunId: latestCrawl.id,
   };
 }

--- a/apps/worker/src/jobs/crawl.ts
+++ b/apps/worker/src/jobs/crawl.ts
@@ -1,6 +1,10 @@
 import { Job } from 'bullmq';
 import { prisma, type PostCrawlScanKickoffStatus, type ScanEnqueueFailureCode } from '@aros/db';
-import { classifyScanEnqueueFailure, enqueueSiteScan } from '@aros/core-services';
+import {
+  classifyScanEnqueueFailure,
+  enqueueSiteScan,
+  persistPostCrawlScanKickoffAfterEnqueue,
+} from '@aros/core-services';
 import { chromium, type Browser, type Page } from 'playwright';
 
 interface CrawlJobData {
@@ -279,23 +283,13 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
             `[Crawl] Post-crawl scan coalesced: ${scanResult.scanRunId} status=${scanResult.status}`
           );
         }
-        await persistKickoff({
-          postCrawlScanKickoffStatus: 'ENQUEUED',
-          postCrawlScanKickoffScanRunId: scanResult.scanRunId,
-          postCrawlScanKickoffReasonCode: null,
-          postCrawlScanKickoffDetail: null,
-        });
+        await persistPostCrawlScanKickoffAfterEnqueue(prisma, crawlRunId, scanResult);
       } else if (scanResult.kind === 'queue_unavailable') {
         const reasonCode = classifyScanEnqueueFailure(scanResult.message);
         console.error(
           `[Crawl] Post-crawl scan enqueue failed (queue): scanRun=${scanResult.scanRunId} ${scanResult.message}`
         );
-        await persistKickoff({
-          postCrawlScanKickoffStatus: 'QUEUE_UNAVAILABLE',
-          postCrawlScanKickoffReasonCode: reasonCode,
-          postCrawlScanKickoffDetail: scanResult.message,
-          postCrawlScanKickoffScanRunId: scanResult.scanRunId,
-        });
+        await persistPostCrawlScanKickoffAfterEnqueue(prisma, crawlRunId, scanResult);
         await prisma.auditLog
           .create({
             data: {
@@ -313,23 +307,13 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
             },
           })
           .catch(() => undefined);
-      } else if (scanResult.kind === 'invalid_target') {
-        const detail =
-          scanResult.reason === 'no_pages'
-            ? 'No pages in database to verify.'
-            : 'Site could not be resolved for scan enqueue.';
-        console.warn(`[Crawl] Post-crawl scan skipped: ${scanResult.reason}`);
-        await persistKickoff({
-          postCrawlScanKickoffStatus: 'NOT_REQUESTED',
-          postCrawlScanKickoffDetail: detail,
-        });
       } else {
-        console.error(`[Crawl] Post-crawl scan failed: ${scanResult.message}`);
-        await persistKickoff({
-          postCrawlScanKickoffStatus: 'KICKOFF_FAILED_UNKNOWN',
-          postCrawlScanKickoffReasonCode: 'KICKOFF_FAILED_UNKNOWN',
-          postCrawlScanKickoffDetail: scanResult.message,
-        });
+        if (scanResult.kind === 'invalid_target') {
+          console.warn(`[Crawl] Post-crawl scan skipped: ${scanResult.reason}`);
+        } else {
+          console.error(`[Crawl] Post-crawl scan failed: ${scanResult.message}`);
+        }
+        await persistPostCrawlScanKickoffAfterEnqueue(prisma, crawlRunId, scanResult);
       }
     }
   } catch (err) {

--- a/packages/core-services/src/index.ts
+++ b/packages/core-services/src/index.ts
@@ -12,6 +12,10 @@ export {
   type ScanEnqueueTrigger,
 } from './scan-enqueue';
 export { classifyScanEnqueueFailure } from './scan-enqueue-failure-code';
+export {
+  persistPostCrawlScanKickoffAfterEnqueue,
+  POST_CRAWL_KICKOFF_FAILURE_STATUSES,
+} from './scan-kickoff-persist';
 export { checkPostgres, checkRedisPing, getQueueDepths } from './checks';
 export {
   isWorkerHeartbeatStale,
@@ -21,6 +25,7 @@ export {
 export type {
   CoreServiceDefinition,
   CoreServiceRuntimeView,
+  LiveInfraProbesMode,
   PlatformHealthReport,
   PlatformBootstrapStatus,
   ServiceHealthState,

--- a/packages/core-services/src/operator-diagnostics.test.ts
+++ b/packages/core-services/src/operator-diagnostics.test.ts
@@ -50,6 +50,7 @@ function baseReport(overrides: Partial<PlatformHealthReport> = {}): PlatformHeal
 
   return {
     checkedAt: overrides.checkedAt ?? '2025-01-01T00:00:00.000Z',
+    liveInfraProbes: 'live' as const,
     bootstrap: {
       installed: true,
       installedAt: '2025-01-01T00:00:00.000Z',

--- a/packages/core-services/src/orchestrator.test.ts
+++ b/packages/core-services/src/orchestrator.test.ts
@@ -28,6 +28,7 @@ describe('collectPlatformHealth', () => {
   });
   afterEach(() => {
     vi.useRealTimers();
+    delete process.env.NEXT_PHASE;
   });
 
   it('reports not_installed when platform row missing', async () => {
@@ -39,6 +40,7 @@ describe('collectPlatformHealth', () => {
     } as unknown as PrismaClient;
 
     const report = await collectPlatformHealth(prisma);
+    expect(report.liveInfraProbes).toBe('live');
     expect(report.bootstrap.installed).toBe(false);
     expect(report.bootstrap.readiness).toBe('not_installed');
     expect(report.operatorPlatformFlags).toBeNull();
@@ -58,8 +60,23 @@ describe('collectPlatformHealth', () => {
     } as unknown as PrismaClient;
 
     const report = await collectPlatformHealth(prisma);
+    expect(report.liveInfraProbes).toBe('live');
     const worker = report.services.find((s) => s.id === 'worker-runtime');
     expect(worker?.healthState).toBe('running');
     expect(report.operatorPlatformFlags).toEqual({});
+  });
+
+  it('skips live infra probes during Next.js production build phase', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PHASE', 'phase-production-build');
+    const prisma = {
+      $queryRaw: vi.fn(),
+      platformState: { findUnique: vi.fn() },
+    } as unknown as PrismaClient;
+
+    const report = await collectPlatformHealth(prisma);
+    expect(report.liveInfraProbes).toBe('skipped_build');
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    expect(report.services).toEqual([]);
   });
 });

--- a/packages/core-services/src/orchestrator.ts
+++ b/packages/core-services/src/orchestrator.ts
@@ -80,6 +80,38 @@ export async function collectPlatformHealth(prisma: PrismaClient): Promise<Platf
   const checkedAt = new Date().toISOString();
   const envDiag = parseEnvDiagnostics(process.env);
 
+  /** Next.js sets this during `next build` static analysis; avoid live DB/Redis probes and log noise. */
+  const skipLiveInfraProbes =
+    process.env.NODE_ENV === 'production' && process.env.NEXT_PHASE === 'phase-production-build';
+
+  if (skipLiveInfraProbes) {
+    const sessionOk = envDiag.valid;
+    const noopInfra = { ok: true as const, checkedAt, skipped: true as const };
+    return {
+      checkedAt,
+      liveInfraProbes: 'skipped_build',
+      bootstrap: {
+        installed: false,
+        installedAt: null,
+        bootstrapVersion: 0,
+        readiness: 'ready',
+        blockers: [] as string[],
+        warnings: [] as string[],
+      },
+      dependencies: {
+        database: noopInfra,
+        redis: noopInfra,
+        sessionStore: {
+          ok: sessionOk,
+          checkedAt,
+          message: sessionOk ? undefined : 'Sessions require valid DB + NEXTAUTH_*',
+        },
+      },
+      services: [],
+      operatorPlatformFlags: null,
+    };
+  }
+
   const dbCheck = await checkPostgres(() => prisma.$queryRaw`SELECT 1`);
   const redisUrl = process.env.REDIS_URL?.trim() || 'redis://localhost:6379';
   const redisCheck = await checkRedisPing(redisUrl);
@@ -456,6 +488,7 @@ export async function collectPlatformHealth(prisma: PrismaClient): Promise<Platf
 
   return {
     checkedAt,
+    liveInfraProbes: 'live',
     bootstrap,
     dependencies: {
       database: dbCheck,

--- a/packages/core-services/src/public-summary.test.ts
+++ b/packages/core-services/src/public-summary.test.ts
@@ -46,6 +46,7 @@ function baseReport(overrides: Partial<PlatformHealthReport> = {}): PlatformHeal
 
   return {
     checkedAt: '2025-01-01T00:00:00.000Z',
+    liveInfraProbes: 'live' as const,
     bootstrap: {
       installed: true,
       installedAt: '2025-01-01T00:00:00.000Z',

--- a/packages/core-services/src/route-platform-truth.test.ts
+++ b/packages/core-services/src/route-platform-truth.test.ts
@@ -6,6 +6,7 @@ function baseReport(overrides: Partial<PlatformHealthReport> = {}): PlatformHeal
   const services = overrides.services;
   return {
     checkedAt: '2025-01-01T00:00:00.000Z',
+    liveInfraProbes: 'live' as const,
     bootstrap: {
       installed: true,
       installedAt: '2025-01-01T00:00:00.000Z',
@@ -145,6 +146,31 @@ function baseReport(overrides: Partial<PlatformHealthReport> = {}): PlatformHeal
 }
 
 describe('buildRoutePlatformTruth', () => {
+  it('returns neutral shell when live probes skipped (build)', () => {
+    const truth = buildRoutePlatformTruth({
+      checkedAt: 't',
+      liveInfraProbes: 'skipped_build',
+      bootstrap: {
+        installed: false,
+        installedAt: null,
+        bootstrapVersion: 0,
+        readiness: 'ready',
+        blockers: [],
+        warnings: [],
+      },
+      dependencies: {
+        database: { ok: true, checkedAt: 't', skipped: true },
+        redis: { ok: true, checkedAt: 't', skipped: true },
+        sessionStore: { ok: true, checkedAt: 't' },
+      },
+      services: [],
+      operatorPlatformFlags: null,
+    });
+    expect(truth.liveInfraProbes).toBe('skipped_build');
+    expect(truth.shellBlocker).toBe('none');
+    expect(truth.flags.redisOk).toBe(true);
+  });
+
   it('marks critical_dependency_down when database is down', () => {
     const t = buildRoutePlatformTruth(
       baseReport({

--- a/packages/core-services/src/route-platform-truth.ts
+++ b/packages/core-services/src/route-platform-truth.ts
@@ -1,4 +1,4 @@
-import type { PlatformHealthReport, PlatformReadiness } from './types';
+import type { LiveInfraProbesMode, PlatformHealthReport, PlatformReadiness } from './types';
 
 /** Safe, route-consumable projection of platform health (no secrets; no raw env values). */
 export type RoutePlatformShellBlocker =
@@ -9,6 +9,8 @@ export type RoutePlatformShellBlocker =
 
 export interface RoutePlatformTruth {
   checkedAt: string;
+  /** When `skipped_build`, health flags are neutral placeholders for compile-time evaluation only. */
+  liveInfraProbes: LiveInfraProbesMode;
   shellBlocker: RoutePlatformShellBlocker;
   /**
    * When true, org-scoped Prisma reads are expected to work; routes should use degraded/partial envelopes
@@ -42,6 +44,28 @@ function serviceById(report: PlatformHealthReport, id: string) {
  * Callers must pass the real report from collectPlatformHealth — do not fabricate readiness.
  */
 export function buildRoutePlatformTruth(report: PlatformHealthReport): RoutePlatformTruth {
+  if (report.liveInfraProbes === 'skipped_build') {
+    return {
+      checkedAt: report.checkedAt,
+      liveInfraProbes: 'skipped_build',
+      shellBlocker: 'none',
+      allowOrgScopedDbReads: true,
+      readiness: 'ready',
+      installed: false,
+      userImpactSummary: [],
+      operatorRemediationHints: [],
+      flags: {
+        databaseOk: true,
+        redisOk: true,
+        sessionOk: true,
+        envConfigOk: true,
+        workerRunning: true,
+        jobPipelinesHealthy: true,
+      },
+      optionalSubsystemIssues: [],
+    };
+  }
+
   const appApi = serviceById(report, 'app-api');
   const database = serviceById(report, 'database');
   const redis = serviceById(report, 'redis-queue');
@@ -117,6 +141,7 @@ export function buildRoutePlatformTruth(report: PlatformHealthReport): RoutePlat
 
   return {
     checkedAt: report.checkedAt,
+    liveInfraProbes: 'live',
     shellBlocker,
     allowOrgScopedDbReads,
     readiness: report.bootstrap.readiness,

--- a/packages/core-services/src/scan-kickoff-persist.test.ts
+++ b/packages/core-services/src/scan-kickoff-persist.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { persistPostCrawlScanKickoffAfterEnqueue } from './scan-kickoff-persist';
+import type { PrismaClient } from '@aros/db';
+
+describe('persistPostCrawlScanKickoffAfterEnqueue', () => {
+  it('sets ENQUEUED and scan run id on queued success', async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const prisma = { crawlRun: { update } } as unknown as PrismaClient;
+    await persistPostCrawlScanKickoffAfterEnqueue(prisma, 'c1', {
+      ok: true,
+      kind: 'queued',
+      scanRunId: 'sr1',
+      bullmqJobId: 'x',
+    });
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'c1' },
+      data: {
+        postCrawlScanKickoffStatus: 'ENQUEUED',
+        postCrawlScanKickoffScanRunId: 'sr1',
+        postCrawlScanKickoffReasonCode: null,
+        postCrawlScanKickoffDetail: null,
+      },
+    });
+  });
+
+  it('sets QUEUE_UNAVAILABLE with reason on queue_unavailable', async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const prisma = { crawlRun: { update } } as unknown as PrismaClient;
+    await persistPostCrawlScanKickoffAfterEnqueue(prisma, 'c1', {
+      ok: false,
+      kind: 'queue_unavailable',
+      message: 'connect ECONNREFUSED',
+      scanRunId: 'sr-fail',
+    });
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'c1' },
+      data: expect.objectContaining({
+        postCrawlScanKickoffStatus: 'QUEUE_UNAVAILABLE',
+        postCrawlScanKickoffScanRunId: 'sr-fail',
+        postCrawlScanKickoffDetail: 'connect ECONNREFUSED',
+      }),
+    });
+  });
+});

--- a/packages/core-services/src/scan-kickoff-persist.ts
+++ b/packages/core-services/src/scan-kickoff-persist.ts
@@ -1,0 +1,73 @@
+import type { PostCrawlScanKickoffStatus, PrismaClient, ScanEnqueueFailureCode } from '@aros/db';
+import { classifyScanEnqueueFailure } from './scan-enqueue-failure-code';
+import type { EnqueueSiteScanResult } from './scan-enqueue';
+
+export const POST_CRAWL_KICKOFF_FAILURE_STATUSES: PostCrawlScanKickoffStatus[] = [
+  'QUEUE_UNAVAILABLE',
+  'QUEUE_REJECTED',
+  'DISPATCH_UNAVAILABLE',
+  'KICKOFF_FAILED_UNKNOWN',
+];
+
+/**
+ * Persists canonical post-crawl scan kickoff outcome on the crawl run (worker + operator retry share this).
+ */
+export async function persistPostCrawlScanKickoffAfterEnqueue(
+  prisma: PrismaClient,
+  crawlRunId: string,
+  result: EnqueueSiteScanResult
+): Promise<void> {
+  if (result.ok) {
+    await prisma.crawlRun.update({
+      where: { id: crawlRunId },
+      data: {
+        postCrawlScanKickoffStatus: 'ENQUEUED',
+        postCrawlScanKickoffScanRunId: result.scanRunId,
+        postCrawlScanKickoffReasonCode: null,
+        postCrawlScanKickoffDetail: null,
+      },
+    });
+    return;
+  }
+
+  if (result.kind === 'invalid_target') {
+    const detail =
+      result.reason === 'no_pages'
+        ? 'No pages in database to verify.'
+        : 'Site could not be resolved for scan enqueue.';
+    await prisma.crawlRun.update({
+      where: { id: crawlRunId },
+      data: {
+        postCrawlScanKickoffStatus: 'NOT_REQUESTED',
+        postCrawlScanKickoffDetail: detail,
+        postCrawlScanKickoffReasonCode: null,
+        postCrawlScanKickoffScanRunId: null,
+      },
+    });
+    return;
+  }
+
+  if (result.kind === 'queue_unavailable') {
+    const reasonCode: ScanEnqueueFailureCode = classifyScanEnqueueFailure(result.message);
+    await prisma.crawlRun.update({
+      where: { id: crawlRunId },
+      data: {
+        postCrawlScanKickoffStatus: 'QUEUE_UNAVAILABLE',
+        postCrawlScanKickoffReasonCode: reasonCode,
+        postCrawlScanKickoffDetail: result.message,
+        postCrawlScanKickoffScanRunId: result.scanRunId,
+      },
+    });
+    return;
+  }
+
+  await prisma.crawlRun.update({
+    where: { id: crawlRunId },
+    data: {
+      postCrawlScanKickoffStatus: 'KICKOFF_FAILED_UNKNOWN',
+      postCrawlScanKickoffReasonCode: 'KICKOFF_FAILED_UNKNOWN',
+      postCrawlScanKickoffDetail: result.message,
+      postCrawlScanKickoffScanRunId: null,
+    },
+  });
+}

--- a/packages/core-services/src/types.ts
+++ b/packages/core-services/src/types.ts
@@ -36,6 +36,11 @@ export interface DependencyCheckResult {
   ok: boolean;
   message?: string;
   checkedAt: string;
+  /**
+   * When true, no live connection was attempted (e.g. Next.js production build).
+   * Callers should not treat `ok: false` as a production outage in this case.
+   */
+  skipped?: boolean;
 }
 
 export interface CoreServiceRuntimeView extends CoreServiceDefinition {
@@ -63,8 +68,12 @@ export interface PlatformBootstrapStatus {
   warnings: string[];
 }
 
+export type LiveInfraProbesMode = 'live' | 'skipped_build';
+
 export interface PlatformHealthReport {
   checkedAt: string;
+  /** When `skipped_build`, Postgres/Redis/queue were not probed (Next.js production build). */
+  liveInfraProbes: LiveInfraProbesMode;
   bootstrap: PlatformBootstrapStatus;
   dependencies: {
     database: DependencyCheckResult;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Build-time noise**: `collectPlatformHealth` skips live Postgres/Redis/queue probes when `NODE_ENV=production` and `NEXT_PHASE=phase-production-build` (Next.js static generation). `buildRoutePlatformTruth` returns a neutral shell projection for that snapshot so dashboards do not show false “Redis down” during compile.
- **Canonical kickoff persistence**: Added `persistPostCrawlScanKickoffAfterEnqueue` in `@aros/core-services`; the crawl worker uses it after `enqueueSiteScan` so success/failure paths stay aligned.
- **Operator UX**: Site detail dedupes the generic `failed_enqueue` banner when it matches the post-crawl hint’s failed ScanRun; added **Retry scan kickoff** (same enqueue path + persistence, `scan:start`).

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`

## Notes

- `autoScanAfterCrawl` settings UI was already present (`sites/[siteId]/settings` + server actions + tests).
- Manual **Queue verification scan** remains `startSiteScanAction`; retry is crawl-scoped and updates the same `CrawlRun` kickoff fields.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e59f3d9-2cb0-4abf-a512-1e0ddb3e1c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e59f3d9-2cb0-4abf-a512-1e0ddb3e1c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

