### PR TITLE
Enforce canonical org boundary for critical server routes and make tenant-boundary checks release-blocking

### DIFF
--- a/apps/web/src/app/api/comments/route.ts
+++ b/apps/web/src/app/api/comments/route.ts
@@ -1,10 +1,8 @@
-import { NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
-import { requireOrgAccess } from "@/lib/auth-guard";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
 import { apiSuccess, apiError } from "@/lib/api-utils";
-import { ApiError } from "@aros/shared";
+import { createFindingComment, listFindingComments } from "@/lib/comments/org-scoped-queries";
 
 const commentSchema = z.object({
   findingId: z.string().min(1),
@@ -19,7 +17,7 @@ const commentSchema = z.object({
  */
 export async function GET(request: Request) {
   try {
-    const user = await requireSession();
+    await requireSession();
     const { searchParams } = new URL(request.url);
     const findingId = searchParams.get("findingId");
     const organizationId = searchParams.get("organizationId");
@@ -31,27 +29,11 @@ export async function GET(request: Request) {
       });
     }
 
-    const ctx = await requireOrgAccess(organizationId, "finding:view", {
+    const ctx = await requireCanonicalOrgAccess(organizationId, "finding:view", {
       requirePaid: true,
     });
 
-    const comments = await prisma.findingComment.findMany({
-      where: {
-        canonicalFindingId: findingId,
-        organizationId: ctx.organizationId,
-        parentId: null, // Top-level comments only
-      },
-      include: {
-        user: { select: { id: true, name: true, email: true } },
-        replies: {
-          include: {
-            user: { select: { id: true, name: true, email: true } },
-          },
-          orderBy: { createdAt: "asc" },
-        },
-      },
-      orderBy: { createdAt: "desc" },
-    });
+    const comments = await listFindingComments(ctx, findingId);
 
     return apiSuccess(comments);
   } catch (error) {
@@ -69,49 +51,17 @@ export async function POST(request: Request) {
     const body = await request.json();
     const parsed = commentSchema.parse(body);
 
-    const ctx = await requireOrgAccess(
+    const ctx = await requireCanonicalOrgAccess(
       parsed.organizationId,
       "finding:manage",
       { requirePaid: true },
     );
 
-    // Verify finding access
-    const finding = await prisma.canonicalFinding.findFirst({
-      where: {
-        id: parsed.findingId,
-        site: { workspace: { organizationId: ctx.organizationId } },
-      },
-    });
-
-    if (!finding) {
-      return apiError(ApiError.notFound("Finding not found"));
-    }
-
-    // If parentId, verify parent exists and belongs to same finding
-    if (parsed.parentId) {
-      const parent = await prisma.findingComment.findFirst({
-        where: {
-          id: parsed.parentId,
-          canonicalFindingId: parsed.findingId,
-        },
-      });
-
-      if (!parent) {
-        return apiError(ApiError.notFound("Parent comment not found"));
-      }
-    }
-
-    const comment = await prisma.findingComment.create({
-      data: {
-        canonicalFindingId: parsed.findingId,
-        userId: user.id,
-        organizationId: ctx.organizationId,
-        body: parsed.body,
-        parentId: parsed.parentId,
-      },
-      include: {
-        user: { select: { id: true, name: true, email: true } },
-      },
+    const comment = await createFindingComment(ctx, {
+      findingId: parsed.findingId,
+      userId: user.id,
+      body: parsed.body,
+      parentId: parsed.parentId,
     });
 
     return apiSuccess(comment, 201);

--- a/apps/web/src/app/api/credits/route.ts
+++ b/apps/web/src/app/api/credits/route.ts
@@ -1,11 +1,10 @@
-import { NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
-import { requireOrgAccess } from "@/lib/auth-guard";
 import { apiSuccess, apiError } from "@/lib/api-utils";
 import { getAppBaseUrl } from "@/lib/billing";
 import { ApiError } from "@aros/shared";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
+import { getBillingCustomerByOrg, getCreditLedger, grantDevCredits } from "@/lib/credits/org-scoped-queries";
 
 const purchaseSchema = z.object({
   organizationId: z.string().min(1),
@@ -38,33 +37,14 @@ export async function GET(request: Request) {
       });
     }
 
-    const ctx = await requireOrgAccess(organizationId, "org:billing", {
+    const ctx = await requireCanonicalOrgAccess(organizationId, "org:billing", {
       requirePaid: true,
     });
 
-    const balance = await prisma.fixCreditBalance.findUnique({
-      where: { organizationId: ctx.organizationId },
-    });
-
-    const recentTransactions = await prisma.fixCredit.findMany({
-      where: { organizationId: ctx.organizationId },
-      orderBy: { createdAt: "desc" },
-      take: 20,
-      select: {
-        id: true,
-        type: true,
-        amount: true,
-        description: true,
-        createdAt: true,
-      },
-    });
+    const ledger = await getCreditLedger(ctx);
 
     return apiSuccess({
-      balance: balance?.balance ?? 0,
-      totalPurchased: balance?.totalPurchased ?? 0,
-      totalSpent: balance?.totalSpent ?? 0,
-      totalRefunded: balance?.totalRefunded ?? 0,
-      recentTransactions,
+      ...ledger,
       packs: Object.entries(CREDIT_PACKS).map(([key, pack]) => ({
         id: key,
         ...pack,
@@ -85,7 +65,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const parsed = purchaseSchema.parse(body);
 
-    const ctx = await requireOrgAccess(parsed.organizationId, "org:billing", {
+    const ctx = await requireCanonicalOrgAccess(parsed.organizationId, "org:billing", {
       requirePaid: true,
     });
     const pack = CREDIT_PACKS[parsed.pack];
@@ -95,9 +75,7 @@ export async function POST(request: Request) {
     }
 
     // Get or create billing customer
-    const billingCustomer = await prisma.billingCustomer.findUnique({
-      where: { organizationId: ctx.organizationId },
-    });
+    const billingCustomer = await getBillingCustomerByOrg(ctx);
 
     if (!billingCustomer) {
       return apiError(
@@ -153,35 +131,10 @@ export async function POST(request: Request) {
     }
 
     // Development mode: directly grant credits
-    const currentBalance = await prisma.fixCreditBalance.findUnique({
-      where: { organizationId: ctx.organizationId },
+    const { newBalance } = await grantDevCredits(ctx, {
+      credits: pack.credits,
+      label: pack.label,
     });
-
-    const newBalance = (currentBalance?.balance ?? 0) + pack.credits;
-
-    await prisma.$transaction([
-      prisma.fixCredit.create({
-        data: {
-          organizationId: ctx.organizationId,
-          type: "GRANT",
-          amount: pack.credits,
-          balance: newBalance,
-          description: `Dev mode: ${pack.label} granted`,
-        },
-      }),
-      prisma.fixCreditBalance.upsert({
-        where: { organizationId: ctx.organizationId },
-        create: {
-          organizationId: ctx.organizationId,
-          balance: pack.credits,
-          totalPurchased: pack.credits,
-        },
-        update: {
-          balance: newBalance,
-          totalPurchased: { increment: pack.credits },
-        },
-      }),
-    ]);
 
     return apiSuccess({
       message: `${pack.credits} credits granted (dev mode)`,

--- a/apps/web/src/app/api/impact/route.ts
+++ b/apps/web/src/app/api/impact/route.ts
@@ -1,9 +1,7 @@
-import { NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
-import { requireOrgAccess } from "@/lib/auth-guard";
 import { apiSuccess, apiError } from "@/lib/api-utils";
-import { ApiError } from "@aros/shared";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
+import { isImpactStale, verifyOrgSiteAccess } from "@/lib/impact/org-scoped-queries";
 import {
   computeClusterImpacts,
   getParetoAnalysis,
@@ -15,7 +13,7 @@ import {
  */
 export async function GET(request: Request) {
   try {
-    const user = await requireSession();
+    await requireSession();
     const { searchParams } = new URL(request.url);
     const organizationId = searchParams.get("organizationId");
     const siteId = searchParams.get("siteId");
@@ -27,33 +25,15 @@ export async function GET(request: Request) {
       });
     }
 
-    const ctx = await requireOrgAccess(organizationId, "finding:view", {
+    const ctx = await requireCanonicalOrgAccess(organizationId, "finding:view", {
       requirePaid: true,
     });
 
-    // Verify site access
-    const site = await prisma.site.findFirst({
-      where: {
-        id: siteId,
-        workspace: { organizationId: ctx.organizationId },
-      },
-    });
+    await verifyOrgSiteAccess(ctx, siteId);
 
-    if (!site) {
-      return apiError(ApiError.notFound("Site not found"));
-    }
+    const stale = await isImpactStale(ctx, siteId);
 
-    // Check if impacts are stale (> 1 hour old)
-    const latestImpact = await prisma.clusterImpact.findFirst({
-      where: { cluster: { siteId } },
-      orderBy: { computedAt: "desc" },
-    });
-
-    const isStale =
-      !latestImpact ||
-      Date.now() - latestImpact.computedAt.getTime() > 60 * 60 * 1000;
-
-    if (isStale) {
+    if (stale) {
       await computeClusterImpacts(siteId);
     }
 
@@ -71,7 +51,7 @@ export async function GET(request: Request) {
  */
 export async function POST(request: Request) {
   try {
-    const user = await requireSession();
+    await requireSession();
     const body = await request.json();
     const { organizationId, siteId } = body;
 
@@ -82,20 +62,11 @@ export async function POST(request: Request) {
       });
     }
 
-    const ctx = await requireOrgAccess(organizationId, "finding:manage", {
+    const ctx = await requireCanonicalOrgAccess(organizationId, "finding:manage", {
       requirePaid: true,
     });
 
-    const site = await prisma.site.findFirst({
-      where: {
-        id: siteId,
-        workspace: { organizationId: ctx.organizationId },
-      },
-    });
-
-    if (!site) {
-      return apiError(ApiError.notFound("Site not found"));
-    }
+    await verifyOrgSiteAccess(ctx, siteId);
 
     const results = await computeClusterImpacts(siteId);
 

--- a/apps/web/src/lib/comments/org-scoped-queries.ts
+++ b/apps/web/src/lib/comments/org-scoped-queries.ts
@@ -1,0 +1,78 @@
+import { prisma } from "@/lib/db";
+import { ApiError } from "@aros/shared";
+import type { OrgMembershipCore } from "@/lib/route-data-boundary";
+import { runCanonicalOrgQuery } from "@/lib/server-org-boundary";
+
+export async function listFindingComments(ctx: OrgMembershipCore, findingId: string) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.findingComment.findMany({
+      where: {
+        canonicalFindingId: findingId,
+        organizationId,
+        parentId: null,
+      },
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+        replies: {
+          include: {
+            user: { select: { id: true, name: true, email: true } },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+  );
+}
+
+export async function createFindingComment(
+  ctx: OrgMembershipCore,
+  input: {
+    findingId: string;
+    userId: string;
+    body: string;
+    parentId?: string;
+  },
+) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) => {
+    const finding = await prisma.canonicalFinding.findFirst({
+      where: {
+        id: input.findingId,
+        site: { workspace: { organizationId } },
+      },
+      select: { id: true },
+    });
+
+    if (!finding) {
+      throw ApiError.notFound("Finding not found");
+    }
+
+    if (input.parentId) {
+      const parent = await prisma.findingComment.findFirst({
+        where: {
+          id: input.parentId,
+          canonicalFindingId: input.findingId,
+          organizationId,
+        },
+        select: { id: true },
+      });
+
+      if (!parent) {
+        throw ApiError.notFound("Parent comment not found");
+      }
+    }
+
+    return prisma.findingComment.create({
+      data: {
+        canonicalFindingId: input.findingId,
+        userId: input.userId,
+        organizationId,
+        body: input.body,
+        parentId: input.parentId,
+      },
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+      },
+    });
+  });
+}

--- a/apps/web/src/lib/credits/org-scoped-queries.ts
+++ b/apps/web/src/lib/credits/org-scoped-queries.ts
@@ -1,0 +1,80 @@
+import { prisma } from "@/lib/db";
+import type { OrgMembershipCore } from "@/lib/route-data-boundary";
+import { runCanonicalOrgQuery } from "@/lib/server-org-boundary";
+
+export async function getCreditLedger(ctx: OrgMembershipCore) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) => {
+    const [balance, recentTransactions] = await Promise.all([
+      prisma.fixCreditBalance.findUnique({
+        where: { organizationId },
+      }),
+      prisma.fixCredit.findMany({
+        where: { organizationId },
+        orderBy: { createdAt: "desc" },
+        take: 20,
+        select: {
+          id: true,
+          type: true,
+          amount: true,
+          description: true,
+          createdAt: true,
+        },
+      }),
+    ]);
+
+    return {
+      balance: balance?.balance ?? 0,
+      totalPurchased: balance?.totalPurchased ?? 0,
+      totalSpent: balance?.totalSpent ?? 0,
+      totalRefunded: balance?.totalRefunded ?? 0,
+      recentTransactions,
+    };
+  });
+}
+
+export async function getBillingCustomerByOrg(ctx: OrgMembershipCore) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.billingCustomer.findUnique({
+      where: { organizationId },
+    }),
+  );
+}
+
+export async function grantDevCredits(
+  ctx: OrgMembershipCore,
+  input: { credits: number; label: string },
+) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) => {
+    const currentBalance = await prisma.fixCreditBalance.findUnique({
+      where: { organizationId },
+    });
+
+    const newBalance = (currentBalance?.balance ?? 0) + input.credits;
+
+    await prisma.$transaction([
+      prisma.fixCredit.create({
+        data: {
+          organizationId,
+          type: "GRANT",
+          amount: input.credits,
+          balance: newBalance,
+          description: `Dev mode: ${input.label} granted`,
+        },
+      }),
+      prisma.fixCreditBalance.upsert({
+        where: { organizationId },
+        create: {
+          organizationId,
+          balance: input.credits,
+          totalPurchased: input.credits,
+        },
+        update: {
+          balance: newBalance,
+          totalPurchased: { increment: input.credits },
+        },
+      }),
+    ]);
+
+    return { newBalance };
+  });
+}

--- a/apps/web/src/lib/impact/org-scoped-queries.ts
+++ b/apps/web/src/lib/impact/org-scoped-queries.ts
@@ -1,0 +1,37 @@
+import { prisma } from "@/lib/db";
+import { ApiError } from "@aros/shared";
+import type { OrgMembershipCore } from "@/lib/route-data-boundary";
+import { runCanonicalOrgQuery } from "@/lib/server-org-boundary";
+
+export async function verifyOrgSiteAccess(ctx: OrgMembershipCore, siteId: string) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) => {
+    const site = await prisma.site.findFirst({
+      where: {
+        id: siteId,
+        workspace: { organizationId },
+      },
+      select: { id: true, name: true },
+    });
+
+    if (!site) {
+      throw ApiError.notFound("Site not found");
+    }
+
+    return site;
+  });
+}
+
+export async function isImpactStale(ctx: OrgMembershipCore, siteId: string) {
+  return runCanonicalOrgQuery(ctx, async () => {
+    const latestImpact = await prisma.clusterImpact.findFirst({
+      where: { cluster: { siteId } },
+      orderBy: { computedAt: "desc" },
+      select: { computedAt: true },
+    });
+
+    return (
+      !latestImpact ||
+      Date.now() - latestImpact.computedAt.getTime() > 60 * 60 * 1000
+    );
+  });
+}

--- a/apps/web/src/lib/server-org-boundary.test.ts
+++ b/apps/web/src/lib/server-org-boundary.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+vi.mock("@/lib/auth-guard", () => ({
+  requireOrgAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/route-data-boundary", () => ({
+  runOrgScopedQuery: vi.fn(),
+}));
+
+import { requireOrgAccess } from "@/lib/auth-guard";
+import { runOrgScopedQuery } from "@/lib/route-data-boundary";
+import { requireCanonicalOrgAccess, runCanonicalOrgQuery } from "./server-org-boundary";
+
+describe("server-org-boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails closed when organizationId is missing", async () => {
+    await expect(requireCanonicalOrgAccess(undefined, "finding:view")).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      statusCode: 400,
+    });
+  });
+
+  it("returns canonical context from requireOrgAccess", async () => {
+    vi.mocked(requireOrgAccess).mockResolvedValueOnce({
+      organizationId: "org-safe",
+      role: "ADMIN",
+    } as any);
+
+    await expect(requireCanonicalOrgAccess("org-safe", "finding:view")).resolves.toEqual({
+      organizationId: "org-safe",
+      role: "ADMIN",
+    });
+  });
+
+  it("denies cross-tenant unsafe query execution when org query wrapper returns not ok", async () => {
+    vi.mocked(runOrgScopedQuery).mockResolvedValueOnce({
+      ok: false,
+      message: "Tenant isolation violation: Missing organization context",
+    });
+
+    await expect(
+      runCanonicalOrgQuery({ organizationId: "", role: "ADMIN" } as any, async () => "never"),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      statusCode: 403,
+      message: "Tenant isolation violation: Missing organization context",
+    });
+  });
+
+  it("returns data when org wrapper succeeds", async () => {
+    vi.mocked(runOrgScopedQuery).mockResolvedValueOnce({ ok: true, data: { count: 4 } });
+
+    await expect(
+      runCanonicalOrgQuery({ organizationId: "org-safe", role: "ADMIN" } as any, async () => ({ count: 4 })),
+    ).resolves.toEqual({ count: 4 });
+  });
+});

--- a/apps/web/src/lib/server-org-boundary.ts
+++ b/apps/web/src/lib/server-org-boundary.ts
@@ -1,0 +1,32 @@
+import { ApiError } from "@aros/shared";
+import { requireOrgAccess } from "@/lib/auth-guard";
+import { runOrgScopedQuery, type OrgMembershipCore } from "@/lib/route-data-boundary";
+import type { Permission } from "@aros/config";
+
+interface OrgBoundaryOptions {
+  requirePaid?: boolean;
+}
+
+export async function requireCanonicalOrgAccess(
+  organizationId: string | null | undefined,
+  permission?: Permission,
+  options: OrgBoundaryOptions = {},
+): Promise<OrgMembershipCore> {
+  if (!organizationId) {
+    throw ApiError.badRequest("organizationId required");
+  }
+
+  const ctx = await requireOrgAccess(organizationId, permission, options);
+  return { organizationId: ctx.organizationId, role: ctx.role };
+}
+
+export async function runCanonicalOrgQuery<T>(
+  ctx: OrgMembershipCore,
+  query: (organizationId: string) => Promise<T>,
+): Promise<T> {
+  const result = await runOrgScopedQuery(ctx, query);
+  if (!result.ok) {
+    throw ApiError.forbidden(result.message);
+  }
+  return result.data;
+}

--- a/docs/verification-gates.md
+++ b/docs/verification-gates.md
@@ -12,7 +12,8 @@ Runs in this exact order:
 
 ## Tier 2 — Release gate (`npm run verify:release`)
 
-Includes Tier 1 and adds env-bound integration tests:
+Includes Tier 1 and adds release-blocking tenant isolation + env-bound integration tests:
+- `npm run verify:tenant-boundary` (fails if critical server entrypoints regress with tenant-boundary lint violations)
 - `npm run test:integration` (currently `apps/web` Vitest integration suite)
 
 ## Tier 3 — Browser/system gate (CI + optional local)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:integration": "npm run test:integration --workspace=apps/web",
     "test:release": "npm run test && npm run test:integration",
     "verify:core": "npm run prisma:check && npm run prisma:imports && npm run lint && npm run typecheck && npm run test && npm run build",
-    "verify:release": "npm run verify:core && npm run test:integration"
+    "verify:release": "npm run verify:core && npm run verify:tenant-boundary && npm run test:integration",
+    "verify:tenant-boundary": "node scripts/check-tenant-boundary-critical.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",

--- a/scripts/check-tenant-boundary-critical.mjs
+++ b/scripts/check-tenant-boundary-critical.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+
+const CRITICAL_ENTRYPOINTS = [
+  "src/app/api/comments/route.ts",
+  "src/app/api/credits/route.ts",
+  "src/app/api/impact/route.ts",
+];
+
+const joined = CRITICAL_ENTRYPOINTS.join(" ");
+
+let stdout = "[]";
+try {
+  stdout = execSync(`npx eslint --format json ${joined}`, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    cwd: "apps/web",
+  });
+} catch (error) {
+  stdout = error.stdout?.toString() ?? "[]";
+}
+
+let report;
+try {
+  report = JSON.parse(stdout);
+} catch {
+  console.error("[verify:tenant-boundary] Failed to parse eslint JSON output.");
+  process.exit(1);
+}
+
+const violations = report.flatMap((file) =>
+  file.messages
+    .filter((message) => message.ruleId === "no-restricted-syntax")
+    .map((message) => ({
+      filePath: file.filePath,
+      line: message.line,
+      column: message.column,
+      message: message.message,
+    })),
+);
+
+if (violations.length > 0) {
+  console.error("[verify:tenant-boundary] Critical tenant-boundary violations detected:");
+  for (const violation of violations) {
+    console.error(`- ${violation.filePath}:${violation.line}:${violation.column} ${violation.message}`);
+  }
+  process.exit(1);
+}
+
+console.log(`[verify:tenant-boundary] Passed for ${CRITICAL_ENTRYPOINTS.length} critical server entrypoints.`);


### PR DESCRIPTION
### Motivation
- Reduce cross-tenant risk by introducing a single canonical server-side org boundary that enforces authenticated actor + resolved org context and fail-closes on ambiguity.
- Move high-risk API surfaces off ad-hoc Prisma in-route logic into org-scoped query modules to eliminate repeated ownership checks and close deterministic denial gaps.
- Make tenant-boundary regressions on the highest-risk entrypoints release-blocking so isolation cannot regress silently.

### Description
- Added a canonical server boundary helper `requireCanonicalOrgAccess` and `runCanonicalOrgQuery` in `apps/web/src/lib/server-org-boundary.ts` that wrap existing auth and the org-scoped query boundary and fail-closed on missing/unsafe org context. 
- Migrated three high-risk API routes to use the canonical boundary and pre-wrapped queries: `/api/comments`, `/api/credits`, `/api/impact` (routes updated to call `requireCanonicalOrgAccess` and delegate DB work to new modules).
- Introduced org-scoped modules that centralize ownership checks and DB access: `comments/org-scoped-queries.ts`, `credits/org-scoped-queries.ts`, and `impact/org-scoped-queries.ts` under `apps/web/src/lib/`.
- Added regression unit tests for the new boundary contract in `apps/web/src/lib/server-org-boundary.test.ts` to assert fail-closed and success paths.
- Added a release-blocking tenant-boundary verifier script `scripts/check-tenant-boundary-critical.mjs` and wired `verify:tenant-boundary` into `package.json`, and updated `docs/verification-gates.md` to document the gate.

### Testing
- Ran lint: `npm run lint` (workspace); tenant-boundary warnings on covered critical entrypoints are eliminated and overall tenant-boundary warnings reduced from 61 → 47 in this pass (lint exits 0, warnings reported). — Passed (warnings reported). 
- Ran unit tests for the new boundary: `npm run test --workspace=apps/web -- src/lib/server-org-boundary.test.ts`; the file suite passed (4 tests passed). — Passed.
- Ran tenant-boundary verifier: `npm run verify:tenant-boundary`; the script runs ESLint JSON against the 3 critical entrypoints and returned success: "Passed for 3 critical server entrypoints." — Passed.
- Ran the deterministic verification flow: `npm run verify:core` and `npm run verify:release` (which now includes `verify:tenant-boundary` and integration tests); these were executed during validation with eventual success after resolving a transient build rename issue observed during an intermediate run (re-run completed successfully). — Passed (see logs for transient ENOENT build which was re-run and resolved).

Notes: CI/E2E (`npm run test:e2e`) was not executed in this pass because it requires Playwright + seeded DB/Redis runtime; the changes do not modify E2E expectations but follow-up CI will exercise E2E against the updated gate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd7bd94ec8328a87ebd74176b1d4f)