### PR TITLE
Canonicalize pricing contract and harden Stripe webhook entitlement handling

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,8 +3,10 @@
 import { useState, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { getPublicPlanCards } from "@/lib/public-packaging";
 
 export default function HomePage() {
+  const plans = getPublicPlanCards();
   const [scanDomain, setScanDomain] = useState("");
   const [scanning, setScanning] = useState(false);
   const [scanError, setScanError] = useState("");
@@ -252,12 +254,12 @@ export default function HomePage() {
               </h3>
               <p className="mt-2">
                 <span className="text-3xl font-bold text-slate-900">
-                  ${plan.price}
+                  ${plan.priceMonthly}
                 </span>
-                {plan.price > 0 && <span className="text-slate-500">/mo</span>}
+                {plan.priceMonthly > 0 && <span className="text-slate-500">/mo</span>}
               </p>
               <ul className="mt-4 space-y-2" role="list">
-                {plan.features.map((f) => (
+                {plan.bullets.map((f) => (
                   <li
                     key={f}
                     className="text-sm text-slate-600 flex items-start gap-2"
@@ -339,64 +341,5 @@ const features = [
     title: "Evidence Reporting",
     description:
       "Generate evidence-grade reports with before/after snapshots, reviewer sign-offs, timestamps, and audit trails.",
-  },
-];
-
-const plans = [
-  {
-    name: "Free",
-    price: 0,
-    highlighted: false,
-    features: [
-      "1 site",
-      "50 pages/crawl",
-      "3 scans/month",
-      "1 seat",
-      "Basic scanning",
-    ],
-  },
-  {
-    name: "Starter",
-    price: 49,
-    highlighted: false,
-    features: [
-      "3 sites",
-      "200 pages/crawl",
-      "10 scans/month",
-      "3 seats",
-      "Component clustering",
-      "AI suggestions",
-      "Pay-per-fix credits",
-    ],
-  },
-  {
-    name: "Professional",
-    price: 149,
-    highlighted: true,
-    features: [
-      "10 sites",
-      "1,000 pages/crawl",
-      "50 scans/month",
-      "10 seats",
-      "Review workflows",
-      "Evidence reports",
-      "Jira integration",
-      "AI copilot chat",
-    ],
-  },
-  {
-    name: "Enterprise",
-    price: 499,
-    highlighted: false,
-    features: [
-      "100 sites",
-      "10,000 pages/crawl",
-      "Unlimited scans",
-      "100 seats",
-      "SSO",
-      "Custom integrations",
-      "SLA",
-      "VPAT export",
-    ],
   },
 ];

--- a/apps/web/src/lib/__tests__/stripe-webhook.integration.test.ts
+++ b/apps/web/src/lib/__tests__/stripe-webhook.integration.test.ts
@@ -149,6 +149,43 @@ describeDb('Stripe webhook integration', () => {
     expect(rows).toHaveLength(1);
   });
 
+
+  it('does not silently grant paid entitlements for unknown price ids', async () => {
+    const eventId = `evt_test_${Date.now()}_unknown_price`;
+    const subId = `sub_test_unknown_${Date.now()}`;
+
+    await prisma.subscription.update({
+      where: { organizationId: orgId },
+      data: {
+        plan: 'FREE',
+        maxDomains: 1,
+        maxPagesPerCrawl: 50,
+        maxScansPerMonth: 3,
+        maxSeats: 1,
+        aiEnabled: false,
+        aiTokenLimit: 0,
+      },
+    });
+
+    const payload = subscriptionPayload({
+      id: subId,
+      eventId,
+      customerId: stripeCustomerId,
+      priceId: 'price_unknown_tier',
+      status: 'active',
+    });
+    const raw = JSON.stringify(payload);
+    const sig = signStripePayload(raw, env.webhookSecret);
+
+    const r = await handleStripeWebhookRequest(raw, sig, env, prisma);
+    expect(r).toEqual({ ok: true, duplicate: false });
+
+    const sub = await prisma.subscription.findUnique({ where: { organizationId: orgId } });
+    expect(sub?.plan).toBe('FREE');
+    expect(sub?.maxDomains).toBe(1);
+    expect(sub?.aiEnabled).toBe(false);
+  });
+
   it('downgrades on customer.subscription.deleted', async () => {
     const eventId = `evt_test_${Date.now()}_del`;
     const payload = {

--- a/apps/web/src/lib/public-packaging.test.ts
+++ b/apps/web/src/lib/public-packaging.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { PLANS } from '@aros/config';
+import { getPublicPlanCards } from './public-packaging';
+
+describe('getPublicPlanCards', () => {
+  it('stays aligned with canonical plan limits and avoids unlimited claim drift', () => {
+    const cards = getPublicPlanCards();
+    const enterprise = cards.find((c) => c.tier === 'ENTERPRISE');
+    expect(enterprise).toBeDefined();
+
+    expect(enterprise?.bullets).toContain(
+      `${PLANS.ENTERPRISE.maxScansPerMonth.toLocaleString()} scans per month`,
+    );
+    expect(enterprise?.bullets.join(' ')).not.toMatch(/unlimited scans/i);
+  });
+
+  it('reflects AI access truthfully by plan tier', () => {
+    const cards = getPublicPlanCards();
+    const starter = cards.find((c) => c.tier === 'STARTER');
+    const professional = cards.find((c) => c.tier === 'PROFESSIONAL');
+
+    expect(starter?.bullets).toContain('AI remediation not included');
+    expect(professional?.bullets).toContain(
+      `AI remediation included (${PLANS.PROFESSIONAL.aiTokenLimit.toLocaleString()} tokens/month)`,
+    );
+  });
+});

--- a/apps/web/src/lib/public-packaging.ts
+++ b/apps/web/src/lib/public-packaging.ts
@@ -1,0 +1,35 @@
+import { PLANS, type PlanTier } from '@aros/config';
+
+const PUBLIC_PLAN_ORDER: PlanTier[] = ['FREE', 'STARTER', 'PROFESSIONAL', 'ENTERPRISE'];
+
+export type PublicPlanCard = {
+  tier: PlanTier;
+  name: string;
+  priceMonthly: number;
+  highlighted: boolean;
+  bullets: string[];
+};
+
+export function getPublicPlanCards(): PublicPlanCard[] {
+  return PUBLIC_PLAN_ORDER.map((tier) => {
+    const plan = PLANS[tier];
+    const aiLine = plan.aiEnabled
+      ? `AI remediation included (${plan.aiTokenLimit.toLocaleString()} tokens/month)`
+      : 'AI remediation not included';
+
+    return {
+      tier,
+      name: plan.name,
+      priceMonthly: plan.priceMonthly,
+      highlighted: tier === 'PROFESSIONAL',
+      bullets: [
+        `${plan.maxDomains} ${plan.maxDomains === 1 ? 'site' : 'sites'}`,
+        `${plan.maxPagesPerCrawl.toLocaleString()} pages per crawl`,
+        `${plan.maxScansPerMonth.toLocaleString()} scans per month`,
+        `${plan.maxSeats} ${plan.maxSeats === 1 ? 'seat' : 'seats'}`,
+        aiLine,
+        ...plan.features,
+      ],
+    };
+  });
+}

--- a/apps/web/src/lib/stripe-webhook.ts
+++ b/apps/web/src/lib/stripe-webhook.ts
@@ -1,4 +1,5 @@
 import { createHmac, timingSafeEqual } from 'crypto';
+import { PLANS, type PlanTier } from '@aros/config';
 import type { Prisma, PrismaClient } from '@prisma/client';
 
 export interface StripeWebhookEnv {
@@ -114,6 +115,26 @@ export async function handleStripeWebhookRequest(
   return { ok: true, duplicate: false };
 }
 
+
+function resolvePlanTierFromPriceId(priceId: string | undefined, env: StripeWebhookEnv): Exclude<PlanTier, 'FREE'> | null {
+  if (!priceId) return null;
+  if (priceId === env.priceStarter) return 'STARTER';
+  if (priceId === env.priceProfessional) return 'PROFESSIONAL';
+  if (priceId === env.priceEnterprise) return 'ENTERPRISE';
+  return null;
+}
+
+const statusMap: Record<string, 'ACTIVE' | 'PAST_DUE' | 'CANCELLED' | 'TRIALING'> = {
+  active: 'ACTIVE',
+  past_due: 'PAST_DUE',
+  canceled: 'CANCELLED',
+  trialing: 'TRIALING',
+};
+
+function subscriptionStatusFromStripe(status: string | undefined): 'ACTIVE' | 'PAST_DUE' | 'CANCELLED' | 'TRIALING' {
+  return statusMap[status ?? ''] ?? 'ACTIVE';
+}
+
 async function applySubscriptionUpsert(
   tx: Prisma.TransactionClient,
   subscription: StripeSubscriptionObject,
@@ -127,49 +148,41 @@ async function applySubscriptionUpsert(
   });
   if (!billingCustomer) return;
 
-  const planMap: Record<
-    string,
-    { plan: 'FREE' | 'STARTER' | 'PROFESSIONAL' | 'ENTERPRISE'; maxDomains: number; maxPages: number; maxScans: number; maxSeats: number; aiEnabled: boolean; aiTokenLimit: number }
-  > = {
-    [env.priceStarter]: { plan: 'STARTER', maxDomains: 3, maxPages: 200, maxScans: 10, maxSeats: 3, aiEnabled: false, aiTokenLimit: 0 },
-    [env.priceProfessional]: { plan: 'PROFESSIONAL', maxDomains: 10, maxPages: 1000, maxScans: 50, maxSeats: 10, aiEnabled: true, aiTokenLimit: 100000 },
-    [env.priceEnterprise]: { plan: 'ENTERPRISE', maxDomains: 100, maxPages: 10000, maxScans: 500, maxSeats: 100, aiEnabled: true, aiTokenLimit: 1000000 },
-  };
-
   const priceId = subscription.items?.data?.[0]?.price?.id;
-  const planConfig = priceId ? planMap[priceId] : null;
+  const resolvedPlanTier = resolvePlanTierFromPriceId(priceId, env);
+  const planConfig = resolvedPlanTier ? PLANS[resolvedPlanTier] : null;
 
-  const statusMap: Record<string, 'ACTIVE' | 'PAST_DUE' | 'CANCELLED' | 'TRIALING'> = {
-    active: 'ACTIVE',
-    past_due: 'PAST_DUE',
-    canceled: 'CANCELLED',
-    trialing: 'TRIALING',
-  };
+  if (!resolvedPlanTier && priceId) {
+    console.warn('[stripe-webhook] unknown price id received; preserving existing entitlement where possible', {
+      stripeSubscriptionId: subscription.id,
+      priceId,
+    });
+  }
 
   await tx.subscription.upsert({
     where: { organizationId: billingCustomer.organizationId },
     create: {
       organizationId: billingCustomer.organizationId,
       stripeSubscriptionId: subscription.id,
-      plan: planConfig?.plan ?? 'STARTER',
-      status: statusMap[subscription.status] ?? 'ACTIVE',
-      maxDomains: planConfig?.maxDomains ?? 3,
-      maxPagesPerCrawl: planConfig?.maxPages ?? 200,
-      maxScansPerMonth: planConfig?.maxScans ?? 10,
-      maxSeats: planConfig?.maxSeats ?? 3,
-      aiEnabled: planConfig?.aiEnabled ?? false,
-      aiTokenLimit: planConfig?.aiTokenLimit ?? 0,
+      plan: planConfig?.tier ?? 'FREE',
+      status: subscriptionStatusFromStripe(subscription.status),
+      maxDomains: planConfig?.maxDomains ?? PLANS.FREE.maxDomains,
+      maxPagesPerCrawl: planConfig?.maxPagesPerCrawl ?? PLANS.FREE.maxPagesPerCrawl,
+      maxScansPerMonth: planConfig?.maxScansPerMonth ?? PLANS.FREE.maxScansPerMonth,
+      maxSeats: planConfig?.maxSeats ?? PLANS.FREE.maxSeats,
+      aiEnabled: planConfig?.aiEnabled ?? PLANS.FREE.aiEnabled,
+      aiTokenLimit: planConfig?.aiTokenLimit ?? PLANS.FREE.aiTokenLimit,
       currentPeriodStart: new Date(subscription.current_period_start * 1000),
       currentPeriodEnd: new Date(subscription.current_period_end * 1000),
       cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,
     },
     update: {
       stripeSubscriptionId: subscription.id,
-      plan: planConfig?.plan ?? undefined,
-      status: statusMap[subscription.status] ?? 'ACTIVE',
+      plan: planConfig?.tier ?? undefined,
+      status: subscriptionStatusFromStripe(subscription.status),
       maxDomains: planConfig?.maxDomains,
-      maxPagesPerCrawl: planConfig?.maxPages,
-      maxScansPerMonth: planConfig?.maxScans,
+      maxPagesPerCrawl: planConfig?.maxPagesPerCrawl,
+      maxScansPerMonth: planConfig?.maxScansPerMonth,
       maxSeats: planConfig?.maxSeats,
       aiEnabled: planConfig?.aiEnabled,
       aiTokenLimit: planConfig?.aiTokenLimit,
@@ -192,12 +205,12 @@ async function applySubscriptionDeleted(tx: Prisma.TransactionClient, subscripti
     data: {
       status: 'CANCELLED',
       plan: 'FREE',
-      maxDomains: 1,
-      maxPagesPerCrawl: 50,
-      maxScansPerMonth: 3,
-      maxSeats: 1,
-      aiEnabled: false,
-      aiTokenLimit: 0,
+      maxDomains: PLANS.FREE.maxDomains,
+      maxPagesPerCrawl: PLANS.FREE.maxPagesPerCrawl,
+      maxScansPerMonth: PLANS.FREE.maxScansPerMonth,
+      maxSeats: PLANS.FREE.maxSeats,
+      aiEnabled: PLANS.FREE.aiEnabled,
+      aiTokenLimit: PLANS.FREE.aiTokenLimit,
     },
   });
 }

--- a/docs/internal/GO_LIVE_READINESS_CHECKLIST.md
+++ b/docs/internal/GO_LIVE_READINESS_CHECKLIST.md
@@ -1,0 +1,20 @@
+# Go-Live Readiness Checklist
+
+Last validated: 2026-04-03.
+
+## Monetization
+- [ ] Plan matrix in public page matches `PLANS` config.
+- [ ] Billing UI shows current plan/limits and gateway readiness.
+- [ ] Stripe webhook integration test passes with real DB.
+- [ ] Unknown Stripe price id does not grant paid access.
+
+## Activation + trust
+- [ ] First-run path from signup -> site -> scan -> findings -> report is tested.
+- [ ] Reliability notices appear when DB/queue is degraded.
+- [ ] Evidence report page includes explicit legal framing.
+
+## Quality gates
+- [ ] `npm run lint`
+- [ ] `npm run typecheck`
+- [ ] `npm run test`
+- [ ] `npm run build`

--- a/docs/internal/ONBOARDING_AND_FIRST_VALUE_RUNBOOK.md
+++ b/docs/internal/ONBOARDING_AND_FIRST_VALUE_RUNBOOK.md
@@ -1,0 +1,27 @@
+# Onboarding + First Value Runbook
+
+Last validated: 2026-04-03.
+
+## Goal
+Get a new workspace from signup to first evidence report with no manual operator intervention.
+
+## Deterministic first-value path
+
+1. **Signup/Login**
+   - Create account and organization (default FREE plan).
+2. **Add site**
+   - `/sites/new` validates permissions and plan limits server-side.
+3. **Run scan / crawl**
+   - Site detail route surfaces enqueue failures and degraded queue states.
+4. **Triage findings**
+   - `/findings` exposes status + evidence freshness semantics.
+5. **Generate evidence report**
+   - `/reports` provides org summary + explicit legal non-guarantee statement.
+6. **Upgrade (if private routes/features required)**
+   - `/settings/billing` explains gating reason and next actions.
+
+## Non-negotiable UX truth constraints
+
+- Degraded data-service state must render reliability notices (never empty “healthy” UI).
+- Entitlement failures must include actionable reason + billing route.
+- First-run pages must prefer next-actions over generic blank states.

--- a/docs/internal/PRICING_PACKAGING_MATRIX.md
+++ b/docs/internal/PRICING_PACKAGING_MATRIX.md
@@ -1,0 +1,34 @@
+# Pricing + Packaging Matrix (Code-Aligned)
+
+Last validated: 2026-04-03.
+
+This document is intentionally derived from `packages/config/src/plans.ts` and must remain consistent with server-side entitlement enforcement and Stripe webhook mapping.
+
+## Plan truth source
+
+- Canonical plan limits/features: `packages/config/src/plans.ts`
+- Billing UI cards: `apps/web/src/lib/billing.ts`
+- Public pricing cards: `apps/web/src/lib/public-packaging.ts`
+- Stripe entitlement sync: `apps/web/src/lib/stripe-webhook.ts`
+
+## Current public/commercial tiers
+
+| Tier | Price/mo | Sites | Pages/crawl | Scans/mo | Seats | AI |
+|---|---:|---:|---:|---:|---:|---|
+| Free | $0 | 1 | 50 | 3 | 1 | No |
+| Starter | $49 | 3 | 200 | 10 | 3 | No |
+| Professional | $149 | 10 | 1,000 | 50 | 10 | Yes (100,000 tokens/mo) |
+| Enterprise | $499 | 100 | 10,000 | 500 | 100 | Yes (1,000,000 tokens/mo) |
+
+## Guardrails
+
+- Do **not** claim "unlimited scans" publicly unless config + enforcement both move to unlimited.
+- Unknown Stripe `price_id` must not grant paid access.
+- Paid-route gating is server-side and fail-closed using auth guard checks.
+
+## Release checklist before pricing changes
+
+1. Update `packages/config/src/plans.ts`.
+2. Update Stripe price env mapping (`STRIPE_PRICE_*`) and validate in staging.
+3. Run billing + webhook tests and full `npm run verify`.
+4. Confirm public pricing page text reflects new limits.

--- a/docs/internal/SUPPORT_AND_BILLING_OPS_PLAYBOOK.md
+++ b/docs/internal/SUPPORT_AND_BILLING_OPS_PLAYBOOK.md
@@ -1,0 +1,27 @@
+# Support + Billing Ops Playbook
+
+Last validated: 2026-04-03.
+
+## Common incident classes
+
+1. **Checkout succeeded but access not upgraded yet**
+   - Cause: Stripe webhook delay/failure.
+   - Operator action: verify webhook delivery + `stripeWebhookEvent` row creation.
+2. **User blocked from paid feature unexpectedly**
+   - Cause: subscription status `PAST_DUE`, canceled, or FREE downgrade.
+   - Operator action: inspect `subscription` row and entitlement reason in app.
+3. **Unknown Stripe price id seen**
+   - Cause: missing env mapping or stale product price.
+   - Operator action: fix env + replay event; unknown price intentionally does not grant paid access.
+
+## Triage queries
+
+- Subscription snapshot by org.
+- Billing customer by `organizationId` / `stripeCustomerId`.
+- Webhook idempotency via `stripeWebhookEvent.id`.
+
+## Escalation criteria
+
+- Any suspected cross-tenant data exposure.
+- Any fail-open entitlement or paywall bypass.
+- Any repeated webhook signature failures (possible secret mismatch).

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,5 +7,5 @@ export {
   type Env,
   type EnvDiagnostics,
 } from './env';
-export { PLANS, type PlanConfig } from './plans';
+export { PLANS, type PlanConfig, type PlanTier } from './plans';
 export { PERMISSIONS, hasPermission, type Permission } from './permissions';

--- a/packages/config/src/plans.ts
+++ b/packages/config/src/plans.ts
@@ -1,15 +1,19 @@
+export type PlanTier = 'FREE' | 'STARTER' | 'PROFESSIONAL' | 'ENTERPRISE';
+
 export interface PlanConfig {
   name: string;
-  tier: 'FREE' | 'STARTER' | 'PROFESSIONAL' | 'ENTERPRISE';
+  tier: PlanTier;
   maxDomains: number;
   maxPagesPerCrawl: number;
   maxScansPerMonth: number;
   maxSeats: number;
   features: string[];
   priceMonthly: number;
+  aiEnabled: boolean;
+  aiTokenLimit: number;
 }
 
-export const PLANS: Record<string, PlanConfig> = {
+export const PLANS: Record<PlanTier, PlanConfig> = {
   FREE: {
     name: 'Free',
     tier: 'FREE',
@@ -19,6 +23,8 @@ export const PLANS: Record<string, PlanConfig> = {
     maxSeats: 1,
     features: ['Basic scanning', 'Findings dashboard', 'CSV export'],
     priceMonthly: 0,
+    aiEnabled: false,
+    aiTokenLimit: 0,
   },
   STARTER: {
     name: 'Starter',
@@ -30,10 +36,11 @@ export const PLANS: Record<string, PlanConfig> = {
     features: [
       'Everything in Free',
       'Component clustering',
-      'AI remediation suggestions',
       'GitHub integration',
     ],
     priceMonthly: 49,
+    aiEnabled: false,
+    aiTokenLimit: 0,
   },
   PROFESSIONAL: {
     name: 'Professional',
@@ -51,6 +58,8 @@ export const PLANS: Record<string, PlanConfig> = {
       'Priority support',
     ],
     priceMonthly: 149,
+    aiEnabled: true,
+    aiTokenLimit: 100000,
   },
   ENTERPRISE: {
     name: 'Enterprise',
@@ -61,12 +70,13 @@ export const PLANS: Record<string, PlanConfig> = {
     maxSeats: 100,
     features: [
       'Everything in Professional',
-      'Unlimited scans',
       'Custom integrations',
       'SSO',
       'Dedicated support',
       'SLA',
     ],
     priceMonthly: 499,
+    aiEnabled: true,
+    aiTokenLimit: 1000000,
   },
 };


### PR DESCRIPTION
### Motivation
- Remove drift between canonical plan configuration, public pricing copy, and Stripe webhook entitlement writes to protect against accidental paid-entitlement grants.  
- Make AI entitlement and token limits first-class plan properties so UI, billing, and server logic share one source of truth.  
- Provide ops artifacts and tests so billing behavior is inspectable and auditable by operators.  

### Description
- Centralized plan contract: added `PlanTier`, `aiEnabled`, and `aiTokenLimit` to `packages/config/src/plans.ts` and exported the new type from `@aros/config`.  
- Public packaging adapter: added `apps/web/src/lib/public-packaging.ts` and switched the landing page to consume canonical `PLANS` so public pricing/cards reflect server truth.  
- Hardened Stripe webhook: refactored `apps/web/src/lib/stripe-webhook.ts` to derive limits/features from `PLANS`, resolve price IDs to plan tiers, and intentionally fail-closed for unknown `price_id` values (preserve existing entitlement and avoid silent paid grants).  
- Tests and docs: added `apps/web/src/lib/public-packaging.test.ts`, extended `apps/web/src/lib/__tests__/stripe-webhook.integration.test.ts` to assert unknown-price behavior, and created internal docs under `docs/internal/` (pricing matrix, onboarding runbook, ops playbook, go-live checklist).  

### Testing
- Ran `npm run db:generate` which succeeded and generated Prisma client.  
- Ran targeted tests: `npm run test --workspace=apps/web -- --run src/lib/public-packaging.test.ts src/lib/billing.test.ts src/lib/__tests__/stripe-webhook.integration.test.ts` and the targeted suites passed.  
- Ran lint/typecheck/build: `npm run lint` (completed with repository warnings), `npm run typecheck` (passed), `npm run build` (Next build succeeded).  
- Ran full test suite: `npm run test` which surfaced pre-existing unrelated failures in the web workspace (sanitizer expectations, Playwright test context misuse in Vitest, several route/mock expectation diffs, and worker workspace test exit behavior); these are baseline issues and were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf18ec77588328b72c3d939946a1c9)