### PR TITLE
Scope operator platform flags to organization context

### DIFF
--- a/apps/web/src/app/(dashboard)/system/page.tsx
+++ b/apps/web/src/app/(dashboard)/system/page.tsx
@@ -11,7 +11,7 @@ import {
   IssueAcknowledgeButton,
   OperatorControlPlaneClient,
 } from '@/components/system/operator-control-plane-client';
-import { parseOperatorPlatformFlags, type PlatformDiagnosticIssue } from '@aros/core-services';
+import { type PlatformDiagnosticIssue } from '@aros/core-services';
 
 export const metadata = { title: 'System & services - AROS' };
 
@@ -171,7 +171,7 @@ export default async function SystemPage() {
                 organizationId={orgId}
                 optionalIssueIds={optionalDiagnosticIds(payload)}
                 initialSuppressedIds={
-                  parseOperatorPlatformFlags(payload.report.operatorPlatformFlags).prefs.suppressedOptionalDiagnosticIds
+                  payload.operatorFlags.prefs.suppressedOptionalDiagnosticIds
                 }
               />
             ) : (

--- a/apps/web/src/app/api/org/[organizationId]/platform/acknowledge/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/acknowledge/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { collectPlatformHealth, derivePlatformDiagnostics, parseOperatorPlatformFlags } from '@aros/core-services';
+import { collectPlatformHealth, derivePlatformDiagnostics } from '@aros/core-services';
 import { requireOrgAccess } from '@/lib/auth-guard';
 import { prisma } from '@/lib/db';
 import { apiError } from '@/lib/api-utils';
 import { logOperatorPlatformAction } from '@/lib/operator-platform-audit';
-import { updateOperatorFlags } from '@/lib/operator-product-flags';
+import { parseOperatorFlagsForOrganization } from '@/lib/operator-org-flags';
+import { updateOperatorFlagsForOrganization } from '@/lib/operator-product-flags';
 import { getPlatformHealthPayload } from '@/lib/platform-health';
 
 export const dynamic = 'force-dynamic';
@@ -42,7 +43,7 @@ export async function POST(
     const { issueId } = parsedBody.data;
 
     const report = await collectPlatformHealth(prisma);
-    const flags = parseOperatorPlatformFlags(report.operatorPlatformFlags);
+    const flags = parseOperatorFlagsForOrganization(report.operatorPlatformFlags, organizationId);
     const { issues } = derivePlatformDiagnostics(report, flags);
     const known = issues.some((i) => i.id === issueId);
     if (!known) {
@@ -65,7 +66,7 @@ export async function POST(
       );
     }
 
-    await updateOperatorFlags((current) => {
+    await updateOperatorFlagsForOrganization(organizationId, (current) => {
       const next = new Set(current.acknowledgements.acknowledgedIssueIds);
       next.add(issueId);
       return {

--- a/apps/web/src/app/api/org/[organizationId]/platform/operator-preferences/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/operator-preferences/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { requireOrgAccess } from '@/lib/auth-guard';
 import { apiError } from '@/lib/api-utils';
 import { logOperatorPlatformAction } from '@/lib/operator-platform-audit';
-import { updateOperatorFlags } from '@/lib/operator-product-flags';
+import { updateOperatorFlagsForOrganization } from '@/lib/operator-product-flags';
 import { getPlatformHealthPayload } from '@/lib/platform-health';
 import { validateSuppressedOptionalDiagnosticIds } from '@/lib/operator-preferences-validation';
 
@@ -63,7 +63,7 @@ export async function PATCH(
       );
     }
 
-    await updateOperatorFlags((current) => ({
+    await updateOperatorFlagsForOrganization(organizationId, (current) => ({
       ...current,
       prefs: {
         ...current.prefs,

--- a/apps/web/src/lib/operator-org-flags.ts
+++ b/apps/web/src/lib/operator-org-flags.ts
@@ -1,0 +1,83 @@
+import {
+  parseOperatorPlatformFlags,
+  serializeOperatorPlatformFlags,
+  type ParsedOperatorPlatformFlags,
+} from '@aros/core-services';
+
+const OPERATOR_PREFS_BY_ORG_KEY = 'operatorPrefsByOrg';
+const OPERATOR_ACKS_BY_ORG_KEY = 'operatorAcknowledgementsByOrg';
+
+function readScopedFlags(raw: Record<string, unknown>, organizationId: string): ParsedOperatorPlatformFlags | null {
+  const prefsByOrg = raw[OPERATOR_PREFS_BY_ORG_KEY];
+  const acksByOrg = raw[OPERATOR_ACKS_BY_ORG_KEY];
+  const scoped = {
+    operatorPrefs:
+      prefsByOrg && typeof prefsByOrg === 'object' && !Array.isArray(prefsByOrg)
+        ? (prefsByOrg as Record<string, unknown>)[organizationId]
+        : undefined,
+    operatorAcknowledgements:
+      acksByOrg && typeof acksByOrg === 'object' && !Array.isArray(acksByOrg)
+        ? (acksByOrg as Record<string, unknown>)[organizationId]
+        : undefined,
+  };
+
+  const parsed = parseOperatorPlatformFlags(scoped);
+  if (
+    parsed.prefs.suppressedOptionalDiagnosticIds.length === 0 &&
+    parsed.acknowledgements.acknowledgedIssueIds.length === 0 &&
+    parsed.acknowledgements.updatedAt == null
+  ) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function parseOperatorFlagsForOrganization(
+  raw: unknown,
+  organizationId?: string
+): ParsedOperatorPlatformFlags {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return parseOperatorPlatformFlags(raw);
+  }
+
+  const record = raw as Record<string, unknown>;
+
+  if (organizationId) {
+    const scoped = readScopedFlags(record, organizationId);
+    if (scoped) {
+      return scoped;
+    }
+  }
+
+  // Backward compatibility for historical deployment-wide keys.
+  return parseOperatorPlatformFlags(record);
+}
+
+export function applyScopedOperatorFlagsUpdate(
+  raw: Record<string, unknown>,
+  organizationId: string,
+  next: ParsedOperatorPlatformFlags
+): Record<string, unknown> {
+  const serialized = serializeOperatorPlatformFlags(next);
+
+  const existingPrefsByOrg = raw[OPERATOR_PREFS_BY_ORG_KEY];
+  const existingAcksByOrg = raw[OPERATOR_ACKS_BY_ORG_KEY];
+  const prefsByOrg: Record<string, unknown> =
+    existingPrefsByOrg && typeof existingPrefsByOrg === 'object' && !Array.isArray(existingPrefsByOrg)
+      ? { ...(existingPrefsByOrg as Record<string, unknown>) }
+      : {};
+  const acksByOrg: Record<string, unknown> =
+    existingAcksByOrg && typeof existingAcksByOrg === 'object' && !Array.isArray(existingAcksByOrg)
+      ? { ...(existingAcksByOrg as Record<string, unknown>) }
+      : {};
+
+  prefsByOrg[organizationId] = serialized.operatorPrefs ?? { suppressedOptionalDiagnosticIds: [] };
+  acksByOrg[organizationId] = serialized.operatorAcknowledgements ?? { acknowledgedIssueIds: [], updatedAt: null };
+
+  return {
+    ...raw,
+    [OPERATOR_PREFS_BY_ORG_KEY]: prefsByOrg,
+    [OPERATOR_ACKS_BY_ORG_KEY]: acksByOrg,
+  };
+}

--- a/apps/web/src/lib/operator-product-flags.test.ts
+++ b/apps/web/src/lib/operator-product-flags.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyScopedOperatorFlagsUpdate,
+  parseOperatorFlagsForOrganization,
+} from './operator-org-flags';
+import type { ParsedOperatorPlatformFlags } from '@aros/core-services';
+
+describe('parseOperatorFlagsForOrganization', () => {
+  it('reads organization-scoped operator flags when available', () => {
+    const parsed = parseOperatorFlagsForOrganization(
+      {
+        operatorPrefsByOrg: {
+          orgA: { suppressedOptionalDiagnosticIds: ['svc:stripe-billing'] },
+        },
+        operatorAcknowledgementsByOrg: {
+          orgA: { acknowledgedIssueIds: ['svc:slack-webhooks'], updatedAt: '2026-03-20T00:00:00.000Z' },
+        },
+      },
+      'orgA'
+    );
+
+    expect(parsed.prefs.suppressedOptionalDiagnosticIds).toEqual(['svc:stripe-billing']);
+    expect(parsed.acknowledgements.acknowledgedIssueIds).toEqual(['svc:slack-webhooks']);
+  });
+
+  it('falls back to legacy deployment-wide keys when scoped keys are missing', () => {
+    const parsed = parseOperatorFlagsForOrganization(
+      {
+        operatorPrefs: { suppressedOptionalDiagnosticIds: ['svc:slack-webhooks'] },
+      },
+      'orgA'
+    );
+
+    expect(parsed.prefs.suppressedOptionalDiagnosticIds).toEqual(['svc:slack-webhooks']);
+  });
+});
+
+describe('applyScopedOperatorFlagsUpdate', () => {
+  it('persists updated flags under organization namespaced keys without dropping unrelated flags', () => {
+    const next: ParsedOperatorPlatformFlags = {
+      prefs: { suppressedOptionalDiagnosticIds: ['svc:jira'] },
+      acknowledgements: { acknowledgedIssueIds: ['svc:s3-evidence'], updatedAt: '2026-03-21T00:00:00.000Z' },
+    };
+
+    const updated = applyScopedOperatorFlagsUpdate(
+      {
+        releaseChannel: 'stable',
+        operatorPrefsByOrg: { orgB: { suppressedOptionalDiagnosticIds: ['svc:stripe-billing'] } },
+      },
+      'orgA',
+      next
+    );
+
+    expect(updated.releaseChannel).toBe('stable');
+    expect((updated.operatorPrefsByOrg as Record<string, unknown>).orgA).toEqual({
+      suppressedOptionalDiagnosticIds: ['svc:jira'],
+    });
+    expect((updated.operatorPrefsByOrg as Record<string, unknown>).orgB).toEqual({
+      suppressedOptionalDiagnosticIds: ['svc:stripe-billing'],
+    });
+    expect((updated.operatorAcknowledgementsByOrg as Record<string, unknown>).orgA).toEqual({
+      acknowledgedIssueIds: ['svc:s3-evidence'],
+      updatedAt: '2026-03-21T00:00:00.000Z',
+    });
+  });
+});

--- a/apps/web/src/lib/operator-product-flags.ts
+++ b/apps/web/src/lib/operator-product-flags.ts
@@ -1,11 +1,9 @@
-import type { Prisma } from '@aros/db';
 import { ApiError } from '@aros/shared';
 import { prisma } from '@/lib/db';
-import {
-  parseOperatorPlatformFlags,
-  serializeOperatorPlatformFlags,
-  type ParsedOperatorPlatformFlags,
-} from '@aros/core-services';
+import type { ParsedOperatorPlatformFlags } from '@aros/core-services';
+import { applyScopedOperatorFlagsUpdate, parseOperatorFlagsForOrganization } from './operator-org-flags';
+
+export { applyScopedOperatorFlagsUpdate, parseOperatorFlagsForOrganization } from './operator-org-flags';
 
 export async function loadProductFlagsRecord(): Promise<Record<string, unknown>> {
   const row = await prisma.platformState.findUnique({
@@ -22,19 +20,22 @@ export async function loadProductFlagsRecord(): Promise<Record<string, unknown>>
 export async function saveProductFlagsRecord(next: Record<string, unknown>) {
   await prisma.platformState.update({
     where: { id: 'platform' },
-    data: { productFlags: next as Prisma.InputJsonValue },
+    data: { productFlags: next as any },
   });
 }
 
-export async function updateOperatorFlags(mutator: (current: ParsedOperatorPlatformFlags) => ParsedOperatorPlatformFlags) {
+export async function updateOperatorFlagsForOrganization(
+  organizationId: string,
+  mutator: (current: ParsedOperatorPlatformFlags) => ParsedOperatorPlatformFlags
+) {
   const exists = await prisma.platformState.findUnique({ where: { id: 'platform' }, select: { id: true } });
   if (!exists) {
     throw ApiError.badRequest('Platform is not installed in the database; run migrations and bootstrap before using operator actions.');
   }
   const merged = await loadProductFlagsRecord();
-  const parsed = parseOperatorPlatformFlags(merged);
+  const parsed = parseOperatorFlagsForOrganization(merged, organizationId);
   const updated = mutator(parsed);
-  const serialized = serializeOperatorPlatformFlags(updated);
-  await saveProductFlagsRecord({ ...merged, ...serialized });
+  const next = applyScopedOperatorFlagsUpdate(merged, organizationId, updated);
+  await saveProductFlagsRecord(next);
   return updated;
 }

--- a/apps/web/src/lib/platform-health.ts
+++ b/apps/web/src/lib/platform-health.ts
@@ -3,7 +3,6 @@ import {
   buildRoutePlatformTruth,
   derivePlatformDiagnostics,
   listOperatorActions,
-  parseOperatorPlatformFlags,
   type ControlPlaneSummary,
   type OperatorActionDescriptor,
   type PlatformDiagnosticIssue,
@@ -11,6 +10,7 @@ import {
 } from '@aros/core-services';
 import { parseEnvDiagnostics } from '@aros/config';
 import { prisma } from './db';
+import { parseOperatorFlagsForOrganization } from './operator-org-flags';
 import type { PlatformHealthReport, RoutePlatformTruth } from '@aros/core-services';
 import { getRecentPlatformAuditEntries, type RecentPlatformAuditEntry } from './operator-platform-audit';
 
@@ -29,6 +29,7 @@ export interface PlatformHealthApiPayload {
   };
   operatorActions: OperatorActionDescriptor[];
   recentPlatformActions: RecentPlatformAuditEntry[];
+  operatorFlags: ReturnType<typeof parseOperatorFlagsForOrganization>;
 }
 
 export async function getPlatformHealthPayload(organizationId?: string): Promise<PlatformHealthApiPayload> {
@@ -37,7 +38,7 @@ export async function getPlatformHealthPayload(organizationId?: string): Promise
     (k) => (diag.fieldErrors[k]?.length ?? 0) > 0
   );
   const report = await collectPlatformHealth(prisma);
-  const parsedFlags = parseOperatorPlatformFlags(report.operatorPlatformFlags);
+  const parsedFlags = parseOperatorFlagsForOrganization(report.operatorPlatformFlags, organizationId);
   const { issues, setupChecklist, summary } = derivePlatformDiagnostics(report, parsedFlags);
   const recentPlatformActions =
     organizationId != null
@@ -50,5 +51,6 @@ export async function getPlatformHealthPayload(organizationId?: string): Promise
     diagnostics: { issues, setupChecklist, summary },
     operatorActions: listOperatorActions(),
     recentPlatformActions,
+    operatorFlags: parsedFlags,
   };
 }


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant control bleed where org-scoped operator endpoints wrote deployment-wide operator preferences/acknowledgements in `PlatformState.productFlags`.  
- Preserve backward compatibility while making operator state materially isolated per organization.  
- Surface the scoped operator flags consistently to diagnostics/UI so operator actions reflect org-local state.

### Description
- Added org-scoped flag helpers in `apps/web/src/lib/operator-org-flags.ts` to read scoped keys (`operatorPrefsByOrg`, `operatorAcknowledgementsByOrg`) with fallback to legacy global keys.  
- Reworked persistence to write namespaced values and keep unrelated flags: `apps/web/src/lib/operator-product-flags.ts` now exposes `updateOperatorFlagsForOrganization`, `load/save` remain but writes go under scoped keys.  
- Wired API routes to use org-scoped reads/writes: `operator-preferences` and `acknowledge` routes now call the organization-scoped helpers.  
- Platform health payload now derives diagnostics from the org-scoped flags and exposes `operatorFlags` so UI consumes parsed org-scoped state; system page updated to use `payload.operatorFlags`.  
- Added unit tests `apps/web/src/lib/operator-product-flags.test.ts` covering scoped parsing, legacy fallback, and scoped update merge behavior.

### Testing
- Ran unit tests for the affected pieces: `npm run test --workspace=apps/web -- operator-product-flags operator-preferences-validation` and `npm run test --workspace=apps/web -- operator-product-flags`; both test suites passed.  
- Ran lint: `npm run lint` succeeded.  
- Ran typecheck/build steps: `npm run typecheck` and `npm run build` failed due to pre-existing repo-wide TypeScript issues unrelated to this change (implicit `any` and missing DB export types); these failures are not introduced by this PR.  
- Added/tests exercised: `apps/web/src/lib/operator-product-flags.test.ts` (3 tests) and existing `operator-preferences-validation.test.ts` (4 tests) — all passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a4fd519c8328b09ddcf41f83ded1)