### PR TITLE
Evidence-gate legacy operator-state retirement readiness

### DIFF
--- a/apps/web/src/app/(dashboard)/system/page.tsx
+++ b/apps/web/src/app/(dashboard)/system/page.tsx
@@ -77,7 +77,7 @@ export default async function SystemPage() {
   let payload: Awaited<ReturnType<typeof getPlatformHealthPayload>> | null = null;
   let loadError: string | null = null;
   try {
-    payload = await getPlatformHealthPayload(orgId);
+    payload = await getPlatformHealthPayload(orgId, user.id);
   } catch (e) {
     loadError = e instanceof Error ? e.message : 'Failed to load platform health';
     console.error('[system] platform health failed', e);
@@ -174,6 +174,13 @@ export default async function SystemPage() {
                   ? ' (legacy fallback active; backfill recommended).'
                   : ' (organization-scoped state or no operator flags detected).'}
               </p>
+              <p className="mt-1">
+                Legacy retirement dependence:{' '}
+                <span className="font-mono text-xs">{payload.legacyRetirement.currentOrganization.dependence}</span>
+                {payload.legacyRetirement.currentOrganization.requiresRepair
+                  ? ' (this org still depends on compatibility fallback).'
+                  : ' (this org is not currently using legacy fallback).'}
+              </p>
             </div>
             {canRunOperatorActions ? (
               <OperatorControlPlaneClient
@@ -183,6 +190,7 @@ export default async function SystemPage() {
                   payload.operatorFlags.prefs.suppressedOptionalDiagnosticIds
                 }
                 fallbackModeActive={payload.operatorFlagsStatus.requiresRepair}
+                initialRetirementReadiness={payload.legacyRetirement.operatorScope?.readiness ?? null}
               />
             ) : (
               <p className="text-sm text-slate-600" role="status">

--- a/apps/web/src/app/api/org/[organizationId]/platform/acknowledge/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/acknowledge/route.ts
@@ -86,7 +86,7 @@ export async function POST(
       metadata: { issueId },
     });
 
-    const payload = await getPlatformHealthPayload(organizationId);
+    const payload = await getPlatformHealthPayload(organizationId, ctx.user.id);
     return NextResponse.json({ success: true, data: { issueId, payload } });
   } catch (e) {
     return apiError(e);

--- a/apps/web/src/app/api/org/[organizationId]/platform/health/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/health/route.ts
@@ -11,8 +11,8 @@ export async function GET(
 ) {
   try {
     const { organizationId } = await context.params;
-    await requireOrgAccess(organizationId, 'org:system:view');
-    const payload = await getPlatformHealthPayload(organizationId);
+    const ctx = await requireOrgAccess(organizationId, 'org:system:view');
+    const payload = await getPlatformHealthPayload(organizationId, ctx.user.id);
     return NextResponse.json({ success: true, data: payload });
   } catch (e) {
     return apiError(e);

--- a/apps/web/src/app/api/org/[organizationId]/platform/legacy-retirement/route.test.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/legacy-retirement/route.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ApiError } from '@aros/shared';
+
+const requireOrgAccessMock = vi.fn();
+const evaluateMock = vi.fn();
+const logActionMock = vi.fn();
+
+vi.mock('@/lib/auth-guard', () => ({
+  requireOrgAccess: requireOrgAccessMock,
+}));
+
+vi.mock('@/lib/operator-legacy-retirement', () => ({
+  evaluateLegacyRetirementForOperator: evaluateMock,
+}));
+
+vi.mock('@/lib/operator-platform-audit', () => ({
+  logOperatorPlatformAction: logActionMock,
+}));
+
+describe('POST /api/org/[organizationId]/platform/legacy-retirement', () => {
+  it('rejects unauthorized callers', async () => {
+    requireOrgAccessMock.mockRejectedValueOnce(ApiError.forbidden('Missing permission: org:system:manage'));
+
+    const { POST } = await import('./route');
+    const response = await POST(new Request('http://localhost'), {
+      params: Promise.resolve({ organizationId: 'orgA' }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(evaluateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns evaluation and logs evidence-gated blocked prune state', async () => {
+    requireOrgAccessMock.mockResolvedValueOnce({ user: { id: 'user1' } });
+    evaluateMock.mockResolvedValueOnce({
+      inventory: [{ organizationId: 'orgA', dependence: 'legacy_fallback', requiresRepair: true }],
+      readiness: {
+        evaluationScope: 'operator_manage_scope',
+        status: 'fallback_detected',
+        inspectedOrganizationCount: 1,
+        fallbackOrganizationCount: 1,
+        fallbackOrganizationIds: ['orgA'],
+        canSafelyPruneLegacyKeys: false,
+        reason: 'Evaluation is scoped to manageable organizations.',
+      },
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(new Request('http://localhost'), {
+      params: Promise.resolve({ organizationId: 'orgA' }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.prune.allowed).toBe(false);
+    expect(logActionMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/app/api/org/[organizationId]/platform/legacy-retirement/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/legacy-retirement/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { requireOrgAccess } from '@/lib/auth-guard';
+import { apiError } from '@/lib/api-utils';
+import { evaluateLegacyRetirementForOperator } from '@/lib/operator-legacy-retirement';
+import { logOperatorPlatformAction } from '@/lib/operator-platform-audit';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _req: Request,
+  context: { params: Promise<{ organizationId: string }> }
+) {
+  try {
+    const { organizationId } = await context.params;
+    const ctx = await requireOrgAccess(organizationId, 'org:system:manage');
+    const evaluation = await evaluateLegacyRetirementForOperator(ctx.user.id);
+
+    await logOperatorPlatformAction({
+      organizationId,
+      userId: ctx.user.id,
+      action: 'platform.legacy_flags.retirement_evaluated',
+      outcome: 'success',
+      metadata: {
+        scope: evaluation.readiness.evaluationScope,
+        readiness: evaluation.readiness.status,
+        inspectedOrganizationCount: evaluation.readiness.inspectedOrganizationCount,
+        fallbackOrganizationCount: evaluation.readiness.fallbackOrganizationCount,
+      },
+    });
+
+    const blocked = !evaluation.readiness.canSafelyPruneLegacyKeys;
+    if (blocked) {
+      await logOperatorPlatformAction({
+        organizationId,
+        userId: ctx.user.id,
+        action: 'platform.legacy_flags.retirement_blocked',
+        outcome: 'blocked',
+        metadata: {
+          reason: evaluation.readiness.reason,
+          readiness: evaluation.readiness.status,
+          fallbackOrganizationCount: evaluation.readiness.fallbackOrganizationCount,
+        },
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        evaluation,
+        prune: {
+          allowed: false,
+          reason: evaluation.readiness.reason,
+        },
+      },
+    });
+  } catch (e) {
+    return apiError(e);
+  }
+}

--- a/apps/web/src/app/api/org/[organizationId]/platform/operator-preferences/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/operator-preferences/route.ts
@@ -79,7 +79,7 @@ export async function PATCH(
       metadata: { count: ids.length },
     });
 
-    const payload = await getPlatformHealthPayload(organizationId);
+    const payload = await getPlatformHealthPayload(organizationId, ctx.user.id);
     return NextResponse.json({ success: true, data: { suppressedOptionalDiagnosticIds: ids, payload } });
   } catch (e) {
     return apiError(e);

--- a/apps/web/src/app/api/org/[organizationId]/platform/recheck/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/recheck/route.ts
@@ -13,7 +13,7 @@ export async function POST(
   try {
     const { organizationId } = await context.params;
     const ctx = await requireOrgAccess(organizationId, 'org:system:manage');
-    const payload = await getPlatformHealthPayload(organizationId);
+    const payload = await getPlatformHealthPayload(organizationId, ctx.user.id);
     await logOperatorPlatformAction({
       organizationId,
       userId: ctx.user.id,

--- a/apps/web/src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.ts
+++ b/apps/web/src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.ts
@@ -58,7 +58,7 @@ export async function POST(
       },
     });
 
-    const payload = await getPlatformHealthPayload(organizationId);
+    const payload = await getPlatformHealthPayload(organizationId, ctx.user.id);
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/components/system/operator-control-plane-client.tsx
+++ b/apps/web/src/components/system/operator-control-plane-client.tsx
@@ -9,6 +9,12 @@ interface Props {
   optionalIssueIds: string[];
   initialSuppressedIds: string[];
   fallbackModeActive: boolean;
+  initialRetirementReadiness: {
+    status: 'fallback_detected' | 'no_fallback_observed' | 'unknown';
+    inspectedOrganizationCount: number;
+    fallbackOrganizationCount: number;
+    reason: string;
+  } | null;
 }
 
 export function OperatorControlPlaneClient({
@@ -16,12 +22,14 @@ export function OperatorControlPlaneClient({
   optionalIssueIds,
   initialSuppressedIds,
   fallbackModeActive,
+  initialRetirementReadiness,
 }: Props) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [suppressed, setSuppressed] = useState<Set<string>>(() => new Set(initialSuppressedIds));
+  const [retirementReadiness, setRetirementReadiness] = useState(initialRetirementReadiness);
 
   const base = `/api/org/${organizationId}/platform`;
 
@@ -93,6 +101,29 @@ export function OperatorControlPlaneClient({
     });
   }, [base, router, suppressed]);
 
+  const evaluateRetirementReadiness = useCallback(() => {
+    setActionError(null);
+    setActionMessage(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`${base}/legacy-retirement`, { method: 'POST' });
+        const body = await res.json().catch(() => null);
+        if (!res.ok || !body?.success) {
+          setActionError(body?.error?.message ?? `Retirement evaluation failed (${res.status})`);
+          return;
+        }
+        const readiness = body?.data?.evaluation?.readiness;
+        if (readiness) {
+          setRetirementReadiness(readiness);
+        }
+        setActionMessage('Legacy retirement readiness evaluated. Prune remains evidence-gated and blocked by default.');
+        router.refresh();
+      } catch {
+        setActionError('Network error evaluating legacy retirement readiness.');
+      }
+    });
+  }, [base, router]);
+
   const toggleSuppressed = (id: string, checked: boolean) => {
     setSuppressed((prev) => {
       const next = new Set(prev);
@@ -137,6 +168,33 @@ export function OperatorControlPlaneClient({
           </button>
         </div>
       )}
+
+      <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700" role="status">
+        <p className="font-medium">Legacy retirement readiness</p>
+        <p className="mt-1">
+          Status:{' '}
+          <span className="font-mono text-xs">
+            {retirementReadiness?.status ?? 'unknown'}
+          </span>{' '}
+          · inspected orgs:{' '}
+          <span className="font-mono text-xs">
+            {retirementReadiness?.inspectedOrganizationCount ?? 0}
+          </span>{' '}
+          · fallback orgs:{' '}
+          <span className="font-mono text-xs">
+            {retirementReadiness?.fallbackOrganizationCount ?? 0}
+          </span>
+        </p>
+        <p className="mt-1 text-slate-600">{retirementReadiness?.reason ?? 'Run evaluation to refresh retirement evidence.'}</p>
+        <button
+          type="button"
+          onClick={evaluateRetirementReadiness}
+          disabled={pending}
+          className="mt-3 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-800 hover:bg-slate-100 disabled:opacity-60"
+        >
+          Evaluate retirement readiness
+        </button>
+      </div>
 
       {actionError && (
         <p className="text-sm text-red-800" role="alert">

--- a/apps/web/src/lib/operator-legacy-retirement.test.ts
+++ b/apps/web/src/lib/operator-legacy-retirement.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const findManyMock = vi.fn();
+const findUniqueMock = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    membership: { findMany: findManyMock },
+    platformState: { findUnique: findUniqueMock },
+  },
+}));
+
+vi.mock('@aros/config', () => ({
+  hasPermission: (role: string, permission: string) => permission === 'org:system:manage' && (role === 'OWNER' || role === 'ADMIN'),
+}));
+
+describe('evaluateLegacyRetirementForOperator', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('reports fallback-dependent org inventory and blocks prune assertions', async () => {
+    findManyMock.mockResolvedValueOnce([
+      { organizationId: 'orgA', role: 'OWNER' },
+      { organizationId: 'orgB', role: 'ADMIN' },
+      { organizationId: 'orgC', role: 'DEVELOPER' },
+    ]);
+    findUniqueMock.mockResolvedValueOnce({
+      productFlags: {
+        operatorPrefs: { suppressedOptionalDiagnosticIds: ['svc:slack-webhooks'] },
+        operatorPrefsByOrg: {
+          orgB: { suppressedOptionalDiagnosticIds: [] },
+        },
+      },
+    });
+
+    const { evaluateLegacyRetirementForOperator } = await import('./operator-legacy-retirement');
+    const result = await evaluateLegacyRetirementForOperator('user1');
+
+    expect(result.inventory).toEqual([
+      { organizationId: 'orgA', dependence: 'legacy_fallback', requiresRepair: true },
+      { organizationId: 'orgB', dependence: 'scoped_clean', requiresRepair: false },
+    ]);
+    expect(result.readiness.status).toBe('fallback_detected');
+    expect(result.readiness.fallbackOrganizationIds).toEqual(['orgA']);
+    expect(result.readiness.canSafelyPruneLegacyKeys).toBe(false);
+  });
+
+  it('returns unknown readiness when operator has no manageable organizations', async () => {
+    findManyMock.mockResolvedValueOnce([{ organizationId: 'orgC', role: 'DEVELOPER' }]);
+    findUniqueMock.mockResolvedValueOnce({ productFlags: {} });
+
+    const { evaluateLegacyRetirementForOperator } = await import('./operator-legacy-retirement');
+    const result = await evaluateLegacyRetirementForOperator('user2');
+
+    expect(result.inventory).toEqual([]);
+    expect(result.readiness.status).toBe('unknown');
+    expect(result.readiness.inspectedOrganizationCount).toBe(0);
+  });
+});

--- a/apps/web/src/lib/operator-legacy-retirement.ts
+++ b/apps/web/src/lib/operator-legacy-retirement.ts
@@ -1,0 +1,85 @@
+import { hasPermission } from '@aros/config';
+import { prisma } from '@/lib/db';
+import {
+  deriveLegacyDependenceStatus,
+  resolveOperatorFlagsForOrganization,
+  type LegacyDependenceStatus,
+} from './operator-org-flags';
+
+export interface LegacyRetirementOrgInventoryRow {
+  organizationId: string;
+  dependence: LegacyDependenceStatus;
+  requiresRepair: boolean;
+}
+
+export interface LegacyRetirementReadiness {
+  evaluationScope: 'operator_manage_scope';
+  status: 'fallback_detected' | 'no_fallback_observed' | 'unknown';
+  inspectedOrganizationCount: number;
+  fallbackOrganizationCount: number;
+  fallbackOrganizationIds: string[];
+  canSafelyPruneLegacyKeys: false;
+  reason: string;
+}
+
+export interface LegacyRetirementEvaluation {
+  inventory: LegacyRetirementOrgInventoryRow[];
+  readiness: LegacyRetirementReadiness;
+}
+
+export async function evaluateLegacyRetirementForOperator(userId: string): Promise<LegacyRetirementEvaluation> {
+  const [memberships, platformRow] = await Promise.all([
+    prisma.membership.findMany({
+      where: { userId },
+      select: { organizationId: true, role: true },
+      orderBy: { organizationId: 'asc' },
+    }),
+    prisma.platformState.findUnique({
+      where: { id: 'platform' },
+      select: { productFlags: true },
+    }),
+  ]);
+
+  const manageableOrgIds = (memberships as Array<{ organizationId: string; role: string }>)
+    .filter((membership) => hasPermission(membership.role as any, 'org:system:manage'))
+    .map((membership) => membership.organizationId);
+
+  const flagsRecord =
+    platformRow?.productFlags && typeof platformRow.productFlags === 'object' && !Array.isArray(platformRow.productFlags)
+      ? (platformRow.productFlags as Record<string, unknown>)
+      : {};
+
+  const inventory = manageableOrgIds.map((organizationId) => {
+    const resolution = resolveOperatorFlagsForOrganization(flagsRecord, organizationId);
+    const dependence = deriveLegacyDependenceStatus(resolution);
+    return {
+      organizationId,
+      dependence,
+      requiresRepair: dependence === 'legacy_fallback',
+    };
+  });
+
+  const fallbackOrganizationIds = inventory.filter((row) => row.requiresRepair).map((row) => row.organizationId);
+  const inspectedOrganizationCount = inventory.length;
+  const fallbackOrganizationCount = fallbackOrganizationIds.length;
+  const status =
+    inspectedOrganizationCount === 0 ? 'unknown' : fallbackOrganizationCount > 0 ? 'fallback_detected' : 'no_fallback_observed';
+
+  const reason =
+    status === 'unknown'
+      ? 'No organizations with org:system:manage were inspectable for this operator.'
+      : 'Evaluation is limited to organizations this operator can manage; global prune safety is intentionally not asserted.';
+
+  return {
+    inventory,
+    readiness: {
+      evaluationScope: 'operator_manage_scope',
+      status,
+      inspectedOrganizationCount,
+      fallbackOrganizationCount,
+      fallbackOrganizationIds,
+      canSafelyPruneLegacyKeys: false,
+      reason,
+    },
+  };
+}

--- a/apps/web/src/lib/operator-org-flags.ts
+++ b/apps/web/src/lib/operator-org-flags.ts
@@ -8,6 +8,7 @@ const OPERATOR_PREFS_BY_ORG_KEY = 'operatorPrefsByOrg';
 const OPERATOR_ACKS_BY_ORG_KEY = 'operatorAcknowledgementsByOrg';
 
 export type OperatorFlagsSource = 'scoped' | 'legacy_fallback' | 'none';
+export type LegacyDependenceStatus = 'scoped_clean' | 'legacy_fallback' | 'no_operator_state';
 
 export interface OperatorFlagsResolution {
   flags: ParsedOperatorPlatformFlags;
@@ -124,6 +125,18 @@ export interface LegacyBackfillResult {
   status: 'migrated' | 'skipped_no_legacy' | 'skipped_scoped_present';
   source: OperatorFlagsSource;
   migrated: boolean;
+}
+
+export function deriveLegacyDependenceStatus(
+  resolution: Pick<OperatorFlagsResolution, 'source'>
+): LegacyDependenceStatus {
+  if (resolution.source === 'scoped') {
+    return 'scoped_clean';
+  }
+  if (resolution.source === 'legacy_fallback') {
+    return 'legacy_fallback';
+  }
+  return 'no_operator_state';
 }
 
 export function backfillLegacyOperatorFlagsForOrgRecord(

--- a/apps/web/src/lib/operator-platform-audit.ts
+++ b/apps/web/src/lib/operator-platform-audit.ts
@@ -6,6 +6,8 @@ const PLATFORM_ACTIONS = [
   'platform.operator_prefs.updated',
   'platform.legacy_flags.fallback_detected',
   'platform.legacy_flags.backfill',
+  'platform.legacy_flags.retirement_evaluated',
+  'platform.legacy_flags.retirement_blocked',
 ] as const;
 
 export type PlatformAuditAction = (typeof PLATFORM_ACTIONS)[number];

--- a/apps/web/src/lib/platform-health.ts
+++ b/apps/web/src/lib/platform-health.ts
@@ -10,9 +10,10 @@ import {
 } from '@aros/core-services';
 import { parseEnvDiagnostics } from '@aros/config';
 import { prisma } from './db';
-import { resolveOperatorFlagsForOrganization } from './operator-org-flags';
+import { deriveLegacyDependenceStatus, resolveOperatorFlagsForOrganization } from './operator-org-flags';
 import type { PlatformHealthReport, RoutePlatformTruth } from '@aros/core-services';
 import { getRecentPlatformAuditEntries, type RecentPlatformAuditEntry } from './operator-platform-audit';
+import { evaluateLegacyRetirementForOperator } from './operator-legacy-retirement';
 
 export interface PlatformHealthApiPayload {
   report: PlatformHealthReport;
@@ -36,9 +37,19 @@ export interface PlatformHealthApiPayload {
     hasLegacyValues: boolean;
     requiresRepair: boolean;
   };
+  legacyRetirement: {
+    currentOrganization: {
+      dependence: ReturnType<typeof deriveLegacyDependenceStatus>;
+      requiresRepair: boolean;
+    };
+    operatorScope: Awaited<ReturnType<typeof evaluateLegacyRetirementForOperator>> | null;
+  };
 }
 
-export async function getPlatformHealthPayload(organizationId?: string): Promise<PlatformHealthApiPayload> {
+export async function getPlatformHealthPayload(
+  organizationId?: string,
+  actorUserId?: string
+): Promise<PlatformHealthApiPayload> {
   const diag = parseEnvDiagnostics(process.env);
   const invalidKeys = Object.keys(diag.fieldErrors).filter(
     (k) => (diag.fieldErrors[k]?.length ?? 0) > 0
@@ -57,6 +68,9 @@ export async function getPlatformHealthPayload(organizationId?: string): Promise
     organizationId != null
       ? await getRecentPlatformAuditEntries(organizationId).catch(() => [])
       : [];
+  const operatorScope = actorUserId ? await evaluateLegacyRetirementForOperator(actorUserId).catch(() => null) : null;
+  const currentDependence = deriveLegacyDependenceStatus(operatorFlagsResolution);
+
   return {
     report,
     envDiagnostics: { valid: diag.valid, invalidKeys },
@@ -70,6 +84,13 @@ export async function getPlatformHealthPayload(organizationId?: string): Promise
       hasScopedEntry: operatorFlagsResolution.hasScopedEntry,
       hasLegacyValues: operatorFlagsResolution.hasLegacyValues,
       requiresRepair: operatorFlagsResolution.source === 'legacy_fallback',
+    },
+    legacyRetirement: {
+      currentOrganization: {
+        dependence: currentDependence,
+        requiresRepair: currentDependence === 'legacy_fallback',
+      },
+      operatorScope,
     },
   };
 }

--- a/packages/core-services/src/operator-diagnostics.ts
+++ b/packages/core-services/src/operator-diagnostics.ts
@@ -607,5 +607,14 @@ export function listOperatorActions(): OperatorActionDescriptor[] {
       pathSuffix: 'repair-legacy-flags',
       available: true,
     },
+    {
+      id: 'evaluate_legacy_retirement',
+      label: 'Evaluate legacy retirement readiness',
+      description:
+        'Produces an evidence report of fallback dependence across organizations this operator can manage. Does not prune shared legacy keys.',
+      method: 'POST',
+      pathSuffix: 'legacy-retirement',
+      available: true,
+    },
   ];
 }


### PR DESCRIPTION
### Motivation
- Make legacy deployment-wide operator-flag dependence measurable and auditable rather than an open-ended compatibility fallback.  
- Give operators a truthful inventory of which organizations still rely on legacy fallback within the operator's manage scope.  
- Provide a deterministic, evidence-gated readiness signal for retirement that never claims global prune safety without provable coverage.  
- Prevent silent regression after repair by preferring scoped truth and surfacing re-entry into fallback as observable, auditable events.

### Description
- Added a small classifier and derived-status primitive `deriveLegacyDependenceStatus` with three values: `scoped_clean`, `legacy_fallback`, and `no_operator_state` (`apps/web/src/lib/operator-org-flags.ts`).  
- Implemented `evaluateLegacyRetirementForOperator` to inventory manageable organizations, emit an operator-scoped readiness payload, and explicitly fail-closed on prune safety (`apps/web/src/lib/operator-legacy-retirement.ts`).  
- Exposed an authenticated operator API `POST /api/org/:organizationId/platform/legacy-retirement` that runs the evaluation, records audit events (`platform.legacy_flags.retirement_evaluated` / `platform.legacy_flags.retirement_blocked`), and returns blocked-prune semantics (`apps/web/src/app/api/org/[organizationId]/platform/legacy-retirement/route.ts`, `apps/web/src/lib/operator-platform-audit.ts`).  
- Threaded actor identity through platform health routes and payloads so UI/routes can include operator-scoped evidence, extended the platform health payload with `legacyRetirement` (current org dependence + optional operator-scope evaluation), and added a UI control to surface readiness and run an explicit evaluation (`apps/web/src/lib/platform-health.ts`, `apps/web/src/components/system/operator-control-plane-client.tsx`, `apps/web/src/app/(dashboard)/system/page.tsx`).

### Testing
- Ran focused unit & route tests with Vitest: `npm run test --workspace=apps/web -- src/lib/operator-product-flags.test.ts src/lib/operator-legacy-retirement.test.ts src/app/api/org/[organizationId]/platform/repair-legacy-flags/route.test.ts src/app/api/org/[organizationId]/platform/legacy-retirement/route.test.ts` and observed all tests pass (`14 passed`).  
- Added new tests covering inventory/readiness behavior and the authorized/blocked retirement endpoint; those tests passed under the same Vitest run.  
- Ran typecheck `npm run typecheck --workspace=apps/web` which failed due to pre-existing, repo-wide TypeScript errors outside the scope of this change; these errors were not introduced by this PR and are noted in the verification output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5e36a57e08328ba68975cc5bd8320)