### PR TITLE
Enforce monthly scan entitlements and add billing usage visibility

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/billing/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/billing/page.tsx
@@ -132,7 +132,21 @@ export default async function BillingPage({ searchParams }: PageProps) {
   const billingResult = await runOrgScopedQuery(
     orgRes,
     async (organizationId) => {
-      const [membership, customer] = await Promise.all([
+      const periodStart = new Date();
+      periodStart.setUTCDate(1);
+      periodStart.setUTCHours(0, 0, 0, 0);
+      const periodEnd = new Date(
+        Date.UTC(
+          periodStart.getUTCFullYear(),
+          periodStart.getUTCMonth() + 1,
+          1,
+          0,
+          0,
+          0,
+          0,
+        ),
+      );
+      const [membership, customer, scansUsedThisMonth] = await Promise.all([
         prisma.membership.findUnique({
           where: {
             userId_organizationId: {
@@ -151,11 +165,23 @@ export default async function BillingPage({ searchParams }: PageProps) {
         prisma.billingCustomer.findUnique({
           where: { organizationId },
         }),
+        prisma.scanRun.count({
+          where: {
+            site: {
+              workspace: { organizationId },
+            },
+            createdAt: {
+              gte: periodStart,
+              lt: periodEnd,
+            },
+          },
+        }),
       ]);
 
       return {
         membership,
         customer,
+        scansUsedThisMonth,
       };
     },
   );
@@ -185,6 +211,13 @@ export default async function BillingPage({ searchParams }: PageProps) {
   const stripeReady = isStripeBillingConfigured();
   const canManageBilling = hasPermission(membership.role, "org:billing");
   const plans = getBillingPlanCards();
+  const scansUsedThisMonth = billingResult.data.scansUsedThisMonth;
+  const scanLimit = subscription?.maxScansPerMonth ?? 3;
+  const scansRemaining = Math.max(scanLimit - scansUsedThisMonth, 0);
+  const usagePercent = Math.min(
+    100,
+    Math.round((scansUsedThisMonth / Math.max(scanLimit, 1)) * 100),
+  );
 
   return (
     <div className="space-y-8 max-w-6xl">
@@ -303,6 +336,35 @@ export default async function BillingPage({ searchParams }: PageProps) {
                 This subscription is set to cancel at period end.
               </p>
             )}
+          </div>
+
+          <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-4">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm font-medium text-slate-900">
+                Verification scan usage
+              </p>
+              <p className="text-xs text-slate-600">
+                {scansUsedThisMonth}/{scanLimit} this month
+              </p>
+            </div>
+            <div
+              className="mt-2 h-2 rounded-full bg-slate-200"
+              role="progressbar"
+              aria-label="Monthly verification scan usage"
+              aria-valuemin={0}
+              aria-valuemax={scanLimit}
+              aria-valuenow={Math.min(scansUsedThisMonth, scanLimit)}
+            >
+              <div
+                className="h-2 rounded-full bg-brand-600"
+                style={{ width: `${usagePercent}%` }}
+              />
+            </div>
+            <p className="mt-2 text-xs text-slate-600">
+              {scansRemaining > 0
+                ? `${scansRemaining} scans remaining in this billing month.`
+                : "You have reached this month’s scan limit. Upgrade to keep running private verification scans."}
+            </p>
           </div>
         </div>
 

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
@@ -28,6 +28,7 @@ export async function startSiteScanAction(
       {
         siteId: ctx.siteId,
         organizationId: ctx.organizationId,
+        monthlyScanLimit: ctx.subscription?.maxScansPerMonth,
         crawlRunId: null,
         trigger: 'operator',
         userId: ctx.user.id,
@@ -75,6 +76,14 @@ export async function startSiteScanAction(
         status: 'queue_unavailable',
         message:
           'Verification queue is unavailable; nothing was queued. Check Redis and workers, then try again.',
+        variant: 'error',
+      };
+    }
+
+    if (result.kind === 'plan_limit_reached') {
+      return {
+        status: 'error',
+        message: `Monthly scan limit reached (${result.usedThisMonth}/${result.monthlyScanLimit}). Upgrade to continue running private verification scans this month.`,
         variant: 'error',
       };
     }
@@ -139,6 +148,7 @@ export async function retryPostCrawlScanKickoffAction(formData: FormData) {
       {
         siteId: ctx.siteId,
         organizationId: ctx.organizationId,
+        monthlyScanLimit: ctx.subscription?.maxScansPerMonth,
         crawlRunId,
         trigger: 'operator',
         userId: ctx.user.id,

--- a/apps/worker/src/jobs/crawl.ts
+++ b/apps/worker/src/jobs/crawl.ts
@@ -37,7 +37,20 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
   const site = await prisma.site.findUnique({
     where: { id: siteId },
     include: {
-      workspace: { select: { organizationId: true } },
+      workspace: {
+        select: {
+          organizationId: true,
+          organization: {
+            select: {
+              subscription: {
+                select: {
+                  maxScansPerMonth: true,
+                },
+              },
+            },
+          },
+        },
+      },
       crawlConfig: { select: { autoScanAfterCrawl: true } },
     },
   });
@@ -266,6 +279,7 @@ export async function handleCrawlJob(job: Job<CrawlJobData>) {
         {
           siteId,
           organizationId: site.workspace.organizationId,
+          monthlyScanLimit: site.workspace.organization.subscription?.maxScansPerMonth ?? null,
           crawlRunId,
           trigger: 'crawl.completed',
           userId: null,

--- a/packages/core-services/src/scan-enqueue.test.ts
+++ b/packages/core-services/src/scan-enqueue.test.ts
@@ -6,7 +6,7 @@ function mockPrisma(overrides: Record<string, unknown> = {}) {
   return {
     site: { findFirst: vi.fn() },
     page: { count: vi.fn() },
-    scanRun: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    scanRun: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn(), count: vi.fn() },
     auditLog: { create: vi.fn() },
     ...overrides,
   } as unknown as PrismaClient;
@@ -23,6 +23,7 @@ describe('enqueueSiteScan', () => {
     const prisma = mockPrisma();
     vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
     vi.mocked(prisma.page.count).mockResolvedValue(2 as never);
+    vi.mocked(prisma.scanRun.count).mockResolvedValue(0 as never);
     vi.mocked(prisma.scanRun.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.scanRun.create).mockResolvedValue({ id: 'sr1' } as never);
     vi.mocked(prisma.auditLog.create).mockResolvedValue({} as never);
@@ -75,6 +76,7 @@ describe('enqueueSiteScan', () => {
     const prisma = mockPrisma();
     vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
     vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.scanRun.count).mockResolvedValue(0 as never);
     vi.mocked(prisma.scanRun.findFirst).mockResolvedValue({ id: 'prev' } as never);
 
     const result = await enqueueSiteScan(
@@ -94,6 +96,7 @@ describe('enqueueSiteScan', () => {
     const prisma = mockPrisma();
     vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
     vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.scanRun.count).mockResolvedValue(0 as never);
     vi.mocked(prisma.scanRun.findFirst).mockResolvedValue({ id: 'active', status: 'PENDING' } as never);
 
     const result = await enqueueSiteScan(
@@ -115,6 +118,7 @@ describe('enqueueSiteScan', () => {
     const prisma = mockPrisma();
     vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
     vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.scanRun.count).mockResolvedValue(0 as never);
     vi.mocked(prisma.scanRun.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.scanRun.create).mockResolvedValue({ id: 'sr-fail' } as never);
     const update = vi.fn().mockResolvedValue({} as never);
@@ -146,6 +150,7 @@ describe('enqueueSiteScan', () => {
     const prisma = mockPrisma();
     vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
     vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.scanRun.count).mockResolvedValue(0 as never);
     vi.mocked(prisma.scanRun.findFirst)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null);
@@ -159,5 +164,24 @@ describe('enqueueSiteScan', () => {
 
     expect(result).toMatchObject({ ok: true, kind: 'queued', scanRunId: 'sr-new' });
     expect(add).toHaveBeenCalled();
+  });
+
+  it('returns plan_limit_reached when monthly scan limit is exhausted', async () => {
+    const prisma = mockPrisma();
+    vi.mocked(prisma.site.findFirst).mockResolvedValue({ id: 's1' } as never);
+    vi.mocked(prisma.page.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.scanRun.count).mockResolvedValue(3 as never);
+
+    const result = await enqueueSiteScan(
+      { prisma, queue: { add: vi.fn(), close: vi.fn() } },
+      { siteId: 's1', organizationId: 'o1', trigger: 'operator', monthlyScanLimit: 3 }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({
+      kind: 'plan_limit_reached',
+      usedThisMonth: 3,
+      monthlyScanLimit: 3,
+    });
   });
 });

--- a/packages/core-services/src/scan-enqueue.ts
+++ b/packages/core-services/src/scan-enqueue.ts
@@ -10,6 +10,7 @@ export type ScanEnqueueTrigger = 'crawl.completed' | 'operator' | 'api';
 export interface EnqueueSiteScanParams {
   siteId: string;
   organizationId: string;
+  monthlyScanLimit?: number | null;
   /** When set, used for idempotency against repeated crawl-completion signals. */
   crawlRunId?: string | null;
   trigger: ScanEnqueueTrigger;
@@ -48,6 +49,14 @@ export type EnqueueSiteScanResult =
     }
   | {
       ok: false;
+      kind: 'plan_limit_reached';
+      usedThisMonth: number;
+      monthlyScanLimit: number;
+      periodStart: Date;
+      periodEnd: Date;
+    }
+  | {
+      ok: false;
       kind: 'internal_error';
       message: string;
     };
@@ -71,7 +80,7 @@ export async function enqueueSiteScan(
   params: EnqueueSiteScanParams
 ): Promise<EnqueueSiteScanResult> {
   const { prisma } = deps;
-  const { siteId, organizationId, crawlRunId, trigger, userId } = params;
+  const { siteId, organizationId, crawlRunId, trigger, userId, monthlyScanLimit } = params;
 
   try {
     const site = await prisma.site.findFirst({
@@ -88,6 +97,29 @@ export async function enqueueSiteScan(
     const pageCount = await prisma.page.count({ where: { siteId } });
     if (pageCount === 0) {
       return { ok: false, kind: 'invalid_target', reason: 'no_pages' };
+    }
+
+    if (monthlyScanLimit && monthlyScanLimit > 0) {
+      const now = new Date();
+      const periodStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      const periodEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+      const usedThisMonth = await prisma.scanRun.count({
+        where: {
+          site: { workspace: { organizationId } },
+          createdAt: { gte: periodStart, lt: periodEnd },
+        },
+      });
+
+      if (usedThisMonth >= monthlyScanLimit) {
+        return {
+          ok: false,
+          kind: 'plan_limit_reached',
+          usedThisMonth,
+          monthlyScanLimit,
+          periodStart,
+          periodEnd,
+        };
+      }
     }
 
     if (crawlRunId) {

--- a/packages/core-services/src/scan-kickoff-persist.ts
+++ b/packages/core-services/src/scan-kickoff-persist.ts
@@ -61,6 +61,19 @@ export async function persistPostCrawlScanKickoffAfterEnqueue(
     return;
   }
 
+  if (result.kind === 'plan_limit_reached') {
+    await prisma.crawlRun.update({
+      where: { id: crawlRunId },
+      data: {
+        postCrawlScanKickoffStatus: 'NOT_REQUESTED',
+        postCrawlScanKickoffDetail: `Monthly scan limit reached (${result.usedThisMonth}/${result.monthlyScanLimit}) for current billing period.`,
+        postCrawlScanKickoffReasonCode: null,
+        postCrawlScanKickoffScanRunId: null,
+      },
+    });
+    return;
+  }
+
   await prisma.crawlRun.update({
     where: { id: crawlRunId },
     data: {


### PR DESCRIPTION
### Motivation

- Ensure plan limits are enforced server-side at the canonical enqueue boundary so paid quotas cannot be bypassed by client behavior. 
- Make plan-limit outcomes explicit and auditable for operator automation and post-crawl workflows. 
- Improve conversion context by surfacing monthly scan usage and remaining capacity on the billing page. 

### Description

- Added `monthlyScanLimit` support to `enqueueSiteScan` and a typed `plan_limit_reached` failure result so the canonical enqueue path enforces monthly scan quotas. 
- Threaded subscription limits into operator-triggered actions and worker post-crawl enqueue calls by passing `monthlyScanLimit` from `ctx.subscription?.maxScansPerMonth` and `site.workspace.organization.subscription?.maxScansPerMonth`. 
- Persisted plan-limit outcomes in `persistPostCrawlScanKickoffAfterEnqueue` by recording a `NOT_REQUESTED` kickoff with a clear machine-readable detail when the monthly limit is reached. 
- Added test coverage for the new plan-limit branch in `packages/core-services/src/scan-enqueue.test.ts` and a billing UI usage meter with accessible `role="progressbar"` indicators in `apps/web/src/app/(dashboard)/settings/billing/page.tsx`. 

### Testing

- Ran `npm install` which completed successfully. 
- Ran `npm run lint`; lint completed with pre-existing repository warnings (no new errors introduced). 
- Ran `npm run typecheck`; this failed due to pre-existing, repo-wide type/export and module-resolution issues not introduced by this change. 
- Ran unit tests for the modified core service: `npm run test --workspace=packages/core-services -- scan-enqueue.test.ts` — all tests passed for that file. 
- Ran affected frontend tests: `npm run test --workspace=apps/web -- src/app/(dashboard)/sites/[siteId]/actions.test.ts` — this test suite had failures related to an existing `NEXT_REDIRECT` expectation mismatch; `src/app/api/ai-copilot/route.test.ts` also failed due to incomplete test mocks on existing modules. 
- Attempted `npm run build` for the web app; build failed due to pre-existing missing dependencies/module-resolution errors (e.g., `sanitize-html`, ESM path issues in shared package). 

Notes: the change is focused and server-enforced; full end-to-end verification (worker + Redis + DB + Stripe webhook) requires the infra environment and resolution of existing repo-wide type/build issues before a complete green pipeline can be achieved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdd7a3ae9c83288a94fcaf8d93244b)