### PR TITLE
Make legacy operator-flag fallback observable and add org-scoped backfill repair

### DIFF
--- a/apps/web/src/app/(dashboard)/system/page.tsx
+++ b/apps/web/src/app/(dashboard)/system/page.tsx
@@ -166,6 +166,15 @@ export default async function SystemPage() {
                 </li>
               ))}
             </ul>
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+              <p>
+                Operator flag state source:{' '}
+                <span className="font-mono text-xs">{payload.operatorFlagsStatus.source}</span>
+                {payload.operatorFlagsStatus.requiresRepair
+                  ? ' (legacy fallback active; backfill recommended).'
+                  : ' (organization-scoped state or no operator flags detected).'}
+              </p>
+            </div>
             {canRunOperatorActions ? (
               <OperatorControlPlaneClient
                 organizationId={orgId}
@@ -173,6 +182,7 @@ export default async function SystemPage() {
                 initialSuppressedIds={
                   payload.operatorFlags.prefs.suppressedOptionalDiagnosticIds
                 }
+                fallbackModeActive={payload.operatorFlagsStatus.requiresRepair}
               />
             ) : (
               <p className="text-sm text-slate-600" role="status">

--- a/apps/web/src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.test.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ApiError } from '@aros/shared';
+
+const requireOrgAccessMock = vi.fn();
+const backfillMock = vi.fn();
+const getPayloadMock = vi.fn();
+const logActionMock = vi.fn();
+
+vi.mock('@/lib/auth-guard', () => ({
+  requireOrgAccess: requireOrgAccessMock,
+}));
+
+vi.mock('@/lib/operator-product-flags', () => ({
+  backfillLegacyOperatorFlagsForOrganization: backfillMock,
+}));
+
+vi.mock('@/lib/platform-health', () => ({
+  getPlatformHealthPayload: getPayloadMock,
+}));
+
+vi.mock('@/lib/operator-platform-audit', () => ({
+  logOperatorPlatformAction: logActionMock,
+}));
+
+describe('POST /api/org/[organizationId]/platform/repair-legacy-flags', () => {
+  it('rejects unauthorized callers', async () => {
+    requireOrgAccessMock.mockRejectedValueOnce(ApiError.forbidden('Missing permission: org:system:manage'));
+
+    const { POST } = await import('./route');
+    const response = await POST(new Request('http://localhost'), {
+      params: Promise.resolve({ organizationId: 'orgA' }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(backfillMock).not.toHaveBeenCalled();
+  });
+
+  it('runs repair and returns updated payload for authorized operator', async () => {
+    requireOrgAccessMock.mockResolvedValueOnce({ user: { id: 'user1' } });
+    backfillMock.mockResolvedValueOnce({ status: 'migrated', source: 'legacy_fallback', migrated: true });
+    getPayloadMock.mockResolvedValueOnce({ operatorFlagsStatus: { source: 'scoped', requiresRepair: false } });
+
+    const { POST } = await import('./route');
+    const response = await POST(new Request('http://localhost'), {
+      params: Promise.resolve({ organizationId: 'orgA' }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.result.status).toBe('migrated');
+    expect(backfillMock).toHaveBeenCalledWith('orgA');
+    expect(logActionMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { requireOrgAccess } from '@/lib/auth-guard';
+import { apiError } from '@/lib/api-utils';
+import { logOperatorPlatformAction } from '@/lib/operator-platform-audit';
+import { backfillLegacyOperatorFlagsForOrganization } from '@/lib/operator-product-flags';
+import { getPlatformHealthPayload } from '@/lib/platform-health';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _req: Request,
+  context: { params: Promise<{ organizationId: string }> }
+) {
+  try {
+    const { organizationId } = await context.params;
+    const ctx = await requireOrgAccess(organizationId, 'org:system:manage');
+
+    console.info('[platform-legacy-flags] repair initiated', { organizationId, userId: ctx.user.id });
+
+    await logOperatorPlatformAction({
+      organizationId,
+      userId: ctx.user.id,
+      action: 'platform.legacy_flags.backfill',
+      outcome: 'success',
+      metadata: { phase: 'initiated' },
+    });
+
+    const result = await backfillLegacyOperatorFlagsForOrganization(organizationId);
+
+    if (result.source === 'legacy_fallback') {
+      await logOperatorPlatformAction({
+        organizationId,
+        userId: ctx.user.id,
+        action: 'platform.legacy_flags.fallback_detected',
+        outcome: 'success',
+        metadata: { detectedBy: 'repair_endpoint' },
+      });
+    }
+
+    console.info('[platform-legacy-flags] repair completed', {
+      organizationId,
+      userId: ctx.user.id,
+      status: result.status,
+      source: result.source,
+      migrated: result.migrated,
+    });
+
+    await logOperatorPlatformAction({
+      organizationId,
+      userId: ctx.user.id,
+      action: 'platform.legacy_flags.backfill',
+      outcome: result.migrated ? 'success' : 'blocked',
+      metadata: {
+        phase: 'completed',
+        status: result.status,
+        source: result.source,
+        migrated: result.migrated,
+      },
+    });
+
+    const payload = await getPlatformHealthPayload(organizationId);
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        result,
+        payload,
+      },
+    });
+  } catch (e) {
+    return apiError(e);
+  }
+}

--- a/apps/web/src/components/system/operator-control-plane-client.tsx
+++ b/apps/web/src/components/system/operator-control-plane-client.tsx
@@ -8,12 +8,14 @@ interface Props {
   organizationId: string;
   optionalIssueIds: string[];
   initialSuppressedIds: string[];
+  fallbackModeActive: boolean;
 }
 
 export function OperatorControlPlaneClient({
   organizationId,
   optionalIssueIds,
   initialSuppressedIds,
+  fallbackModeActive,
 }: Props) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
@@ -38,6 +40,32 @@ export function OperatorControlPlaneClient({
         router.refresh();
       } catch {
         setActionError('Network error during recheck.');
+      }
+    });
+  }, [base, router]);
+
+  const runLegacyBackfill = useCallback(() => {
+    setActionError(null);
+    setActionMessage(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`${base}/repair-legacy-flags`, { method: 'POST' });
+        const body = await res.json().catch(() => null);
+        if (!res.ok || !body?.success) {
+          setActionError(body?.error?.message ?? `Repair failed (${res.status})`);
+          return;
+        }
+        const status = body?.data?.result?.status;
+        if (status === 'migrated') {
+          setActionMessage('Legacy fallback data was backfilled to this organization.');
+        } else if (status === 'skipped_scoped_present') {
+          setActionMessage('No repair needed. Organization-scoped operator state already exists.');
+        } else {
+          setActionMessage('No legacy fallback data was available to backfill.');
+        }
+        router.refresh();
+      } catch {
+        setActionError('Network error during legacy backfill.');
       }
     });
   }, [base, router]);
@@ -92,6 +120,24 @@ export function OperatorControlPlaneClient({
         </p>
       </div>
 
+      {fallbackModeActive && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900" role="status">
+          <p className="font-medium">Compatibility mode active</p>
+          <p className="mt-1">
+            This organization is currently reading legacy deployment-wide operator flags. Run backfill to copy them into
+            organization-scoped keys and retire silent shared-state fallback.
+          </p>
+          <button
+            type="button"
+            onClick={runLegacyBackfill}
+            disabled={pending}
+            className="mt-3 rounded-md border border-amber-300 bg-white px-3 py-1.5 text-sm font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-60"
+          >
+            Backfill legacy operator flags
+          </button>
+        </div>
+      )}
+
       {actionError && (
         <p className="text-sm text-red-800" role="alert">
           {actionError}
@@ -107,7 +153,7 @@ export function OperatorControlPlaneClient({
         <fieldset className="rounded-lg border border-slate-200 bg-slate-50/80 p-4">
           <legend className="px-1 text-sm font-medium text-slate-900">Optional service banner suppression</legend>
           <p className="mt-2 text-xs text-slate-600">
-            Deployment-wide preference only. It hides specific optional-service diagnostics from summary banners; it does
+            Organization-scoped preference. It hides specific optional-service diagnostics from summary banners; it does
             not disable integrations or change environment variables.
           </p>
           <ul className="mt-3 space-y-2">

--- a/apps/web/src/lib/operator-org-flags.ts
+++ b/apps/web/src/lib/operator-org-flags.ts
@@ -7,51 +7,161 @@ import {
 const OPERATOR_PREFS_BY_ORG_KEY = 'operatorPrefsByOrg';
 const OPERATOR_ACKS_BY_ORG_KEY = 'operatorAcknowledgementsByOrg';
 
-function readScopedFlags(raw: Record<string, unknown>, organizationId: string): ParsedOperatorPlatformFlags | null {
+export type OperatorFlagsSource = 'scoped' | 'legacy_fallback' | 'none';
+
+export interface OperatorFlagsResolution {
+  flags: ParsedOperatorPlatformFlags;
+  source: OperatorFlagsSource;
+  hasScopedEntry: boolean;
+  hasLegacyValues: boolean;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function hasMeaningfulFlags(parsed: ParsedOperatorPlatformFlags): boolean {
+  return (
+    parsed.prefs.suppressedOptionalDiagnosticIds.length > 0 ||
+    parsed.acknowledgements.acknowledgedIssueIds.length > 0 ||
+    parsed.acknowledgements.updatedAt != null
+  );
+}
+
+function readScopedFlags(raw: Record<string, unknown>, organizationId: string): {
+  flags: ParsedOperatorPlatformFlags;
+  hasScopedEntry: boolean;
+} {
   const prefsByOrg = raw[OPERATOR_PREFS_BY_ORG_KEY];
   const acksByOrg = raw[OPERATOR_ACKS_BY_ORG_KEY];
+
+  const prefsByOrgRecord =
+    prefsByOrg && typeof prefsByOrg === 'object' && !Array.isArray(prefsByOrg)
+      ? (prefsByOrg as Record<string, unknown>)
+      : null;
+  const acksByOrgRecord =
+    acksByOrg && typeof acksByOrg === 'object' && !Array.isArray(acksByOrg)
+      ? (acksByOrg as Record<string, unknown>)
+      : null;
+
+  const hasScopedEntry =
+    (prefsByOrgRecord ? hasOwn(prefsByOrgRecord, organizationId) : false) ||
+    (acksByOrgRecord ? hasOwn(acksByOrgRecord, organizationId) : false);
+
   const scoped = {
-    operatorPrefs:
-      prefsByOrg && typeof prefsByOrg === 'object' && !Array.isArray(prefsByOrg)
-        ? (prefsByOrg as Record<string, unknown>)[organizationId]
-        : undefined,
-    operatorAcknowledgements:
-      acksByOrg && typeof acksByOrg === 'object' && !Array.isArray(acksByOrg)
-        ? (acksByOrg as Record<string, unknown>)[organizationId]
-        : undefined,
+    operatorPrefs: prefsByOrgRecord?.[organizationId],
+    operatorAcknowledgements: acksByOrgRecord?.[organizationId],
   };
 
-  const parsed = parseOperatorPlatformFlags(scoped);
-  if (
-    parsed.prefs.suppressedOptionalDiagnosticIds.length === 0 &&
-    parsed.acknowledgements.acknowledgedIssueIds.length === 0 &&
-    parsed.acknowledgements.updatedAt == null
-  ) {
-    return null;
+  return {
+    flags: parseOperatorPlatformFlags(scoped),
+    hasScopedEntry,
+  };
+}
+
+export function resolveOperatorFlagsForOrganization(
+  raw: unknown,
+  organizationId?: string
+): OperatorFlagsResolution {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {
+      flags: parseOperatorPlatformFlags(raw),
+      source: 'none',
+      hasScopedEntry: false,
+      hasLegacyValues: false,
+    };
   }
 
-  return parsed;
+  const record = raw as Record<string, unknown>;
+  const legacyFlags = parseOperatorPlatformFlags(record);
+  const hasLegacyValues = hasMeaningfulFlags(legacyFlags);
+
+  if (organizationId) {
+    const scoped = readScopedFlags(record, organizationId);
+    if (scoped.hasScopedEntry) {
+      return {
+        flags: scoped.flags,
+        source: 'scoped',
+        hasScopedEntry: true,
+        hasLegacyValues,
+      };
+    }
+
+    if (hasLegacyValues) {
+      return {
+        flags: legacyFlags,
+        source: 'legacy_fallback',
+        hasScopedEntry: false,
+        hasLegacyValues: true,
+      };
+    }
+
+    return {
+      flags: scoped.flags,
+      source: 'none',
+      hasScopedEntry: false,
+      hasLegacyValues: false,
+    };
+  }
+
+  return {
+    flags: legacyFlags,
+    source: hasLegacyValues ? 'legacy_fallback' : 'none',
+    hasScopedEntry: false,
+    hasLegacyValues,
+  };
 }
 
 export function parseOperatorFlagsForOrganization(
   raw: unknown,
   organizationId?: string
 ): ParsedOperatorPlatformFlags {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return parseOperatorPlatformFlags(raw);
+  return resolveOperatorFlagsForOrganization(raw, organizationId).flags;
+}
+
+
+export interface LegacyBackfillResult {
+  status: 'migrated' | 'skipped_no_legacy' | 'skipped_scoped_present';
+  source: OperatorFlagsSource;
+  migrated: boolean;
+}
+
+export function backfillLegacyOperatorFlagsForOrgRecord(
+  raw: Record<string, unknown>,
+  organizationId: string
+): { next: Record<string, unknown>; result: LegacyBackfillResult } {
+  const resolution = resolveOperatorFlagsForOrganization(raw, organizationId);
+
+  if (resolution.source === 'scoped') {
+    return {
+      next: raw,
+      result: {
+        status: 'skipped_scoped_present',
+        source: resolution.source,
+        migrated: false,
+      },
+    };
   }
 
-  const record = raw as Record<string, unknown>;
-
-  if (organizationId) {
-    const scoped = readScopedFlags(record, organizationId);
-    if (scoped) {
-      return scoped;
-    }
+  if (resolution.source !== 'legacy_fallback') {
+    return {
+      next: raw,
+      result: {
+        status: 'skipped_no_legacy',
+        source: resolution.source,
+        migrated: false,
+      },
+    };
   }
 
-  // Backward compatibility for historical deployment-wide keys.
-  return parseOperatorPlatformFlags(record);
+  return {
+    next: applyScopedOperatorFlagsUpdate(raw, organizationId, resolution.flags),
+    result: {
+      status: 'migrated',
+      source: resolution.source,
+      migrated: true,
+    },
+  };
 }
 
 export function applyScopedOperatorFlagsUpdate(

--- a/apps/web/src/lib/operator-platform-audit.ts
+++ b/apps/web/src/lib/operator-platform-audit.ts
@@ -4,6 +4,8 @@ const PLATFORM_ACTIONS = [
   'platform.recheck',
   'platform.issue.acknowledged',
   'platform.operator_prefs.updated',
+  'platform.legacy_flags.fallback_detected',
+  'platform.legacy_flags.backfill',
 ] as const;
 
 export type PlatformAuditAction = (typeof PLATFORM_ACTIONS)[number];

--- a/apps/web/src/lib/operator-product-flags.test.ts
+++ b/apps/web/src/lib/operator-product-flags.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyScopedOperatorFlagsUpdate,
+  backfillLegacyOperatorFlagsForOrgRecord,
   parseOperatorFlagsForOrganization,
+  resolveOperatorFlagsForOrganization,
 } from './operator-org-flags';
 import type { ParsedOperatorPlatformFlags } from '@aros/core-services';
 
-describe('parseOperatorFlagsForOrganization', () => {
+describe('resolveOperatorFlagsForOrganization', () => {
   it('reads organization-scoped operator flags when available', () => {
-    const parsed = parseOperatorFlagsForOrganization(
+    const resolved = resolveOperatorFlagsForOrganization(
       {
         operatorPrefsByOrg: {
           orgA: { suppressedOptionalDiagnosticIds: ['svc:stripe-billing'] },
@@ -19,11 +21,41 @@ describe('parseOperatorFlagsForOrganization', () => {
       'orgA'
     );
 
-    expect(parsed.prefs.suppressedOptionalDiagnosticIds).toEqual(['svc:stripe-billing']);
-    expect(parsed.acknowledgements.acknowledgedIssueIds).toEqual(['svc:slack-webhooks']);
+    expect(resolved.source).toBe('scoped');
+    expect(resolved.flags.prefs.suppressedOptionalDiagnosticIds).toEqual(['svc:stripe-billing']);
+    expect(resolved.flags.acknowledgements.acknowledgedIssueIds).toEqual(['svc:slack-webhooks']);
   });
 
   it('falls back to legacy deployment-wide keys when scoped keys are missing', () => {
+    const resolved = resolveOperatorFlagsForOrganization(
+      {
+        operatorPrefs: { suppressedOptionalDiagnosticIds: ['svc:slack-webhooks'] },
+      },
+      'orgA'
+    );
+
+    expect(resolved.source).toBe('legacy_fallback');
+    expect(resolved.flags.prefs.suppressedOptionalDiagnosticIds).toEqual(['svc:slack-webhooks']);
+  });
+
+  it('prefers explicit scoped empty state over legacy fallback once org keys exist', () => {
+    const resolved = resolveOperatorFlagsForOrganization(
+      {
+        operatorPrefs: { suppressedOptionalDiagnosticIds: ['svc:slack-webhooks'] },
+        operatorPrefsByOrg: {
+          orgA: { suppressedOptionalDiagnosticIds: [] },
+        },
+      },
+      'orgA'
+    );
+
+    expect(resolved.source).toBe('scoped');
+    expect(resolved.flags.prefs.suppressedOptionalDiagnosticIds).toEqual([]);
+  });
+});
+
+describe('parseOperatorFlagsForOrganization', () => {
+  it('returns parsed flag payload for existing consumers', () => {
     const parsed = parseOperatorFlagsForOrganization(
       {
         operatorPrefs: { suppressedOptionalDiagnosticIds: ['svc:slack-webhooks'] },
@@ -62,5 +94,56 @@ describe('applyScopedOperatorFlagsUpdate', () => {
       acknowledgedIssueIds: ['svc:s3-evidence'],
       updatedAt: '2026-03-21T00:00:00.000Z',
     });
+  });
+});
+
+describe('backfillLegacyOperatorFlagsForOrgRecord', () => {
+  it('backfills legacy flags into org namespace when fallback is active', () => {
+    const { next, result } = backfillLegacyOperatorFlagsForOrgRecord(
+      {
+        operatorPrefs: { suppressedOptionalDiagnosticIds: ['svc:slack-webhooks'] },
+      },
+      'orgA'
+    );
+
+    expect(result).toEqual({
+      status: 'migrated',
+      source: 'legacy_fallback',
+      migrated: true,
+    });
+    expect((next.operatorPrefsByOrg as Record<string, unknown>).orgA).toEqual({
+      suppressedOptionalDiagnosticIds: ['svc:slack-webhooks'],
+    });
+  });
+
+  it('is idempotent when scoped state already exists for org', () => {
+    const original = {
+      operatorPrefsByOrg: {
+        orgA: { suppressedOptionalDiagnosticIds: ['svc:jira'] },
+      },
+      operatorPrefs: { suppressedOptionalDiagnosticIds: ['svc:slack-webhooks'] },
+    };
+
+    const { next, result } = backfillLegacyOperatorFlagsForOrgRecord(original, 'orgA');
+
+    expect(result).toEqual({
+      status: 'skipped_scoped_present',
+      source: 'scoped',
+      migrated: false,
+    });
+    expect(next).toBe(original);
+  });
+
+  it('skips when no legacy fallback data exists', () => {
+    const original = { releaseChannel: 'stable' };
+
+    const { next, result } = backfillLegacyOperatorFlagsForOrgRecord(original, 'orgA');
+
+    expect(result).toEqual({
+      status: 'skipped_no_legacy',
+      source: 'none',
+      migrated: false,
+    });
+    expect(next).toBe(original);
   });
 });

--- a/apps/web/src/lib/operator-product-flags.ts
+++ b/apps/web/src/lib/operator-product-flags.ts
@@ -1,9 +1,21 @@
 import { ApiError } from '@aros/shared';
 import { prisma } from '@/lib/db';
 import type { ParsedOperatorPlatformFlags } from '@aros/core-services';
-import { applyScopedOperatorFlagsUpdate, parseOperatorFlagsForOrganization } from './operator-org-flags';
+import {
+  applyScopedOperatorFlagsUpdate,
+  backfillLegacyOperatorFlagsForOrgRecord,
+  parseOperatorFlagsForOrganization,
+  type LegacyBackfillResult,
+  resolveOperatorFlagsForOrganization,
+} from './operator-org-flags';
 
-export { applyScopedOperatorFlagsUpdate, parseOperatorFlagsForOrganization } from './operator-org-flags';
+export {
+  applyScopedOperatorFlagsUpdate,
+  backfillLegacyOperatorFlagsForOrgRecord,
+  parseOperatorFlagsForOrganization,
+  type LegacyBackfillResult,
+  resolveOperatorFlagsForOrganization,
+} from './operator-org-flags';
 
 export async function loadProductFlagsRecord(): Promise<Record<string, unknown>> {
   const row = await prisma.platformState.findUnique({
@@ -24,18 +36,36 @@ export async function saveProductFlagsRecord(next: Record<string, unknown>) {
   });
 }
 
-export async function updateOperatorFlagsForOrganization(
-  organizationId: string,
-  mutator: (current: ParsedOperatorPlatformFlags) => ParsedOperatorPlatformFlags
-) {
+async function assertPlatformInstalled() {
   const exists = await prisma.platformState.findUnique({ where: { id: 'platform' }, select: { id: true } });
   if (!exists) {
     throw ApiError.badRequest('Platform is not installed in the database; run migrations and bootstrap before using operator actions.');
   }
+}
+
+export async function updateOperatorFlagsForOrganization(
+  organizationId: string,
+  mutator: (current: ParsedOperatorPlatformFlags) => ParsedOperatorPlatformFlags
+) {
+  await assertPlatformInstalled();
+
   const merged = await loadProductFlagsRecord();
   const parsed = parseOperatorFlagsForOrganization(merged, organizationId);
   const updated = mutator(parsed);
   const next = applyScopedOperatorFlagsUpdate(merged, organizationId, updated);
   await saveProductFlagsRecord(next);
   return updated;
+}
+
+export async function backfillLegacyOperatorFlagsForOrganization(organizationId: string): Promise<LegacyBackfillResult> {
+  await assertPlatformInstalled();
+
+  const merged = await loadProductFlagsRecord();
+  const { next, result } = backfillLegacyOperatorFlagsForOrgRecord(merged, organizationId);
+
+  if (result.migrated) {
+    await saveProductFlagsRecord(next);
+  }
+
+  return result;
 }

--- a/apps/web/src/lib/platform-health.ts
+++ b/apps/web/src/lib/platform-health.ts
@@ -10,7 +10,7 @@ import {
 } from '@aros/core-services';
 import { parseEnvDiagnostics } from '@aros/config';
 import { prisma } from './db';
-import { parseOperatorFlagsForOrganization } from './operator-org-flags';
+import { resolveOperatorFlagsForOrganization } from './operator-org-flags';
 import type { PlatformHealthReport, RoutePlatformTruth } from '@aros/core-services';
 import { getRecentPlatformAuditEntries, type RecentPlatformAuditEntry } from './operator-platform-audit';
 
@@ -29,7 +29,13 @@ export interface PlatformHealthApiPayload {
   };
   operatorActions: OperatorActionDescriptor[];
   recentPlatformActions: RecentPlatformAuditEntry[];
-  operatorFlags: ReturnType<typeof parseOperatorFlagsForOrganization>;
+  operatorFlags: ReturnType<typeof resolveOperatorFlagsForOrganization>['flags'];
+  operatorFlagsStatus: {
+    source: ReturnType<typeof resolveOperatorFlagsForOrganization>['source'];
+    hasScopedEntry: boolean;
+    hasLegacyValues: boolean;
+    requiresRepair: boolean;
+  };
 }
 
 export async function getPlatformHealthPayload(organizationId?: string): Promise<PlatformHealthApiPayload> {
@@ -38,8 +44,15 @@ export async function getPlatformHealthPayload(organizationId?: string): Promise
     (k) => (diag.fieldErrors[k]?.length ?? 0) > 0
   );
   const report = await collectPlatformHealth(prisma);
-  const parsedFlags = parseOperatorFlagsForOrganization(report.operatorPlatformFlags, organizationId);
-  const { issues, setupChecklist, summary } = derivePlatformDiagnostics(report, parsedFlags);
+  const operatorFlagsResolution = resolveOperatorFlagsForOrganization(report.operatorPlatformFlags, organizationId);
+  const { issues, setupChecklist, summary } = derivePlatformDiagnostics(report, operatorFlagsResolution.flags);
+
+  if (organizationId && operatorFlagsResolution.source === 'legacy_fallback') {
+    console.warn('[platform-health] legacy operator flag fallback active', {
+      organizationId,
+      hasLegacyValues: operatorFlagsResolution.hasLegacyValues,
+    });
+  }
   const recentPlatformActions =
     organizationId != null
       ? await getRecentPlatformAuditEntries(organizationId).catch(() => [])
@@ -51,6 +64,12 @@ export async function getPlatformHealthPayload(organizationId?: string): Promise
     diagnostics: { issues, setupChecklist, summary },
     operatorActions: listOperatorActions(),
     recentPlatformActions,
-    operatorFlags: parsedFlags,
+    operatorFlags: operatorFlagsResolution.flags,
+    operatorFlagsStatus: {
+      source: operatorFlagsResolution.source,
+      hasScopedEntry: operatorFlagsResolution.hasScopedEntry,
+      hasLegacyValues: operatorFlagsResolution.hasLegacyValues,
+      requiresRepair: operatorFlagsResolution.source === 'legacy_fallback',
+    },
   };
 }

--- a/docs/PLATFORM_ACTIONS_AND_AUDIT.md
+++ b/docs/PLATFORM_ACTIONS_AND_AUDIT.md
@@ -5,21 +5,24 @@
 | Capability | Permission |
 | --- | --- |
 | View `/system`, `GET .../platform/health` | `org:system:view` (OWNER, ADMIN) |
-| Recheck, acknowledge, operator preferences | `org:system:manage` (OWNER, ADMIN) |
+| Recheck, acknowledge, operator preferences, legacy backfill | `org:system:manage` (OWNER, ADMIN) |
 
 ## Endpoints
 
 - `POST /api/org/:organizationId/platform/recheck` — synchronous health refresh; audits `platform.recheck`.
 - `POST /api/org/:organizationId/platform/acknowledge` — body `{ issueId }`; validates id against current diagnostics; audits `platform.issue.acknowledged`.
-- `PATCH /api/org/:organizationId/platform/operator-preferences` — body `{ suppressedOptionalDiagnosticIds: string[] }` (only `svc:<optionalServiceId>`); audits `platform.operator_prefs.updated`.
+- `PATCH /api/org/:organizationId/platform/operator-preferences` — body `{ suppressedOptionalDiagnosticIds: string[] }` (only `svc:<optionalServiceId>`); writes organization-scoped keys; audits `platform.operator_prefs.updated`.
+- `POST /api/org/:organizationId/platform/repair-legacy-flags` — copies legacy deployment-wide operator flags into this org namespace when fallback mode is active; audits `platform.legacy_flags.fallback_detected` and `platform.legacy_flags.backfill`.
 
 ## Persistence
 
-Acknowledgements and suppression lists live under **`PlatformState.productFlags`** (`operatorAcknowledgements`, `operatorPrefs`). This is **deployment-wide**, not per-organization — the audit log row is still scoped to the acting user’s organization for traceability.
+Operator preferences and acknowledgements are stored in `PlatformState.productFlags` under organization keys (`operatorPrefsByOrg`, `operatorAcknowledgementsByOrg`).
+
+Legacy deployment-wide keys (`operatorPrefs`, `operatorAcknowledgements`) are still read **only as compatibility fallback** when no org-scoped entry exists for the current organization. The health payload exposes fallback state via `operatorFlagsStatus`, and operators can retire it with the repair endpoint.
 
 ## Audit metadata
 
-`AuditLog.metadata` stores outcomes and non-secret fields only (issue ids, counts, readiness). Secret values and raw env are never written.
+`AuditLog.metadata` stores outcomes and non-secret fields only (issue ids, counts, readiness, backfill status/source). Secret values and raw env are never written.
 
 ## Verification
 

--- a/packages/core-services/src/operator-diagnostics.ts
+++ b/packages/core-services/src/operator-diagnostics.ts
@@ -14,7 +14,7 @@ export type RemediationType =
 export type ActorResponsibility = 'platform_operator' | 'deployment_engineer' | 'org_admin' | 'end_user_unaffected';
 
 export interface OperatorProductFlags {
-  /** Optional service diagnostic IDs suppressed from critical/warning banners (deployment-wide). */
+  /** Optional service diagnostic IDs suppressed from critical/warning banners (organization-scoped when namespaced keys are present). */
   suppressedOptionalDiagnosticIds: string[];
 }
 
@@ -592,9 +592,19 @@ export function listOperatorActions(): OperatorActionDescriptor[] {
       id: 'suppress_optional',
       label: 'Hide optional warning',
       description:
-        'Stops showing a specific optional-service diagnostic in operator banners. Deployment-wide; does not disable the service.',
+        'Stops showing a specific optional-service diagnostic in operator banners for the active organization. Does not disable the service.',
       method: 'PATCH',
       pathSuffix: 'operator-preferences',
+      available: true,
+    },
+
+    {
+      id: 'repair_legacy_operator_flags',
+      label: 'Backfill legacy operator flags',
+      description:
+        'Copies legacy deployment-wide operator flags into this organization namespace when fallback mode is detected.',
+      method: 'POST',
+      pathSuffix: 'repair-legacy-flags',
       available: true,
     },
   ];


### PR DESCRIPTION
### Motivation
- Remove silent compatibility behavior where reads could implicitly use deployment-wide operator flags, and make fallback explicit and actionable per organization.
- Provide a smallest-safe server-side repair that backfills legacy prefs/acks into an organization namespace without reintroducing global writes.
- Ensure runtime and UI truthfulness so operators can see whether scoped state is present, fallback is active, or repair is required.

### Description
- Introduced a resolver that returns `flags` plus `source` (`scoped` | `legacy_fallback` | `none`), `hasScopedEntry`, and `hasLegacyValues` and preserved `parseOperatorFlagsForOrganization` compatibility. (`apps/web/src/lib/operator-org-flags.ts`).
- Added deterministic backfill logic to copy legacy `operatorPrefs` / `operatorAcknowledgements` into the requesting org namespace (idempotent and org-scoped only) and exposed programmatic helpers for the product flags layer. (`apps/web/src/lib/operator-product-flags.ts`, `apps/web/src/lib/operator-org-flags.ts`).
- Exposed operator-flag resolution metadata in the health payload as `operatorFlagsStatus` and emit a server warning when fallback is active. (`apps/web/src/lib/platform-health.ts`).
- Added a protected repair endpoint `POST /api/org/:organizationId/platform/repair-legacy-flags` that requires `org:system:manage`, logs structured start/complete info, and writes audit events for backfill lifecycle and fallback detection. (`apps/web/src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.ts`, `apps/web/src/lib/operator-platform-audit.ts`).
- Surface compatibility state and an operator CTA in the System UI and the operator control panel (banner + backfill button), and update copy to reflect organization-scoped semantics. (`apps/web/src/app/(dashboard)/system/page.tsx`, `apps/web/src/components/system/operator-control-plane-client.tsx`).
- Added focused tests that validate resolver behavior, backfill idempotency, and repair-route auth+success behavior. (`apps/web/src/lib/operator-product-flags.test.ts`, `apps/web/src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.test.ts`).
- Updated operator action descriptors and docs to reflect the compatibility/backfill flow and that writes are organization-scoped. (`packages/core-services/src/operator-diagnostics.ts`, `docs/PLATFORM_ACTIONS_AND_AUDIT.md`).

### Testing
- Ran web unit tests for the changed area with `npm run test --workspace=@aros/web -- src/lib/operator-product-flags.test.ts src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.test.ts` and all included tests passed.
- Ran core-services unit tests with `npm run test --workspace=@aros/core-services -- src/operator-diagnostics.test.ts` and they passed.
- Ran workspace typecheck `npm run typecheck --workspace=@aros/web` which failed due to existing, repo-wide TypeScript issues unrelated to this change; these failures are pre-existing and not caused by this slice.
- The repair route test asserts auth rejection and successful backfill flow and verifies audit logging was invoked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5aa31970483288c16ea058773ecbf)