### PR TITLE
Harden E2E preflight and reduce tenant-boundary false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,18 @@ Open http://localhost:3000
 
 ```bash
 npm run verify        # lint + typecheck + unit tests + production build
+npm run verify:release # verify:core + integration tests (strict release gate before E2E)
 npm run test          # Run all unit tests (Vitest)
-npm run test:e2e      # Playwright (requires DATABASE_URL; global setup runs db:push + db:seed)
+npm run test:e2e      # Playwright (requires DATABASE_URL; preflight validates env before db:push + db:seed)
 npm run typecheck     # TypeScript type checking
 npm run lint          # ESLint
 ```
+
+E2E bootstrap is now explicit and fails fast with actionable errors:
+1. `docker compose -f docker/docker-compose.yml up -d`
+2. `cp .env.example .env`
+3. set `DATABASE_URL` (and `REDIS_URL` / `NEXTAUTH_SECRET` when auth-heavy flows are exercised)
+4. run `npm run test:e2e`
 
 With Postgres available, `npm run test --workspace=apps/web` also runs **Stripe webhook integration tests** (subscription upsert, delete, idempotency, HMAC verification). CI sets `STRIPE_WEBHOOK_SECRET` for those tests. The webhook handler stores each Stripe `event.id` in `stripe_webhook_events` so retries are idempotent.
 

--- a/apps/web/e2e/global-setup.mjs
+++ b/apps/web/e2e/global-setup.mjs
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { formatE2EPreflightError, runE2EPreflight } from './preflight.mjs';
 
 // apps/web/e2e -> repo root
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
@@ -10,10 +11,14 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
  * Requires DATABASE_URL (CI provides it; local dev should run docker compose + .env).
  */
 export default async function globalSetup() {
-  if (!process.env.DATABASE_URL) {
-    throw new Error('E2E global setup requires DATABASE_URL (run docker compose and copy .env.example)');
+  const preflight = runE2EPreflight(process.env);
+  if (!preflight.ok) {
+    throw new Error(formatE2EPreflightError(preflight));
   }
 
+  console.log('[e2e:setup] Preflight passed. Syncing schema...');
   execSync('npm run db:push', { cwd: repoRoot, stdio: 'inherit', env: process.env });
+  console.log('[e2e:setup] Schema synced. Seeding deterministic demo data...');
   execSync('npm run db:seed', { cwd: repoRoot, stdio: 'inherit', env: process.env });
+  console.log('[e2e:setup] Database bootstrap complete.');
 }

--- a/apps/web/e2e/preflight.mjs
+++ b/apps/web/e2e/preflight.mjs
@@ -1,0 +1,50 @@
+import { URL } from "node:url";
+
+const REQUIRED_ENV = ["DATABASE_URL"];
+
+function assertUrlLike(name, value, errors) {
+  try {
+    const parsed = new URL(value);
+    void parsed;
+  } catch {
+    errors.push(`${name} must be a valid URL. Received "${value}".`);
+  }
+}
+
+/**
+ * @param {Record<string, string | undefined>} env
+ */
+export function runE2EPreflight(env = process.env) {
+  const missing = REQUIRED_ENV.filter((name) => !env[name] || env[name]?.trim().length === 0);
+  const errors = [];
+
+  if (missing.length > 0) {
+    errors.push(`Missing required environment variables: ${missing.join(", ")}.`);
+  }
+
+  if (env.DATABASE_URL) {
+    assertUrlLike("DATABASE_URL", env.DATABASE_URL, errors);
+  }
+
+  return {
+    ok: errors.length === 0,
+    missing,
+    errors,
+    required: REQUIRED_ENV,
+  };
+}
+
+export function formatE2EPreflightError(result) {
+  const guidance = [
+    "E2E preflight failed. Playwright global setup cannot safely seed the test environment.",
+    ...result.errors.map((error) => `- ${error}`),
+    "",
+    "Required bootstrap order:",
+    "1) docker compose -f docker/docker-compose.yml up -d",
+    "2) cp .env.example .env",
+    "3) set DATABASE_URL (and REDIS_URL/NEXTAUTH_SECRET when auth-dependent flows are exercised)",
+    "4) npm run test:e2e",
+  ];
+
+  return guidance.join("\n");
+}

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -11,7 +11,7 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-export default [
+const config = [
   {
     ignores: [".next/**"],
   },
@@ -36,8 +36,10 @@ export default [
     },
   },
   {
-    // Enforce the Data Boundary specifically in Next.js App Router endpoints, pages, and actions
-    files: ["src/app/**/*.ts", "src/app/**/*.tsx"],
+    // Enforce the Data Boundary specifically in server mutation/read boundaries
+    // (API route handlers + server actions). Server-rendered pages are excluded to
+    // reduce false positives where data access is already delegated to scoped modules.
+    files: ["src/app/**/route.ts", "src/app/**/actions.ts", "src/app/**/scan-actions.ts"],
     rules: {
       "no-restricted-syntax": [
         "warn",
@@ -66,3 +68,5 @@ export default [
     }
   }
 ];
+
+export default config;

--- a/apps/web/src/lib/e2e-preflight.test.ts
+++ b/apps/web/src/lib/e2e-preflight.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { formatE2EPreflightError, runE2EPreflight } from "../../e2e/preflight.mjs";
+
+describe("E2E environment preflight", () => {
+  it("fails with explicit errors when required env vars are missing", () => {
+    const result = runE2EPreflight({});
+
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual(["DATABASE_URL"]);
+    expect(formatE2EPreflightError(result)).toContain(
+      "Missing required environment variables: DATABASE_URL.",
+    );
+  });
+
+  it("fails when DATABASE_URL is not URL-like", () => {
+    const result = runE2EPreflight({ DATABASE_URL: "not-a-url" });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((msg) => msg.includes("DATABASE_URL must be a valid URL"))).toBe(true);
+  });
+
+  it("passes when DATABASE_URL is present and valid", () => {
+    const result = runE2EPreflight({
+      DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/aros",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/route-data-boundary.test.ts
+++ b/apps/web/src/lib/route-data-boundary.test.ts
@@ -1,52 +1,104 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveDashboardOrgMembership, runOrgScopedQuery } from "./route-data-boundary";
+import { prisma } from "./db";
+import { cookies } from "next/headers";
 
-// Mock representations of the boundary functions described in ROUTE_SAFE_BOUNDARY.md
-const resolveDashboardOrgMembership = async (userId: string, truth: any) => {
-  if (!truth.allowOrgScopedDbReads) return { kind: 'platform_blocked' };
-  if (userId === 'valid-user') return { kind: 'ok', organizationId: 'org-1' };
-  return { kind: 'none' };
-};
+vi.mock("./db", () => ({
+  prisma: {
+    membership: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
 
-const runOrgScopedQuery = async (ctx: any, fn: any) => {
-  if (ctx.kind !== 'ok') return { ok: false, message: 'Unauthorized or degraded platform state' };
-  try {
-    const data = await fn(ctx.organizationId);
-    return { ok: true, data };
-  } catch (err) {
-    return { ok: false, message: 'Query failed' };
-  }
-};
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
 
-describe('Route Data Boundary', () => {
-  it('should return platform_blocked without querying DB if allowOrgScopedDbReads is false', async () => {
-    const truth = { allowOrgScopedDbReads: false };
-    const result = await resolveDashboardOrgMembership('any-user', truth);
-    
-    expect(result.kind).toBe('platform_blocked');
+describe("route-data-boundary", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
   });
 
-  it('should execute the scoped query safely if membership is confirmed', async () => {
-    const ctx = { kind: 'ok', organizationId: 'org-1' };
-    const mockPrismaQuery = vi.fn().mockResolvedValue([{ id: 'finding-1' }]);
-    
-    const result = await runOrgScopedQuery(ctx, mockPrismaQuery);
-    
-    expect(result.ok).toBe(true);
-    expect(result.data).toEqual([{ id: 'finding-1' }]);
-    // Enforce that the organization ID is forcibly injected into the query
-    expect(mockPrismaQuery).toHaveBeenCalledWith('org-1');
+  it("returns platform_blocked and never queries membership when platform truth blocks DB reads", async () => {
+    const result = await resolveDashboardOrgMembership("user-1", {
+      allowOrgScopedDbReads: false,
+    } as any);
+
+    expect(result).toEqual({
+      kind: "platform_blocked",
+      truth: { allowOrgScopedDbReads: false },
+    });
+    expect(prisma.membership.findUnique).not.toHaveBeenCalled();
+    expect(prisma.membership.findFirst).not.toHaveBeenCalled();
   });
 
-  it('should short-circuit and block the query if context is not ok (e.g. platform blocked)', async () => {
-    const ctx = { kind: 'platform_blocked' };
-    const mockPrismaQuery = vi.fn();
-    
-    const result = await runOrgScopedQuery(ctx, mockPrismaQuery);
-    
-    expect(result.ok).toBe(false);
-    expect(result.message).toContain('degraded');
-    
-    // Crucial security check: The DB query must NEVER execute if the boundary fails
-    expect(mockPrismaQuery).not.toHaveBeenCalled();
+  it("prefers cookie-selected org membership when it exists", async () => {
+    vi.mocked(cookies).mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: "org-cookie" }),
+    } as any);
+    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
+      organizationId: "org-cookie",
+      role: "ADMIN",
+    } as any);
+
+    const result = await resolveDashboardOrgMembership("user-1", {
+      allowOrgScopedDbReads: true,
+    } as any);
+
+    expect(result).toEqual({
+      kind: "ok",
+      organizationId: "org-cookie",
+      role: "ADMIN",
+    });
+    expect(prisma.membership.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("falls back to oldest membership when cookie org is absent or invalid", async () => {
+    vi.mocked(cookies).mockResolvedValue({
+      get: vi.fn().mockReturnValue(undefined),
+    } as any);
+    vi.mocked(prisma.membership.findFirst).mockResolvedValue({
+      organizationId: "org-fallback",
+      role: "DEVELOPER",
+    } as any);
+
+    const result = await resolveDashboardOrgMembership("user-1", {
+      allowOrgScopedDbReads: true,
+    } as any);
+
+    expect(result).toEqual({
+      kind: "ok",
+      organizationId: "org-fallback",
+      role: "DEVELOPER",
+    });
+    expect(prisma.membership.findFirst).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+      select: { organizationId: true, role: true },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("blocks query execution when organization context is missing", async () => {
+    const query = vi.fn();
+    const result = await runOrgScopedQuery({ role: "ADMIN" } as any, query);
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Tenant isolation violation: Missing organization context",
+    });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("injects canonical organizationId into callback for safe tenant-scoped execution", async () => {
+    const query = vi.fn().mockResolvedValue({ id: "result" });
+    const result = await runOrgScopedQuery(
+      { organizationId: "org-safe", role: "ADMIN" },
+      query,
+    );
+
+    expect(result).toEqual({ ok: true, data: { id: "result" } });
+    expect(query).toHaveBeenCalledWith("org-safe");
   });
 });


### PR DESCRIPTION
### Motivation
- Make Playwright E2E bootstrap deterministic and actionable by failing fast with clear remediation when required env is missing or malformed.
- Reduce noisy tenant-boundary lint signals by narrowing the rule to server-entry surfaces so warnings focus on real server-side isolation risks.

### Description
- Add `apps/web/e2e/preflight.mjs` with `runE2EPreflight()` and `formatE2EPreflightError()` to validate `DATABASE_URL` and provide explicit bootstrap guidance before any DB mutations.
- Wire preflight into Playwright global setup (`apps/web/e2e/global-setup.mjs`) so `db:push`/`db:seed` only run after preflight succeeds and emit deterministic progress logs.
- Replace the previous synthetic/mocked boundary test with real unit tests exercising `resolveDashboardOrgMembership` and `runOrgScopedQuery` (`apps/web/src/lib/route-data-boundary.test.ts`) and add focused preflight tests (`apps/web/src/lib/e2e-preflight.test.ts`).
- Tighten tenant-boundary lint scope in `apps/web/eslint.config.mjs` to only `route.ts`, `actions.ts`, and `scan-actions.ts` (server mutation/read boundaries) and update `README.md` testing instructions to document strict E2E bootstrap steps.

### Testing
- Ran targeted unit tests: `npm run test --workspace=apps/web src/lib/route-data-boundary.test.ts src/lib/e2e-preflight.test.ts` and both test files passed.
- Ran workspace verification: `npm run lint` (completed; tenant-boundary warnings reduced and now scoped to server routes), `npm run typecheck` (passed), `npm run test` (full test suite passed), `npm run build` (passed), `npm run verify:core` (passed), and `npm run verify:release` (passed).
- `npm run test:e2e` correctly fails fast when `DATABASE_URL` is not provided and prints actionable bootstrap steps (this is expected behavior for environments without the required services).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfc77f9c488328b3c4262770ff5a69)