### PR TITLE
Harden verification gates, add Prisma drift/import checks, and separate integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,11 @@ jobs:
           REDIS_URL: redis://localhost:6379
         run: npm run db:push && npm run db:seed
 
-      - name: Run Verification (Lint, Typecheck, Test, Build)
+      - name: Run Release Verification (Core + Integration)
         env:
           DATABASE_URL: postgresql://aros_user:aros_password@localhost:5432/aros_test?schema=public
           REDIS_URL: redis://localhost:6379
-        run: npm run verify
+        run: npm run verify:release
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,10 +10,11 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --exclude \"src/**/*.integration.test.ts\"",
     "test:e2e": "playwright test",
     "test:ct": "playwright test -c playwright-ct.config.ts",
-    "test:e2e:update": "playwright test --update-snapshots"
+    "test:e2e:update": "playwright test --update-snapshots",
+    "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts"
   },
   "dependencies": {
     "@aros/config": "*",

--- a/apps/web/src/app/api/__tests__/public-features.test.ts
+++ b/apps/web/src/app/api/__tests__/public-features.test.ts
@@ -16,15 +16,24 @@ describe("Public Scan API", () => {
       "localhost",
     ];
 
-    const domainRegex =
-      /^(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(?:\/.*)?$/;
+    const isValidDomain = (input: string) => {
+      try {
+        const candidate = input.startsWith("http://") || input.startsWith("https://")
+          ? input
+          : `https://${input}`;
+        const parsed = new URL(candidate);
+        return Boolean(parsed.hostname && parsed.hostname.includes("."));
+      } catch {
+        return false;
+      }
+    };
 
     for (const domain of validDomains) {
-      expect(domainRegex.test(domain)).toBe(true);
+      expect(isValidDomain(domain)).toBe(true);
     }
 
     for (const domain of invalidDomains) {
-      expect(domainRegex.test(domain)).toBe(false);
+      expect(isValidDomain(domain)).toBe(false);
     }
   });
 

--- a/apps/web/src/app/api/badge/route.ts
+++ b/apps/web/src/app/api/badge/route.ts
@@ -31,10 +31,15 @@ function getScoreCategory(score: number | null): string {
  */
 /** Basic domain format validation – rejects obvious injection attempts. */
 function isValidDomain(domain: string): boolean {
-  // Max 253 chars per RFC 1035; allow subdomains and ports
   if (domain.length > 253) return false;
-  // Must look like a hostname (optionally with port), no path separators or shell chars
-  return /^[a-zA-Z0-9]([a-zA-Z0-9\-_.]*[a-zA-Z0-9])?(:\d{1,5})?$/.test(domain);
+  if (domain.includes("/") || domain.includes("\\") || domain.includes(" ")) return false;
+
+  try {
+    const parsed = new URL(`https://${domain}`);
+    return Boolean(parsed.hostname && parsed.hostname.includes("."));
+  } catch {
+    return false;
+  }
 }
 
 export async function GET(request: Request) {

--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -9,7 +9,8 @@ export const runtime = "edge";
  * Used as the og:image meta tag on public scan results pages.
  */
 export async function GET(request: NextRequest) {
-  const { searchParams } = request.nextUrl;
+  try {
+    const { searchParams } = request.nextUrl;
   const domain = searchParams.get("domain") ?? "unknown";
   const score = parseInt(searchParams.get("score") ?? "0", 10);
   const critical = parseInt(searchParams.get("critical") ?? "0", 10);
@@ -27,7 +28,7 @@ export async function GET(request: NextRequest) {
           ? "#f97316"
           : "#ef4444";
 
-  return new ImageResponse(
+    return new ImageResponse(
     <div
       style={{
         display: "flex",
@@ -176,5 +177,8 @@ export async function GET(request: NextRequest) {
       width: 1200,
       height: 630,
     },
-  );
+    );
+  } catch {
+    return new Response("Failed to generate OG image", { status: 500 });
+  }
 }

--- a/apps/web/src/app/api/public-scan/route.ts
+++ b/apps/web/src/app/api/public-scan/route.ts
@@ -11,15 +11,25 @@ const PUBLIC_SCAN_MAX_PAGES = 5;
 const RATE_LIMIT_SECONDS = 300; // 5 minutes between scans per IP+domain
 
 const scanSchema = z.object({
-  domain: z
-    .string()
-    .min(1, "Domain is required")
-    .max(253)
-    .regex(
-      /^(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,})(?:\/.*)?$/,
-      "Invalid domain format",
-    ),
+  domain: z.string().min(1, "Domain is required").max(253),
 });
+
+function normalizePublicScanDomain(rawDomain: string): { domain: string; url: string } {
+  const candidate = rawDomain.startsWith("http://") || rawDomain.startsWith("https://")
+    ? rawDomain
+    : `https://${rawDomain}`;
+
+  const parsed = new URL(candidate);
+  if (!parsed.hostname || !parsed.hostname.includes(".")) {
+    throw ApiError.badRequest("Invalid domain format");
+  }
+
+  const normalizedDomain = parsed.hostname.toLowerCase();
+  return {
+    domain: normalizedDomain,
+    url: `${parsed.protocol}//${normalizedDomain}${parsed.pathname === "/" ? "" : parsed.pathname}`
+  };
+}
 
 /**
  * POST /api/public-scan
@@ -32,9 +42,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const parsed = scanSchema.parse(body);
 
-    // Normalize domain: strip protocol and trailing slashes
-    let domain = parsed.domain.replace(/^https?:\/\//, "").replace(/\/+$/, "");
-    const url = domain.startsWith("http") ? domain : `https://${domain}`;
+    const { domain, url } = normalizePublicScanDomain(parsed.domain.trim());
 
     // Rate limit check: hash IP + domain for privacy
     const forwarded = request.headers.get("x-forwarded-for");

--- a/apps/web/src/app/api/webhooks/stripe/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe/route.ts
@@ -14,19 +14,23 @@ function getStripeEnv(): StripeWebhookEnv | null {
 }
 
 export async function POST(request: Request) {
-  const env = getStripeEnv();
-  if (!env) {
-    return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 });
+  try {
+    const env = getStripeEnv();
+    if (!env) {
+      return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 });
+    }
+
+    const body = await request.text();
+    const signature = request.headers.get('stripe-signature');
+
+    const result = await handleStripeWebhookRequest(body, signature, env, prisma);
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.message }, { status: result.status });
+    }
+
+    return NextResponse.json({ received: true, duplicate: result.duplicate });
+  } catch {
+    return NextResponse.json({ error: 'Unhandled webhook error' }, { status: 500 });
   }
-
-  const body = await request.text();
-  const signature = request.headers.get('stripe-signature');
-
-  const result = await handleStripeWebhookRequest(body, signature, env, prisma);
-
-  if (!result.ok) {
-    return NextResponse.json({ error: result.message }, { status: result.status });
-  }
-
-  return NextResponse.json({ received: true, duplicate: result.duplicate });
 }

--- a/apps/web/src/lib/__tests__/stripe-webhook.integration.test.ts
+++ b/apps/web/src/lib/__tests__/stripe-webhook.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@aros/db';
 import {
   handleStripeWebhookRequest,
   signStripePayload,

--- a/apps/web/src/lib/stripe-webhook.ts
+++ b/apps/web/src/lib/stripe-webhook.ts
@@ -1,6 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import { PLANS, type PlanTier } from '@aros/config';
-import type { Prisma, PrismaClient } from '@prisma/client';
+import type { Prisma, PrismaClient } from '@aros/db';
 
 export interface StripeWebhookEnv {
   webhookSecret: string;

--- a/docs/verification-gates.md
+++ b/docs/verification-gates.md
@@ -1,0 +1,26 @@
+# Verification Gate Tiers
+
+## Tier 1 — Core deterministic gate (`npm run verify:core`)
+
+Runs in this exact order:
+1. `npm run prisma:check` (fails if generated Prisma client is missing/drifted from `packages/db/prisma/schema.prisma`)
+2. `npm run prisma:imports` (fails if any package/app imports `@prisma/client` directly outside `packages/db`)
+3. `npm run lint` (workspace lint, warnings allowed)
+4. `npm run typecheck` (workspace typecheck)
+5. `npm run test` (workspace unit tests; `apps/web` excludes `*.integration.test.ts`)
+6. `npm run build` (production web build)
+
+## Tier 2 — Release gate (`npm run verify:release`)
+
+Includes Tier 1 and adds env-bound integration tests:
+- `npm run test:integration` (currently `apps/web` Vitest integration suite)
+
+## Tier 3 — Browser/system gate (CI + optional local)
+
+Not included in `verify`:
+- `npm run test:e2e` (Playwright requires browser + seeded DB/Redis + app runtime)
+
+## Notes
+
+- `npm run verify` maps to Tier 1 to keep deterministic local checks fast and explicit.
+- CI (`.github/workflows/ci.yml`) runs Tier 2 (`npm run verify:release`) and then Tier 3 (`npm run test:e2e`).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   ],
   "scripts": {
     "postinstall": "node scripts/workspace-symlinks.js",
-    "pretypecheck": "npm run db:generate",
     "dev": "npm run dev --workspace=apps/web",
     "dev:worker": "npm run dev --workspace=apps/worker",
     "build": "npm run build --workspace=apps/web",
@@ -23,8 +22,14 @@
     "test": "npm run test --workspaces --if-present",
     "test:e2e": "npm run test:e2e --workspace=apps/web",
     "test:ct": "npm run test:ct --workspace=apps/web",
-    "verify": "npm run lint && npm run typecheck && npm run test && npm run build",
-    "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules"
+    "verify": "npm run verify:core",
+    "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules",
+    "prisma:check": "node scripts/check-prisma-client-drift.mjs",
+    "prisma:imports": "node scripts/check-prisma-import-boundaries.mjs",
+    "test:integration": "npm run test:integration --workspace=apps/web",
+    "test:release": "npm run test && npm run test:integration",
+    "verify:core": "npm run prisma:check && npm run prisma:imports && npm run lint && npm run typecheck && npm run test && npm run build",
+    "verify:release": "npm run verify:core && npm run test:integration"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",

--- a/scripts/check-prisma-client-drift.mjs
+++ b/scripts/check-prisma-client-drift.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = process.cwd();
+const schemaPath = resolve(repoRoot, 'packages/db/prisma/schema.prisma');
+const generatedSchemaPath = resolve(repoRoot, 'node_modules/.prisma/client/schema.prisma');
+const generatedEntrypoint = resolve(repoRoot, 'node_modules/@prisma/client/index.d.ts');
+
+if (!existsSync(generatedEntrypoint) || !existsSync(generatedSchemaPath)) {
+  console.error('[prisma:check] Generated Prisma client is missing. Run: npm run db:generate');
+  process.exit(1);
+}
+
+const canonicalize = (schema) => schema
+  .replace(/\/\/.*$/gm, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+const canonicalSchema = canonicalize(readFileSync(schemaPath, 'utf8'));
+const generatedSchema = canonicalize(readFileSync(generatedSchemaPath, 'utf8'));
+
+if (canonicalSchema !== generatedSchema) {
+  console.error('[prisma:check] Prisma schema drift detected between packages/db/prisma/schema.prisma and generated client artifacts.');
+  console.error('[prisma:check] Run: npm run db:generate');
+  process.exit(1);
+}
+
+console.log('[prisma:check] Prisma client artifacts are in sync with canonical schema.');

--- a/scripts/check-prisma-import-boundaries.mjs
+++ b/scripts/check-prisma-import-boundaries.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
+const ALLOWED_DIRECT_PRISMA_IMPORTS = new Set([
+  'packages/shared/src/ai-usage.ts',
+]);
+
+let output = '';
+
+try {
+  output = execSync(
+    'rg -n "from [\\\"\']@prisma/client[\\\"\']|import\\([\\\"\']@prisma/client[\\\"\']\\)" apps packages --glob "*.ts" --glob "*.tsx" --glob "!packages/db/**"',
+    { encoding: 'utf8' },
+  );
+} catch (error) {
+  if (error.status !== 1) {
+    throw error;
+  }
+}
+
+const lines = output
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean)
+  .filter((line) => !line.includes('from "@aros/db"') && !line.includes("from '@aros/db'"))
+  .filter((line) => {
+    const [filePath] = line.split(':');
+    return !ALLOWED_DIRECT_PRISMA_IMPORTS.has(filePath);
+  });
+
+if (lines.length > 0) {
+  console.error('[prisma:imports] Direct @prisma/client imports outside packages/db are forbidden. Use @aros/db exports instead.');
+  for (const line of lines) {
+    console.error(`  ${line}`);
+  }
+  process.exit(1);
+}
+
+console.log('[prisma:imports] Import boundary check passed.');


### PR DESCRIPTION
### Motivation

- Make the repository’s verification gates explicit and trustworthy so a passing `verify` means a deterministic, reviewable set of checks. 
- Prevent silent Prisma schema/client drift and accidental consumption of generated clients from non-canonical locations. 
- Separate env-bound integration/E2E suites from fast deterministic unit gates to avoid false-green CI signals. 
- Reduce high-risk validation warnings (unsafe regex / route-handler error handling) and tighten domain input handling for public endpoints.

### Description

- Added explicit gate scripts in the repo root: `prisma:check`, `prisma:imports`, `verify:core`, and `verify:release`, and made `verify` map to `verify:core`. 
- Added `scripts/check-prisma-client-drift.mjs` to compare canonical `packages/db/prisma/schema.prisma` with generated artifacts and fail on drift, and `scripts/check-prisma-import-boundaries.mjs` to forbid direct `@prisma/client` imports outside `packages/db` (with a documented allowlist). 
- Split `apps/web` tests so default `test` excludes integration files and added `test:integration` to run the Stripe webhook integration suite, and updated CI to run `npm run verify:release` before Playwright. 
- Hardened public endpoint validation and error handling by replacing unsafe regex checks with URL-based normalization for `public-scan` and `badge`, wrapping the OG image and Stripe webhook handlers in top-level `try/catch`, and aligned Prisma imports in webhook code/tests to use `@aros/db`. 
- Added `docs/verification-gates.md` documenting the three-tier gate model (core deterministic, release integration, and browser/e2e) and their execution order.

### Testing

- Ran `npm run db:generate` which succeeded and produced the Prisma client artifacts. 
- Ran `npm run prisma:check` and `npm run prisma:imports` and both passed (import check includes a deliberate allowlist entry for `packages/shared/src/ai-usage.ts`). 
- Ran `npm run lint` which completed successfully but left warning-level tenant-boundary findings (these are recorded as the remaining high-priority backlog). 
- Ran `npm run typecheck`, `npm run test` (unit suites across workspaces) and `npm run build`, all of which completed successfully; unit tests reported: 103 tests passed in `apps/web`. 
- Ran `npm run test:integration` which executed the Stripe webhook integration suite (1 passed, 6 skipped) and `npm run verify:release` which completed end-to-end for the release-tier checks. 
- Ran `npm run test:e2e` and it failed as expected in this environment due to missing `DATABASE_URL` (Playwright global setup requirement), which is now explicitly classified as an env-bound gate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb67aa6cc832897419ff89f363316)