### PR TITLE
Harden public-scan boundary checks and expire stale public evidence

### DIFF
--- a/apps/web/src/app/(public)/scan/[domain]/page.tsx
+++ b/apps/web/src/app/(public)/scan/[domain]/page.tsx
@@ -13,7 +13,7 @@ export async function generateMetadata({
   const decoded = decodeURIComponent(domain);
 
   const scan = await prisma.publicScanResult.findFirst({
-    where: { domain: decoded, status: "COMPLETED" },
+    where: { domain: decoded, status: "COMPLETED", expiresAt: { gt: new Date() } },
     orderBy: { createdAt: "desc" },
   });
 
@@ -46,7 +46,7 @@ export default async function PublicScanPage({ params }: PageProps) {
   const decoded = decodeURIComponent(domain);
 
   const scan = await prisma.publicScanResult.findFirst({
-    where: { domain: decoded },
+    where: { domain: decoded, expiresAt: { gt: new Date() } },
     orderBy: { createdAt: "desc" },
   });
 

--- a/apps/web/src/app/api/public-scan/[id]/route.ts
+++ b/apps/web/src/app/api/public-scan/[id]/route.ts
@@ -32,14 +32,39 @@ export async function GET(
         screenshotKeys: true,
         createdAt: true,
         completedAt: true,
+        expiresAt: true,
       },
     });
 
     if (!scan) {
       return apiError(ApiError.notFound("Scan not found"));
     }
+    if (scan.expiresAt && scan.expiresAt <= new Date()) {
+      return apiError(
+        new ApiError(
+          "Scan result has expired. Start a new scan to generate fresh evidence.",
+          "SCAN_EXPIRED",
+          410,
+        ),
+      );
+    }
 
-    return apiSuccess(scan);
+    return apiSuccess({
+      id: scan.id,
+      domain: scan.domain,
+      status: scan.status,
+      score: scan.score,
+      totalViolations: scan.totalViolations,
+      criticalCount: scan.criticalCount,
+      seriousCount: scan.seriousCount,
+      moderateCount: scan.moderateCount,
+      minorCount: scan.minorCount,
+      pagesScanned: scan.pagesScanned,
+      violations: scan.violations,
+      screenshotKeys: scan.screenshotKeys,
+      createdAt: scan.createdAt,
+      completedAt: scan.completedAt,
+    });
   } catch (error) {
     return apiError(error);
   }

--- a/apps/web/src/app/api/public-scan/route.test.ts
+++ b/apps/web/src/app/api/public-scan/route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findUniqueMock } = vi.hoisted(() => ({
+  findUniqueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    publicScanResult: {
+      findUnique: findUniqueMock,
+    },
+  },
+}));
+
+import { GET, isPrivateOrLoopbackAddress, validatePublicScanTarget } from "./route";
+
+describe("public scan target validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("blocks loopback/private literal addresses", () => {
+    expect(isPrivateOrLoopbackAddress("127.0.0.1")).toBe(true);
+    expect(isPrivateOrLoopbackAddress("10.0.0.4")).toBe(true);
+    expect(isPrivateOrLoopbackAddress("192.168.1.9")).toBe(true);
+    expect(isPrivateOrLoopbackAddress("8.8.8.8")).toBe(false);
+    expect(isPrivateOrLoopbackAddress("::1")).toBe(true);
+    expect(isPrivateOrLoopbackAddress("2001:4860:4860::8888")).toBe(false);
+  });
+
+  it("rejects domains that resolve to private addresses", async () => {
+    await expect(validatePublicScanTarget("localhost")).rejects.toMatchObject({
+      code: "PUBLIC_SCAN_HOST_BLOCKED",
+      statusCode: 400,
+    });
+  });
+});
+
+describe("GET /api/public-scan?id=...", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 410 for expired scans", async () => {
+    findUniqueMock.mockResolvedValueOnce({
+      id: "scan_1",
+      domain: "example.com",
+      status: "COMPLETED",
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+
+    const request = new Request("http://localhost/api/public-scan?id=scan_1");
+    const response = await GET(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(410);
+    expect(payload.error?.code).toBe("SCAN_EXPIRED");
+  });
+});

--- a/apps/web/src/app/api/public-scan/route.ts
+++ b/apps/web/src/app/api/public-scan/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/db";
 import { apiSuccess, apiError } from "@/lib/api-utils";
 import { ApiError } from "@aros/shared";
 import { createHash } from "crypto";
+import { lookup } from "node:dns/promises";
 
 export const runtime = "nodejs";
 
@@ -14,17 +15,81 @@ const scanSchema = z.object({
   domain: z.string().min(1, "Domain is required").max(253),
 });
 
-function normalizePublicScanDomain(rawDomain: string): { domain: string; url: string } {
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "0.0.0.0",
+  "169.254.169.254", // cloud metadata endpoint
+]);
+
+function isPrivateIpv4(address: string): boolean {
+  const octets = address.split(".").map(Number);
+  if (octets.length !== 4 || octets.some((octet) => Number.isNaN(octet) || octet < 0 || octet > 255)) {
+    return false;
+  }
+
+  return (
+    octets[0] === 10 ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168) ||
+    octets[0] === 127 ||
+    (octets[0] === 169 && octets[1] === 254)
+  );
+}
+
+function isPrivateIpv6(address: string): boolean {
+  const normalized = address.toLowerCase();
+  return normalized === "::1" || normalized.startsWith("fc") || normalized.startsWith("fd") || normalized.startsWith("fe80:");
+}
+
+export function isPrivateOrLoopbackAddress(address: string): boolean {
+  return address.includes(":") ? isPrivateIpv6(address) : isPrivateIpv4(address);
+}
+
+export async function validatePublicScanTarget(hostname: string): Promise<void> {
+  const normalizedHostname = hostname.toLowerCase();
+
+  if (BLOCKED_HOSTNAMES.has(normalizedHostname) || normalizedHostname.endsWith(".local")) {
+    throw new ApiError(
+      "Private, loopback, and local network hosts are not allowed for public scans.",
+      "PUBLIC_SCAN_HOST_BLOCKED",
+      400,
+    );
+  }
+
+  let resolvedAddress: string;
+  try {
+    const { address } = await lookup(normalizedHostname);
+    resolvedAddress = address;
+  } catch {
+    throw ApiError.badRequest("Domain could not be resolved. Please enter a public hostname.");
+  }
+  if (isPrivateOrLoopbackAddress(resolvedAddress)) {
+    throw new ApiError(
+      "Resolved host points to a private or loopback address and cannot be scanned publicly.",
+      "PUBLIC_SCAN_HOST_BLOCKED",
+      400,
+      { hostname: normalizedHostname },
+    );
+  }
+}
+
+async function normalizePublicScanDomain(rawDomain: string): Promise<{ domain: string; url: string }> {
   const candidate = rawDomain.startsWith("http://") || rawDomain.startsWith("https://")
     ? rawDomain
     : `https://${rawDomain}`;
 
   const parsed = new URL(candidate);
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw ApiError.badRequest("Only HTTP and HTTPS URLs are allowed");
+  }
   if (!parsed.hostname || !parsed.hostname.includes(".")) {
     throw ApiError.badRequest("Invalid domain format");
   }
 
   const normalizedDomain = parsed.hostname.toLowerCase();
+  await validatePublicScanTarget(normalizedDomain);
   return {
     domain: normalizedDomain,
     url: `${parsed.protocol}//${normalizedDomain}${parsed.pathname === "/" ? "" : parsed.pathname}`
@@ -42,7 +107,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const parsed = scanSchema.parse(body);
 
-    const { domain, url } = normalizePublicScanDomain(parsed.domain.trim());
+    const { domain, url } = await normalizePublicScanDomain(parsed.domain.trim());
 
     // Rate limit check: hash IP + domain for privacy
     const forwarded = request.headers.get("x-forwarded-for");
@@ -150,12 +215,13 @@ export async function GET(request: Request) {
       return apiError(ApiError.badRequest("Scan ID required"));
     }
 
-    const scan = await prisma.publicScanResult.findUnique({
-      where: { id },
-    });
+    const scan = await prisma.publicScanResult.findUnique({ where: { id } });
 
     if (!scan) {
       return apiError(ApiError.notFound("Scan not found"));
+    }
+    if (scan.expiresAt && scan.expiresAt <= new Date()) {
+      return apiError(new ApiError("Scan result has expired. Start a new scan to generate fresh evidence.", "SCAN_EXPIRED", 410));
     }
 
     return apiSuccess({


### PR DESCRIPTION
### Motivation
- Prevent abuse and SSRF-style scans from the anonymous public-scan endpoint and avoid serving stale scan evidence as current results. 
- Improve buyer/operator trust by making public-scan acceptance rules explicit and machine-visible when results are no longer valid. 

### Description
- Add hostname/DNS validation and private-address detection to `/api/public-scan` via `validatePublicScanTarget` which blocks `localhost`, loopback, link-local metadata host, `.local` names and any host that resolves to a private or loopback IP. 
- Restrict accepted targets to HTTP/HTTPS and perform a `node:dns/promises` `lookup` before enqueuing scans to fail-closed on unresolved or private hosts. 
- Enforce scan TTL/expiry semantics: created public scans get a 24h `expiresAt` and both polling endpoints return `410` with code `SCAN_EXPIRED` for expired evidence. 
- Update public results page queries to ignore expired scan records and add a focused test file covering private-address detection and expired-scan behavior. 

### Testing
- Ran the new route unit tests with `npm run test --workspace=apps/web -- src/app/api/public-scan/route.test.ts` and the tests passed. 
- Ran lint with `npm run lint --workspace=apps/web` which completed; repo still reports tenant-boundary warnings but none introduced by this change. 
- Ran typecheck with `npm run typecheck --workspace=apps/web` which failed due to pre-existing, repository-wide TypeScript issues unrelated to this change (no new type errors introduced by these edits).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd9499a288328bcdbfce34f3f7400)