### PR TITLE
Normalize app base URL and use in Stripe checkout for credits; add tests

### DIFF
--- a/apps/web/src/app/api/credits/route.ts
+++ b/apps/web/src/app/api/credits/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
 import { requireOrgAccess } from "@/lib/auth-guard";
 import { apiSuccess, apiError } from "@/lib/api-utils";
+import { getAppBaseUrl } from "@/lib/billing";
 import { ApiError } from "@aros/shared";
 
 const purchaseSchema = z.object({
@@ -26,7 +27,7 @@ const CREDIT_PACKS: Record<
  */
 export async function GET(request: Request) {
   try {
-    const user = await requireSession();
+    await requireSession();
     const { searchParams } = new URL(request.url);
     const organizationId = searchParams.get("organizationId");
 
@@ -80,7 +81,7 @@ export async function GET(request: Request) {
  */
 export async function POST(request: Request) {
   try {
-    const user = await requireSession();
+    await requireSession();
     const body = await request.json();
     const parsed = purchaseSchema.parse(body);
 
@@ -120,6 +121,7 @@ export async function POST(request: Request) {
 
       if (Stripe) {
         const client = new Stripe(stripeSecret);
+        const appBaseUrl = getAppBaseUrl();
 
         const session = await client.checkout.sessions.create({
           customer: billingCustomer.stripeCustomerId,
@@ -142,8 +144,8 @@ export async function POST(request: Request) {
             creditPack: parsed.pack,
             creditAmount: String(pack.credits),
           },
-          success_url: `${process.env.NEXTAUTH_URL}/settings/billing?credits=success`,
-          cancel_url: `${process.env.NEXTAUTH_URL}/settings/billing?credits=cancelled`,
+          success_url: `${appBaseUrl}/settings/billing?credits=success`,
+          cancel_url: `${appBaseUrl}/settings/billing?credits=cancelled`,
         });
 
         return apiSuccess({ checkoutUrl: session.url });

--- a/apps/web/src/lib/billing.test.ts
+++ b/apps/web/src/lib/billing.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getAppBaseUrl } from './billing';
+
+const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+const originalVercelUrl = process.env.VERCEL_URL;
+
+afterEach(() => {
+  if (originalNextAuthUrl === undefined) {
+    delete process.env.NEXTAUTH_URL;
+  } else {
+    process.env.NEXTAUTH_URL = originalNextAuthUrl;
+  }
+
+  if (originalVercelUrl === undefined) {
+    delete process.env.VERCEL_URL;
+  } else {
+    process.env.VERCEL_URL = originalVercelUrl;
+  }
+});
+
+describe('getAppBaseUrl', () => {
+  it('prefers NEXTAUTH_URL when configured', () => {
+    process.env.NEXTAUTH_URL = 'https://app.aros.dev/some/path?with=query';
+    process.env.VERCEL_URL = 'preview.aros.dev';
+
+    expect(getAppBaseUrl()).toBe('https://app.aros.dev');
+  });
+
+  it('falls back to VERCEL_URL when NEXTAUTH_URL is missing', () => {
+    delete process.env.NEXTAUTH_URL;
+    process.env.VERCEL_URL = 'preview.aros.dev';
+
+    expect(getAppBaseUrl()).toBe('https://preview.aros.dev');
+  });
+
+  it('uses localhost fallback when env vars are missing', () => {
+    delete process.env.NEXTAUTH_URL;
+    delete process.env.VERCEL_URL;
+
+    expect(getAppBaseUrl()).toBe('http://localhost:3000');
+  });
+
+  it('falls back when NEXTAUTH_URL is not a valid url', () => {
+    process.env.NEXTAUTH_URL = 'not-a-url';
+    process.env.VERCEL_URL = 'preview.aros.dev';
+
+    expect(getAppBaseUrl()).toBe('https://preview.aros.dev');
+  });
+
+  it('falls back when NEXTAUTH_URL protocol is unsupported', () => {
+    process.env.NEXTAUTH_URL = 'ftp://app.aros.dev';
+    delete process.env.VERCEL_URL;
+
+    expect(getAppBaseUrl()).toBe('http://localhost:3000');
+  });
+});

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -23,15 +23,27 @@ export function getBillingPlanCards() {
 }
 
 export function getAppBaseUrl(): string {
-  if (process.env.NEXTAUTH_URL) {
-    return process.env.NEXTAUTH_URL;
-  }
+  const normalizedNextAuthUrl = normalizeConfiguredBaseUrl(process.env.NEXTAUTH_URL);
+  if (normalizedNextAuthUrl) return normalizedNextAuthUrl;
 
-  if (process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
-  }
+  const normalizedVercelUrl = normalizeConfiguredBaseUrl(
+    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined,
+  );
+  if (normalizedVercelUrl) return normalizedVercelUrl;
 
   return 'http://localhost:3000';
+}
+
+function normalizeConfiguredBaseUrl(input: string | undefined): string | null {
+  if (!input) return null;
+
+  try {
+    const parsed = new URL(input);
+    if (!['http:', 'https:'].includes(parsed.protocol)) return null;
+    return parsed.origin;
+  } catch {
+    return null;
+  }
 }
 
 export function isStripeBillingConfigured(): boolean {


### PR DESCRIPTION
### Motivation

- Ensure generation of deterministic, safe application base URLs for redirects (used by Stripe checkout) rather than relying on raw `NEXTAUTH_URL` or `VERCEL_URL` values.
- Avoid runtime issues when `NEXTAUTH_URL` is malformed and failover to sensible defaults during local development.
- Fix a lint/unused variable by not assigning `requireSession()` return value when it is unused.

### Description

- Added `getAppBaseUrl()` in `apps/web/src/lib/billing.ts` that normalizes and validates `NEXTAUTH_URL` and `VERCEL_URL`, falling back to `http://localhost:3000` when needed, and extracted a `normalizeConfiguredBaseUrl()` helper to validate origin and protocol.
- Updated the credits API at `apps/web/src/app/api/credits/route.ts` to import and use `getAppBaseUrl()` for `success_url` and `cancel_url` in Stripe checkout sessions instead of directly using `NEXTAUTH_URL`, and removed unused `user` assignments after `requireSession()` calls.
- Added unit tests in `apps/web/src/lib/billing.test.ts` covering `getAppBaseUrl()` behavior across `NEXTAUTH_URL` and `VERCEL_URL` permutations.

### Testing

- Added and ran unit tests for `getAppBaseUrl()` with `vitest` via the repository test suite, and the new tests passed.
- Existing automated checks (typechecks/tests) were run as part of the test command and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdd7b3e51c83289424a22c0853e4a8)