### PR TITLE
Productize proof summaries: canonical proof contract + findings/scan/report surfaces

### DIFF
--- a/apps/web/src/app/(dashboard)/findings/page.tsx
+++ b/apps/web/src/app/(dashboard)/findings/page.tsx
@@ -12,6 +12,7 @@ import { RouteReliabilityNotice } from "@/components/reliability/route-reliabili
 import { hasPermission } from "@aros/config";
 import { StatusBadge, EmptyState } from "@aros/ui";
 import { getAutomationEvidenceFreshnessDescriptor } from "@/lib/findings/evidence-freshness";
+import { buildFindingProofSummary } from "@/lib/findings/proof-summary";
 
 type FindingListRow = Prisma.CanonicalFindingGetPayload<{
   include: {
@@ -22,6 +23,11 @@ type FindingListRow = Prisma.CanonicalFindingGetPayload<{
 }>;
 
 export const metadata = { title: "Findings - AROS" };
+const ACTIVE_FINDING_STATUSES: FindingStatus[] = [
+  "OPEN",
+  "ACKNOWLEDGED",
+  "IN_PROGRESS",
+];
 
 interface SearchParams {
   page?: string;
@@ -154,10 +160,55 @@ export default async function FindingsPage({
         select: { completedAt: true },
       }),
     ]);
+    const ruleIds = Array.from(new Set(findings.map((finding) => finding.ruleId)));
+    const familyAggregates =
+      ruleIds.length === 0
+        ? []
+        : await prisma.canonicalFinding.groupBy({
+            by: ["ruleId"],
+            where: {
+              site: {
+                workspace: { organizationId },
+                ...(params.siteId ? { id: params.siteId } : {}),
+              },
+              ruleId: { in: ruleIds },
+            },
+            _count: { _all: true },
+            _max: { lastSeenAt: true },
+          });
+    const activeFamilyAggregates =
+      ruleIds.length === 0
+        ? []
+        : await prisma.canonicalFinding.groupBy({
+            by: ["ruleId"],
+            where: {
+              site: {
+                workspace: { organizationId },
+                ...(params.siteId ? { id: params.siteId } : {}),
+              },
+              ruleId: { in: ruleIds },
+              status: { in: ACTIVE_FINDING_STATUSES },
+            },
+            _count: { _all: true },
+          });
+
+    const familySummaryByRuleId = Object.fromEntries(
+      familyAggregates.map((agg) => [
+        agg.ruleId,
+        {
+          totalFindings: agg._count._all,
+          activeFindings:
+            activeFamilyAggregates.find((active) => active.ruleId === agg.ruleId)
+              ?._count._all ?? 0,
+          lastSeenAt: agg._max.lastSeenAt ?? null,
+        },
+      ]),
+    );
     return {
       findings,
       total,
       latestCompletedScanCompletedAt: latestCompletedScan?.completedAt ?? null,
+      familySummaryByRuleId,
     };
   });
 
@@ -178,7 +229,8 @@ export default async function FindingsPage({
     );
   }
 
-  const { findings, total, latestCompletedScanCompletedAt } = listResult.data;
+  const { findings, total, latestCompletedScanCompletedAt, familySummaryByRuleId } =
+    listResult.data;
   const totalPages = Math.ceil(total / limit);
 
   return (
@@ -302,6 +354,7 @@ export default async function FindingsPage({
               finding={finding}
               latestCompletedScanCompletedAt={latestCompletedScanCompletedAt}
               jobPipelinesHealthy={platformTruth.flags.jobPipelinesHealthy}
+              familySummary={familySummaryByRuleId[finding.ruleId]}
             />
           ))}
         </div>
@@ -346,10 +399,16 @@ function FindingRow({
   finding,
   latestCompletedScanCompletedAt,
   jobPipelinesHealthy,
+  familySummary,
 }: {
   finding: FindingListRow;
   latestCompletedScanCompletedAt: Date | null;
   jobPipelinesHealthy: boolean;
+  familySummary?: {
+    totalFindings: number;
+    activeFindings: number;
+    lastSeenAt: Date | null;
+  };
 }) {
   const freshness = getAutomationEvidenceFreshnessDescriptor({
     evidenceSource: finding.evidenceSource,
@@ -362,6 +421,15 @@ function FindingRow({
     freshness?.tone === "warning"
       ? "bg-amber-50 text-amber-700 border border-amber-200"
       : "bg-slate-100 text-slate-700 border border-slate-200";
+  const proofSummary = buildFindingProofSummary({
+    evidenceSummary: finding.evidenceSummary,
+    provenance: finding.provenance,
+    firstSeenAt: finding.firstSeenAt,
+    lastSeenAt: finding.lastSeenAt,
+    reopenedCount: finding.reopenedCount,
+  });
+  const proofCompletenessScore =
+    Object.values(proofSummary.completeness).filter(Boolean).length;
 
   return (
     <article className="card hover:shadow-md transition-shadow">
@@ -404,12 +472,31 @@ function FindingRow({
                   {finding.cluster.name}
                 </span>
               )}
+              <span
+                className={`badge ${
+                  proofCompletenessScore >= 4
+                    ? "bg-emerald-50 text-emerald-700 border border-emerald-200"
+                    : "bg-amber-50 text-amber-700 border border-amber-200"
+                }`}
+                title="Compact proof completeness across summary, verification status, page URL, and lineage metadata."
+              >
+                Proof completeness {proofCompletenessScore}/5
+              </span>
+              <span className="badge bg-white text-slate-700 border border-slate-200">
+                {proofSummary.changedSinceLastRun.replaceAll("_", " ")}
+              </span>
             </div>
             <p className="text-sm font-medium text-slate-900">
               {finding.description}
             </p>
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs text-slate-500">
               <span>{finding._count.occurrences} occurrences</span>
+              {familySummary && (
+                <span>
+                  Family: {familySummary.totalFindings} total /{" "}
+                  {familySummary.activeFindings} active
+                </span>
+              )}
               <span>Site: {finding.site.name}</span>
               <span>
                 First seen: {finding.firstSeenAt.toLocaleDateString()}
@@ -418,6 +505,14 @@ function FindingRow({
                 <span>
                   Last verified: {finding.lastVerifiedAt.toLocaleDateString()}
                 </span>
+              )}
+              {familySummary?.lastSeenAt && (
+                <span>
+                  Family last seen: {familySummary.lastSeenAt.toLocaleDateString()}
+                </span>
+              )}
+              {proofSummary.lineage.scanRunId && (
+                <span>Lineage scan: {proofSummary.lineage.scanRunId}</span>
               )}
               {finding.wcagTags.length > 0 && (
                 <span>WCAG: {finding.wcagTags.join(", ")}</span>

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
@@ -19,6 +19,7 @@ import {
   getSiteVerificationStatus,
   getPostCrawlScanEnqueueFailureHint,
 } from "@/lib/sites/verification-status";
+import { buildFindingProofSummary } from "@/lib/findings/proof-summary";
 import { startCrawlAction } from "./actions";
 import {
   startSiteScanAction,
@@ -170,6 +171,7 @@ export default async function SiteDetailPage({
     findings,
     pageCountForScan,
     verificationExtras,
+    findingsForRecentScanProof,
   ] = await Promise.all([
     prisma.crawlRun.findMany({
       where: { siteId },
@@ -234,7 +236,41 @@ export default async function SiteDetailPage({
         };
       }
     })(),
+    prisma.canonicalFinding.findMany({
+      where: { siteId, lastScanRunId: { in: site.scanRuns.map((scan) => scan.id) } },
+      select: {
+        lastScanRunId: true,
+        evidenceSummary: true,
+        provenance: true,
+        firstSeenAt: true,
+        lastSeenAt: true,
+        reopenedCount: true,
+      },
+    }),
   ]);
+  const proofByScanRunId: Record<
+    string,
+    { complete: number; incomplete: number; regressed: number }
+  > = {};
+  for (const finding of findingsForRecentScanProof) {
+    if (!finding.lastScanRunId) continue;
+    const proof = buildFindingProofSummary({
+      evidenceSummary: finding.evidenceSummary,
+      provenance: finding.provenance,
+      firstSeenAt: finding.firstSeenAt,
+      lastSeenAt: finding.lastSeenAt,
+      reopenedCount: finding.reopenedCount,
+    });
+    const completenessCount = Object.values(proof.completeness).filter(Boolean).length;
+    const bucket = (proofByScanRunId[finding.lastScanRunId] ??= {
+      complete: 0,
+      incomplete: 0,
+      regressed: 0,
+    });
+    if (completenessCount >= 4) bucket.complete += 1;
+    else bucket.incomplete += 1;
+    if (proof.changedSinceLastRun === "regressed") bucket.regressed += 1;
+  }
 
   const { verificationStatus, postCrawlEnqueueHint, verificationLoadError } =
     verificationExtras;
@@ -547,6 +583,18 @@ export default async function SiteDetailPage({
                   </th>
                   <th
                     scope="col"
+                    className="pb-2 text-left font-medium text-slate-500"
+                  >
+                    Proof snapshot
+                  </th>
+                  <th
+                    scope="col"
+                    className="pb-2 text-right font-medium text-slate-500"
+                  >
+                    Changed
+                  </th>
+                  <th
+                    scope="col"
                     className="pb-2 text-right font-medium text-slate-500"
                   >
                     Started
@@ -554,7 +602,13 @@ export default async function SiteDetailPage({
                 </tr>
               </thead>
               <tbody>
-                {recentScans.map((scan) => (
+                {recentScans.map((scan, index) => {
+                  const previous = recentScans[index + 1];
+                  const change = previous
+                    ? scan.violationsFound - previous.violationsFound
+                    : null;
+                  const proofSnapshot = proofByScanRunId[scan.id];
+                  return (
                   <tr key={scan.id} className="border-b border-slate-100">
                     <td className="py-2">
                       <span
@@ -578,11 +632,34 @@ export default async function SiteDetailPage({
                     <td className="py-2 text-right text-slate-600">
                       {scan.violationsFound}
                     </td>
+                    <td className="py-2 text-left text-slate-600 text-xs">
+                      {proofSnapshot ? (
+                        <span>
+                          {proofSnapshot.complete} complete · {proofSnapshot.incomplete} incomplete
+                          {proofSnapshot.regressed > 0
+                            ? ` · ${proofSnapshot.regressed} regressed`
+                            : ""}
+                        </span>
+                      ) : (
+                        <span className="text-slate-400">No linked finding lineage yet</span>
+                      )}
+                    </td>
+                    <td className="py-2 text-right text-slate-600">
+                      {change == null ? (
+                        <span className="text-slate-400">—</span>
+                      ) : change > 0 ? (
+                        <span className="text-red-700">+{change}</span>
+                      ) : change < 0 ? (
+                        <span className="text-emerald-700">{change}</span>
+                      ) : (
+                        <span className="text-slate-500">0</span>
+                      )}
+                    </td>
                     <td className="py-2 text-right text-slate-500">
                       {scan.startedAt?.toLocaleString() ?? "-"}
                     </td>
                   </tr>
-                ))}
+                )})}
               </tbody>
             </table>
           </div>

--- a/apps/web/src/app/api/reports/route.ts
+++ b/apps/web/src/app/api/reports/route.ts
@@ -7,6 +7,7 @@ import {
   collectPlatformHealth,
   buildRoutePlatformTruth,
 } from "@aros/core-services";
+import { buildFindingProofSummary } from "@/lib/findings/proof-summary";
 
 export async function GET(request: Request) {
   try {
@@ -99,6 +100,28 @@ export async function GET(request: Request) {
           imported: findings.filter((f) => f.evidenceSource === "IMPORTED")
             .length,
         },
+        proofCompleteness: {
+          complete: findings.filter((f) => {
+            const summary = buildFindingProofSummary({
+              evidenceSummary: f.evidenceSummary,
+              provenance: f.provenance,
+              firstSeenAt: f.firstSeenAt,
+              lastSeenAt: f.lastSeenAt,
+              reopenedCount: f.reopenedCount,
+            });
+            return Object.values(summary.completeness).filter(Boolean).length >= 4;
+          }).length,
+          partial: findings.filter((f) => {
+            const summary = buildFindingProofSummary({
+              evidenceSummary: f.evidenceSummary,
+              provenance: f.provenance,
+              firstSeenAt: f.firstSeenAt,
+              lastSeenAt: f.lastSeenAt,
+              reopenedCount: f.reopenedCount,
+            });
+            return Object.values(summary.completeness).filter(Boolean).length < 4;
+          }).length,
+        },
       },
       findings: findings.map((f) => ({
         id: f.id,
@@ -123,6 +146,13 @@ export async function GET(request: Request) {
         lastVerifiedAt: f.lastVerifiedAt,
         lastScanRunId: f.lastScanRunId,
         reopenedCount: f.reopenedCount,
+        proofSummary: buildFindingProofSummary({
+          evidenceSummary: f.evidenceSummary,
+          provenance: f.provenance,
+          firstSeenAt: f.firstSeenAt,
+          lastSeenAt: f.lastSeenAt,
+          reopenedCount: f.reopenedCount,
+        }),
         evidenceCount: f.evidenceRecords.length,
         latestVerification: f.verificationRuns[0]
           ? {

--- a/apps/web/src/lib/findings/proof-summary.test.ts
+++ b/apps/web/src/lib/findings/proof-summary.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildFindingProofSummary } from "./proof-summary";
+
+describe("buildFindingProofSummary", () => {
+  it("extracts completeness and lineage fields", () => {
+    const summary = buildFindingProofSummary({
+      evidenceSummary: {
+        latestObservationAt: "2026-04-01T10:00:00.000Z",
+        latestVerificationStatus: "FAILED",
+        pageUrl: "https://example.com",
+      },
+      provenance: {
+        sourceType: "SCAN",
+        scanRunId: "scan_123",
+        rawViolationId: "raw_456",
+        pageId: "page_789",
+      },
+      firstSeenAt: new Date("2026-04-01T10:00:00.000Z"),
+      lastSeenAt: new Date("2026-04-01T10:00:00.000Z"),
+      reopenedCount: 0,
+    });
+
+    expect(summary.completeness.hasSummary).toBe(true);
+    expect(summary.completeness.hasLineage).toBe(true);
+    expect(summary.lineage.scanRunId).toBe("scan_123");
+    expect(summary.changedSinceLastRun).toBe("newly_detected");
+  });
+
+  it("marks regressed when reopened", () => {
+    const summary = buildFindingProofSummary({
+      evidenceSummary: null,
+      provenance: null,
+      firstSeenAt: new Date("2026-03-01T10:00:00.000Z"),
+      lastSeenAt: new Date("2026-04-01T10:00:00.000Z"),
+      reopenedCount: 1,
+    });
+
+    expect(summary.completeness.hasSummary).toBe(false);
+    expect(summary.changedSinceLastRun).toBe("regressed");
+  });
+});

--- a/apps/web/src/lib/findings/proof-summary.ts
+++ b/apps/web/src/lib/findings/proof-summary.ts
@@ -1,0 +1,84 @@
+type JsonRecord = Record<string, unknown>;
+
+export interface FindingProofSummary {
+  completeness: {
+    hasSummary: boolean;
+    hasLatestObservationTimestamp: boolean;
+    hasVerificationStatus: boolean;
+    hasPageUrl: boolean;
+    hasLineage: boolean;
+  };
+  lineage: {
+    sourceType: string | null;
+    scanRunId: string | null;
+    rawViolationId: string | null;
+    pageId: string | null;
+    pageUrl: string | null;
+  };
+  latestVerificationStatus: string | null;
+  latestObservationAt: string | null;
+  changedSinceLastRun: "newly_detected" | "regressed" | "persistent" | "unknown";
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export function buildFindingProofSummary(input: {
+  evidenceSummary: unknown;
+  provenance: unknown;
+  firstSeenAt: Date;
+  lastSeenAt: Date;
+  reopenedCount: number;
+}): FindingProofSummary {
+  const evidenceSummary = asRecord(input.evidenceSummary);
+  const provenance = asRecord(input.provenance);
+
+  const latestObservationAt = asString(evidenceSummary?.latestObservationAt);
+  const latestVerificationStatus = asString(
+    evidenceSummary?.latestVerificationStatus,
+  );
+  const summaryPageUrl = asString(evidenceSummary?.pageUrl);
+
+  const sourceType = asString(provenance?.sourceType);
+  const scanRunId = asString(provenance?.scanRunId);
+  const rawViolationId = asString(provenance?.rawViolationId);
+  const pageId = asString(provenance?.pageId);
+  const provenancePageUrl = asString(provenance?.pageUrl);
+
+  let changedSinceLastRun: FindingProofSummary["changedSinceLastRun"] = "unknown";
+  if (input.reopenedCount > 0) {
+    changedSinceLastRun = "regressed";
+  } else if (input.firstSeenAt.getTime() === input.lastSeenAt.getTime()) {
+    changedSinceLastRun = "newly_detected";
+  } else if (input.lastSeenAt.getTime() > input.firstSeenAt.getTime()) {
+    changedSinceLastRun = "persistent";
+  }
+
+  return {
+    completeness: {
+      hasSummary: evidenceSummary != null,
+      hasLatestObservationTimestamp: latestObservationAt != null,
+      hasVerificationStatus: latestVerificationStatus != null,
+      hasPageUrl: summaryPageUrl != null || provenancePageUrl != null,
+      hasLineage:
+        sourceType != null || scanRunId != null || rawViolationId != null,
+    },
+    lineage: {
+      sourceType,
+      scanRunId,
+      rawViolationId,
+      pageId,
+      pageUrl: summaryPageUrl ?? provenancePageUrl,
+    },
+    latestVerificationStatus,
+    latestObservationAt,
+    changedSinceLastRun,
+  };
+}

--- a/docs/internal/GO_LIVE_READINESS_CHECKLIST.md
+++ b/docs/internal/GO_LIVE_READINESS_CHECKLIST.md
@@ -1,0 +1,31 @@
+# Go-live readiness checklist
+
+Last updated: 2026-04-03.
+
+## Product-system checks
+
+- [ ] Findings list surfaces proof completeness and recurring family summary.
+- [ ] Site scan history surfaces proof snapshot and violation delta.
+- [ ] Report export includes proof summary + completeness totals.
+- [ ] Public claims avoid conformance guarantees and match implementation.
+
+## Commercial checks
+
+- [ ] Paid-only routes fail-closed server-side.
+- [ ] Billing page shows status and actionable next steps.
+- [ ] Plan/limit language matches current subscription fields.
+
+## Reliability + trust checks
+
+- [ ] Platform degradation banners appear when dependencies are unhealthy.
+- [ ] No empty states imply “healthy” when data is unavailable.
+- [ ] Tenant-scoped queries are used for dashboard, findings, and site routes.
+
+## Verification gate
+
+- [ ] `npm run lint`
+- [ ] `npm run typecheck`
+- [ ] `npm run test`
+- [ ] `npm run build`
+
+If any check fails, classify as pre-existing vs introduced before release decision.

--- a/docs/internal/ONBOARDING_RUNBOOK.md
+++ b/docs/internal/ONBOARDING_RUNBOOK.md
@@ -1,0 +1,37 @@
+# FlexibleAccessible onboarding runbook (operator-first)
+
+Last updated: 2026-04-03.
+
+## Objective
+
+Get a new workspace from account creation to first meaningful proof artifact with no hidden prerequisites.
+
+## Deterministic path
+
+1. **Auth + org membership**
+   - User signs in.
+   - Dashboard resolves organization membership via scoped boundary checks.
+   - If membership missing, UI shows explicit blocked state.
+2. **Add first site**
+   - Operator uses `/sites/new`.
+   - Validation errors are rendered with accessible labels and state.
+3. **Run crawl / scan**
+   - Operator triggers crawl or scan from site detail.
+   - If queue/worker degraded, route reliability notices and operator hints appear.
+4. **Triage findings**
+   - Findings list shows severity, truth status, freshness, proof completeness, and family-level counts.
+5. **Export proofpack**
+   - Paid orgs can call `/api/reports` for JSON/CSV export including proof summary and lineage.
+
+## Explicit degraded states that must remain visible
+
+- Platform blocked (database/session unavailable).
+- Organization context resolution failure.
+- Worker/queue degradation (automation freshness degraded).
+- No scans or no findings yet.
+
+## Support handoff checklist
+
+- Confirm `organizationId`, `siteId`, and most recent `scanRunId`.
+- Capture screenshot of findings row badges (freshness + completeness + change state).
+- Confirm billing entitlement reason when paid features are blocked.

--- a/docs/internal/PRICING_AND_PACKAGING_MATRIX.md
+++ b/docs/internal/PRICING_AND_PACKAGING_MATRIX.md
@@ -1,0 +1,34 @@
+# FlexibleAccessible pricing and packaging matrix (implementation-aligned)
+
+Last updated: 2026-04-03.
+
+## Canonical enforcement source
+
+- Server-side entitlement gates are enforced through `requireOrgAccess(..., { requirePaid: true })` and `getEntitlementState(...)`.
+- UI upsell messaging uses `EntitlementWall`, but client rendering is not the source of truth.
+
+## Plan model (current code reality)
+
+| Package | Intended buyer | Enforced capabilities | Limits surfaced in billing UI |
+| --- | --- | --- | --- |
+| Free / Trial | Evaluation, single operator | No paid-only routes (`requirePaid`) | Domains, pages per crawl, scans per month, seats |
+| Paid | Team operations | Reports export, remediation + AI workflows, billing controls | Same limits with higher ceilings |
+| Enterprise | Procurement/security review | Same server-enforced paid capabilities + contract controls outside app | Contractual overrides currently represented by subscription fields |
+
+## Feature-to-entitlement mapping
+
+- **Reports export API** (`/api/reports`) is paid-only and fail-closed.
+- **AI copilot + remediation actions** are paid-only.
+- **Billing visibility** shows active status, cancellation window, and limits, so downgrade risk is operator-visible.
+
+## Packaging truth constraints
+
+- Public copy must describe evidence as **testing evidence**, not legal conformance guarantee.
+- Any claim about proof lineage must map to canonical finding provenance + evidence summary fields.
+- Any “automation freshness” claim must reflect platform truth flags and scan recency.
+
+## Gaps to close next
+
+1. Add metered usage events for proof export volume (if pricing depends on exports).
+2. Add explicit grace-period UX language tied to subscription status enum.
+3. Publish externally-visible pricing table only from this mapping file (or generated derivative).

--- a/docs/internal/SUPPORT_AND_BILLING_OPS.md
+++ b/docs/internal/SUPPORT_AND_BILLING_OPS.md
@@ -1,0 +1,38 @@
+# Support + billing operations guide
+
+Last updated: 2026-04-03.
+
+## Triage order for “feature blocked” tickets
+
+1. **Authz check**: user role has permission for route/action.
+2. **Entitlement check**: server-side `requirePaid` gate decision and reason.
+3. **Subscription state**: status, period end, cancel-at-period-end.
+4. **Platform reliability**: job pipeline health and worker status.
+
+Never resolve a ticket as “UI bug” until these server truth checks pass.
+
+## Common operator questions
+
+### “Why can’t I export reports?”
+
+- Verify route is `/api/reports` and returns 403 with entitlement reason when unpaid.
+- Direct operator to billing settings where plan status and limits are visible.
+
+### “Why does evidence look stale?”
+
+- Check findings freshness badge conditions:
+  - newer completed scan exists
+  - pipelines unhealthy
+  - missing verification timestamps
+
+### “Why did an issue come back?”
+
+- Use finding proof summary `changedSinceLastRun = regressed`.
+- Confirm `reopenedCount` and recent verification run outcomes.
+
+## Billing incident runbook
+
+1. Snapshot subscription row (`plan`, `status`, limits, period end).
+2. Replay latest Stripe webhook event in staging if mismatch is suspected.
+3. Re-check protected route with same org context.
+4. Document entitlement reason and next operator action in ticket.


### PR DESCRIPTION
### Motivation
- Create a single canonical interpreter for finding proof/lineage so list surfaces and exports stop reinterpreting evidence locally and operators can triage without opening every record. 
- Surface compact proof completeness, lineage, and change-state at list/scan surfaces so recurring families and regressions are visible for daily operator workflows. 
- Make report exports buyer-friendly by including proof completeness rollups and per-finding proof summaries, and add internal ops docs to align monetization and onboarding with implementation.

### Description
- Added `buildFindingProofSummary(...)` in `apps/web/src/lib/findings/proof-summary.ts` to normalize completeness flags, lineage extraction, and `changedSinceLastRun` semantics, and added `apps/web/src/lib/findings/proof-summary.test.ts` with deterministic unit tests. 
- Updated findings list (`apps/web/src/app/(dashboard)/findings/page.tsx`) to compute family-level aggregates, show a compact proof-completeness badge, changed-state label, lineage scan id, and family counts on each row. 
- Enhanced site scan history (`apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx`) with per-scan proof snapshot rollups (complete/partial/regressed counts) and a run-over-run `Changed` delta column for violations. 
- Extended report export (`apps/web/src/app/api/reports/route.ts`) to include `summary.proofCompleteness` totals and per-finding `proofSummary` to support buyer/procurement trust artifacts. 
- Added internal operational docs under `docs/internal/` covering pricing/packaging truth, onboarding runbook, support & billing ops, and a go-live readiness checklist.

### Testing
- Ran lint with `npm run lint` which completed and reported repository warnings (pre-existing), and the changes do not introduce new lint failures. 
- Ran the new unit tests with `npm run test --workspace=apps/web -- proof-summary` and the proof-summary tests passed. 
- Performed full type and build checks: `npm run typecheck` and `npm run build --workspace=apps/web` failed due to existing, pre-existing TypeScript / Prisma typing and workspace-wide type errors that are unrelated to this PR's logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf1878040083289d2d2140b3f97357)