### PR TITLE
Harden public-scan evidence validity and expand tenant-boundary gate; migrate report/integration routes to org‑scoped queries

### DIFF
--- a/apps/web/src/app/(public)/scan/[domain]/page.tsx
+++ b/apps/web/src/app/(public)/scan/[domain]/page.tsx
@@ -1,4 +1,4 @@
-import { prisma } from "@/lib/db";
+import { getLatestValidPublicScanForDomain } from "@/lib/public-scan/validity";
 import { Metadata } from "next";
 import { PublicScanResults } from "./public-scan-results";
 
@@ -12,10 +12,7 @@ export async function generateMetadata({
   const { domain } = await params;
   const decoded = decodeURIComponent(domain);
 
-  const scan = await prisma.publicScanResult.findFirst({
-    where: { domain: decoded, status: "COMPLETED", expiresAt: { gt: new Date() } },
-    orderBy: { createdAt: "desc" },
-  });
+  const scan = await getLatestValidPublicScanForDomain(decoded, { requireCompleted: true });
 
   const score = scan?.score ?? 0;
   const total = scan?.totalViolations ?? 0;
@@ -45,10 +42,7 @@ export default async function PublicScanPage({ params }: PageProps) {
   const { domain } = await params;
   const decoded = decodeURIComponent(domain);
 
-  const scan = await prisma.publicScanResult.findFirst({
-    where: { domain: decoded, expiresAt: { gt: new Date() } },
-    orderBy: { createdAt: "desc" },
-  });
+  const scan = await getLatestValidPublicScanForDomain(decoded, { requireCompleted: false });
 
   return (
     <PublicScanResults

--- a/apps/web/src/app/api/badge/route.ts
+++ b/apps/web/src/app/api/badge/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
+import { getLatestValidPublicScanForDomain } from "@/lib/public-scan/validity";
 
 export const runtime = "nodejs";
 
@@ -58,11 +58,7 @@ export async function GET(request: Request) {
   let totalViolations = 0;
 
   try {
-    const scan = await prisma.publicScanResult.findFirst({
-      where: { domain, status: "COMPLETED" },
-      orderBy: { createdAt: "desc" },
-      select: { score: true, totalViolations: true },
-    });
+    const scan = await getLatestValidPublicScanForDomain(domain, { requireCompleted: true });
 
     if (scan) {
       score = scan.score;

--- a/apps/web/src/app/api/deploy-webhook/route.ts
+++ b/apps/web/src/app/api/deploy-webhook/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
-import { requireOrgAccess } from "@/lib/auth-guard";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
 import { apiSuccess, apiError } from "@/lib/api-utils";
 import { ApiError } from "@aros/shared";
 import { createHmac, timingSafeEqual } from "crypto";
+import { createPendingScanRun, findActiveDeployWebhookByDomain, listDeployWebhooks } from "@/lib/integrations/org-scoped-queries";
 
 export const runtime = "nodejs";
 
@@ -146,27 +146,7 @@ export async function POST(request: Request) {
     const domain = new URL(deployUrl).hostname;
 
     // Find matching deploy webhook configuration
-    const deployWebhook = await prisma.deployWebhook.findFirst({
-      where: {
-        isActive: true,
-        site: { domain },
-      },
-      include: {
-        site: {
-          include: {
-            workspace: {
-              include: {
-                organization: {
-                  include: {
-                    subscription: true,
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const deployWebhook = await findActiveDeployWebhookByDomain(domain);
 
     if (!deployWebhook) {
       // No matching config - acknowledge but don't scan
@@ -203,12 +183,7 @@ export async function POST(request: Request) {
     }
 
     // Create scan run
-    const scanRun = await prisma.scanRun.create({
-      data: {
-        siteId: deployWebhook.siteId,
-        status: "PENDING",
-      },
-    });
+    const scanRun = await createPendingScanRun(deployWebhook.siteId);
 
     // Enqueue scan
     const { Queue } = await import("bullmq");
@@ -249,15 +224,11 @@ export async function GET(request: Request) {
       });
     }
 
-    await requireOrgAccess(organizationId, "integrations:view", {
+    const ctx = await requireCanonicalOrgAccess(organizationId, "integrations:view", {
       requirePaid: true,
     });
 
-    const webhooks = await prisma.deployWebhook.findMany({
-      where: { organizationId },
-      include: { site: { select: { id: true, name: true, domain: true } } },
-      orderBy: { createdAt: "desc" },
-    });
+    const webhooks = await listDeployWebhooks(ctx);
 
     return apiSuccess(webhooks);
   } catch (error) {

--- a/apps/web/src/app/api/github-action/route.ts
+++ b/apps/web/src/app/api/github-action/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma } from "@/lib/db";
-import { requireOrgAccess } from "@/lib/auth-guard";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
 import { apiSuccess, apiError } from "@/lib/api-utils";
 import { ApiError } from "@aros/shared";
 import { Queue } from "bullmq";
 import { bullmqConnectionOptions } from "@aros/shared";
+import { createPendingScanRun, findGithubActionSite } from "@/lib/integrations/org-scoped-queries";
 
 export const runtime = "nodejs";
 
@@ -33,34 +33,19 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     const parsed = scanActionSchema.parse(body);
-    const ctx = await requireOrgAccess(parsed.organizationId, "scan:start", {
+    const ctx = await requireCanonicalOrgAccess(parsed.organizationId, "scan:start", {
       requirePaid: true,
     });
 
     // Verify site exists and user has access
-    const site = await prisma.site.findFirst({
-      where: {
-        id: parsed.siteId,
-        workspace: { organizationId: ctx.organizationId },
-      },
-      include: {
-        workspace: {
-          include: { organization: true },
-        },
-      },
-    });
+    const site = await findGithubActionSite(ctx, parsed.siteId);
 
     if (!site) {
       return apiError(ApiError.notFound("Site not found"));
     }
 
     // Create scan run
-    const scanRun = await prisma.scanRun.create({
-      data: {
-        siteId: site.id,
-        status: "PENDING",
-      },
-    });
+    const scanRun = await createPendingScanRun(site.id);
 
     // Enqueue scan
     const scanQueue = new Queue("scan", {

--- a/apps/web/src/app/api/public-scan/[id]/route.ts
+++ b/apps/web/src/app/api/public-scan/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
 import { apiSuccess, apiError } from "@/lib/api-utils";
 import { ApiError } from "@aros/shared";
+import { getPublicScanById, getPublicScanEvidenceState, toPublicScanApiPayload } from "@/lib/public-scan/validity";
 
 /**
  * GET /api/public-scan/[id]
@@ -15,31 +15,12 @@ export async function GET(
   try {
     const { id } = await context.params;
 
-    const scan = await prisma.publicScanResult.findUnique({
-      where: { id },
-      select: {
-        id: true,
-        domain: true,
-        status: true,
-        score: true,
-        totalViolations: true,
-        criticalCount: true,
-        seriousCount: true,
-        moderateCount: true,
-        minorCount: true,
-        pagesScanned: true,
-        violations: true,
-        screenshotKeys: true,
-        createdAt: true,
-        completedAt: true,
-        expiresAt: true,
-      },
-    });
+    const scan = await getPublicScanById(id);
 
     if (!scan) {
       return apiError(ApiError.notFound("Scan not found"));
     }
-    if (scan.expiresAt && scan.expiresAt <= new Date()) {
+    if (getPublicScanEvidenceState(scan) === "expired") {
       return apiError(
         new ApiError(
           "Scan result has expired. Start a new scan to generate fresh evidence.",
@@ -49,22 +30,7 @@ export async function GET(
       );
     }
 
-    return apiSuccess({
-      id: scan.id,
-      domain: scan.domain,
-      status: scan.status,
-      score: scan.score,
-      totalViolations: scan.totalViolations,
-      criticalCount: scan.criticalCount,
-      seriousCount: scan.seriousCount,
-      moderateCount: scan.moderateCount,
-      minorCount: scan.minorCount,
-      pagesScanned: scan.pagesScanned,
-      violations: scan.violations,
-      screenshotKeys: scan.screenshotKeys,
-      createdAt: scan.createdAt,
-      completedAt: scan.completedAt,
-    });
+    return apiSuccess(toPublicScanApiPayload(scan));
   } catch (error) {
     return apiError(error);
   }

--- a/apps/web/src/app/api/public-scan/route.test.ts
+++ b/apps/web/src/app/api/public-scan/route.test.ts
@@ -12,7 +12,8 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { GET, isPrivateOrLoopbackAddress, validatePublicScanTarget } from "./route";
+import { GET, POST } from "./route";
+import { isPrivateOrLoopbackAddress, validatePublicScanTarget } from "@/lib/public-scan/target-validation";
 
 describe("public scan target validation", () => {
   beforeEach(() => {
@@ -55,5 +56,33 @@ describe("GET /api/public-scan?id=...", () => {
 
     expect(response.status).toBe(410);
     expect(payload.error?.code).toBe("SCAN_EXPIRED");
+  });
+
+  it("rejects URLs with embedded credentials", async () => {
+    const request = new Request("http://localhost/api/public-scan", {
+      method: "POST",
+      body: JSON.stringify({ domain: "https://user:pass@example.com" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error?.message).toMatch(/embedded credentials/i);
+  });
+
+  it("rejects URLs that target non-default ports", async () => {
+    const request = new Request("http://localhost/api/public-scan", {
+      method: "POST",
+      body: JSON.stringify({ domain: "https://example.com:8443" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error?.message).toMatch(/default http/i);
   });
 });

--- a/apps/web/src/app/api/public-scan/route.ts
+++ b/apps/web/src/app/api/public-scan/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma } from "@/lib/db";
 import { apiSuccess, apiError } from "@/lib/api-utils";
 import { ApiError } from "@aros/shared";
+import { getPublicScanById, getPublicScanEvidenceState, toPublicScanApiPayload } from "@/lib/public-scan/validity";
+import { createPublicScanResult, findRecentPublicScanForRateLimit } from "@/lib/public-scan/queries";
+import { validatePublicScanTarget } from "@/lib/public-scan/target-validation";
 import { createHash } from "crypto";
-import { lookup } from "node:dns/promises";
 
 export const runtime = "nodejs";
 
@@ -15,66 +16,6 @@ const scanSchema = z.object({
   domain: z.string().min(1, "Domain is required").max(253),
 });
 
-const BLOCKED_HOSTNAMES = new Set([
-  "localhost",
-  "127.0.0.1",
-  "::1",
-  "0.0.0.0",
-  "169.254.169.254", // cloud metadata endpoint
-]);
-
-function isPrivateIpv4(address: string): boolean {
-  const octets = address.split(".").map(Number);
-  if (octets.length !== 4 || octets.some((octet) => Number.isNaN(octet) || octet < 0 || octet > 255)) {
-    return false;
-  }
-
-  return (
-    octets[0] === 10 ||
-    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
-    (octets[0] === 192 && octets[1] === 168) ||
-    octets[0] === 127 ||
-    (octets[0] === 169 && octets[1] === 254)
-  );
-}
-
-function isPrivateIpv6(address: string): boolean {
-  const normalized = address.toLowerCase();
-  return normalized === "::1" || normalized.startsWith("fc") || normalized.startsWith("fd") || normalized.startsWith("fe80:");
-}
-
-export function isPrivateOrLoopbackAddress(address: string): boolean {
-  return address.includes(":") ? isPrivateIpv6(address) : isPrivateIpv4(address);
-}
-
-export async function validatePublicScanTarget(hostname: string): Promise<void> {
-  const normalizedHostname = hostname.toLowerCase();
-
-  if (BLOCKED_HOSTNAMES.has(normalizedHostname) || normalizedHostname.endsWith(".local")) {
-    throw new ApiError(
-      "Private, loopback, and local network hosts are not allowed for public scans.",
-      "PUBLIC_SCAN_HOST_BLOCKED",
-      400,
-    );
-  }
-
-  let resolvedAddress: string;
-  try {
-    const { address } = await lookup(normalizedHostname);
-    resolvedAddress = address;
-  } catch {
-    throw ApiError.badRequest("Domain could not be resolved. Please enter a public hostname.");
-  }
-  if (isPrivateOrLoopbackAddress(resolvedAddress)) {
-    throw new ApiError(
-      "Resolved host points to a private or loopback address and cannot be scanned publicly.",
-      "PUBLIC_SCAN_HOST_BLOCKED",
-      400,
-      { hostname: normalizedHostname },
-    );
-  }
-}
-
 async function normalizePublicScanDomain(rawDomain: string): Promise<{ domain: string; url: string }> {
   const candidate = rawDomain.startsWith("http://") || rawDomain.startsWith("https://")
     ? rawDomain
@@ -84,11 +25,17 @@ async function normalizePublicScanDomain(rawDomain: string): Promise<{ domain: s
   if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
     throw ApiError.badRequest("Only HTTP and HTTPS URLs are allowed");
   }
+  if (parsed.username || parsed.password) {
+    throw ApiError.badRequest("URLs with embedded credentials are not allowed");
+  }
+  if (parsed.port && parsed.port !== "80" && parsed.port !== "443") {
+    throw ApiError.badRequest("Only default HTTP(S) ports are allowed");
+  }
   if (!parsed.hostname || !parsed.hostname.includes(".")) {
     throw ApiError.badRequest("Invalid domain format");
   }
 
-  const normalizedDomain = parsed.hostname.toLowerCase();
+  const normalizedDomain = parsed.hostname.toLowerCase().replace(/\.$/, "");
   await validatePublicScanTarget(normalizedDomain);
   return {
     domain: normalizedDomain,
@@ -117,13 +64,10 @@ export async function POST(request: Request) {
       "unknown";
     const ipHash = createHash("sha256").update(`${ip}:${domain}`).digest("hex");
 
-    const recentScan = await prisma.publicScanResult.findFirst({
-      where: {
-        domain,
-        ipHash,
-        createdAt: { gte: new Date(Date.now() - RATE_LIMIT_SECONDS * 1000) },
-      },
-      orderBy: { createdAt: "desc" },
+    const recentScan = await findRecentPublicScanForRateLimit({
+      domain,
+      ipHash,
+      rateLimitSeconds: RATE_LIMIT_SECONDS,
     });
 
     if (recentScan) {
@@ -155,15 +99,13 @@ export async function POST(request: Request) {
     }
 
     // Create scan record
-    const scan = await prisma.publicScanResult.create({
-      data: {
-        domain,
-        url,
-        status: "PENDING",
-        maxPages: PUBLIC_SCAN_MAX_PAGES,
-        ipHash,
-        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h TTL
-      },
+    const scan = await createPublicScanResult({
+      domain,
+      url,
+      status: "PENDING",
+      maxPages: PUBLIC_SCAN_MAX_PAGES,
+      ipHash,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
     });
 
     // Enqueue the scan job (fire and forget - client polls for results)
@@ -215,31 +157,16 @@ export async function GET(request: Request) {
       return apiError(ApiError.badRequest("Scan ID required"));
     }
 
-    const scan = await prisma.publicScanResult.findUnique({ where: { id } });
+    const scan = await getPublicScanById(id);
 
     if (!scan) {
       return apiError(ApiError.notFound("Scan not found"));
     }
-    if (scan.expiresAt && scan.expiresAt <= new Date()) {
+    if (getPublicScanEvidenceState(scan) === "expired") {
       return apiError(new ApiError("Scan result has expired. Start a new scan to generate fresh evidence.", "SCAN_EXPIRED", 410));
     }
 
-    return apiSuccess({
-      id: scan.id,
-      domain: scan.domain,
-      status: scan.status,
-      score: scan.score,
-      totalViolations: scan.totalViolations,
-      criticalCount: scan.criticalCount,
-      seriousCount: scan.seriousCount,
-      moderateCount: scan.moderateCount,
-      minorCount: scan.minorCount,
-      pagesScanned: scan.pagesScanned,
-      violations: scan.violations,
-      screenshotKeys: scan.screenshotKeys,
-      createdAt: scan.createdAt,
-      completedAt: scan.completedAt,
-    });
+    return apiSuccess(toPublicScanApiPayload(scan));
   } catch (error) {
     return apiError(error);
   }

--- a/apps/web/src/app/api/reports/route.ts
+++ b/apps/web/src/app/api/reports/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from "next/server";
 import { requireSession } from "@/lib/session";
 import { prisma } from "@/lib/db";
-import { hasPermission } from "@aros/config";
-import { getEntitlementState, requireOrgAccess } from "@/lib/auth-guard";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
 import {
   collectPlatformHealth,
   buildRoutePlatformTruth,
 } from "@aros/core-services";
 import { buildFindingProofSummary } from "@/lib/findings/proof-summary";
 import { summarizeFindingFamilies } from "@/lib/findings/family-summary";
+import { listFindingsForReport } from "@/lib/reports/org-scoped-queries";
 
 export async function GET(request: Request) {
   try {
@@ -27,54 +27,18 @@ export async function GET(request: Request) {
     }
 
     // Use centralized auth guard
-    const ctx = await requireOrgAccess(requestedOrgId, "reports:export", {
+    const ctx = await requireCanonicalOrgAccess(requestedOrgId, "reports:export", {
       requirePaid: true,
     });
-
-    const where: Record<string, unknown> = {
-      site: {
-        workspace: { organizationId: ctx.organizationId },
-        ...(siteId ? { id: siteId } : {}),
-      },
-    };
 
     const health = await collectPlatformHealth(prisma);
     const truth = buildRoutePlatformTruth(health);
 
-    const findings = await prisma.canonicalFinding.findMany({
-      where,
-      include: {
-        occurrences: {
-          include: { page: { select: { url: true, title: true } } },
-          take: 100,
-        },
-        evidenceRecords: {
-          take: 20,
-          orderBy: [{ capturedAt: "desc" }, { createdAt: "desc" }],
-        },
-        verificationRuns: {
-          take: 10,
-          orderBy: [{ completedAt: "desc" }, { createdAt: "desc" }],
-        },
-        governanceDecisions: {
-          take: 10,
-          orderBy: [{ createdAt: "desc" }],
-          select: {
-            id: true,
-            kind: true,
-            status: true,
-            rationale: true,
-            justification: true,
-            expiresAt: true,
-            createdAt: true,
-          },
-        },
-      },
-      orderBy: [{ impact: "asc" }, { occurrenceCount: "desc" }],
-    });
+    const findings = await listFindingsForReport(ctx, siteId);
+    type ReportFinding = (typeof findings)[number];
 
     const familySummaryByRuleId = summarizeFindingFamilies(
-      findings.map((finding) => ({
+      findings.map((finding: ReportFinding) => ({
         ruleId: finding.ruleId,
         firstSeenAt: finding.firstSeenAt,
         lastSeenAt: finding.lastSeenAt,
@@ -96,23 +60,23 @@ export async function GET(request: Request) {
       summary: {
         totalFindings: findings.length,
         bySeverity: {
-          critical: findings.filter((f) => f.impact === "CRITICAL").length,
-          serious: findings.filter((f) => f.impact === "SERIOUS").length,
-          moderate: findings.filter((f) => f.impact === "MODERATE").length,
-          minor: findings.filter((f) => f.impact === "MINOR").length,
+          critical: findings.filter((f: ReportFinding) => f.impact === "CRITICAL").length,
+          serious: findings.filter((f: ReportFinding) => f.impact === "SERIOUS").length,
+          moderate: findings.filter((f: ReportFinding) => f.impact === "MODERATE").length,
+          minor: findings.filter((f: ReportFinding) => f.impact === "MINOR").length,
         },
         byEvidenceSource: {
           automatedAxe: findings.filter(
-            (f) => f.evidenceSource === "AUTOMATED_AXE",
+            (f: ReportFinding) => f.evidenceSource === "AUTOMATED_AXE",
           ).length,
           manualReview: findings.filter(
-            (f) => f.evidenceSource === "MANUAL_REVIEW",
+            (f: ReportFinding) => f.evidenceSource === "MANUAL_REVIEW",
           ).length,
-          imported: findings.filter((f) => f.evidenceSource === "IMPORTED")
+          imported: findings.filter((f: ReportFinding) => f.evidenceSource === "IMPORTED")
             .length,
         },
         proofCompleteness: {
-          complete: findings.filter((f) => {
+          complete: findings.filter((f: ReportFinding) => {
             const summary = buildFindingProofSummary({
               evidenceSummary: f.evidenceSummary,
               provenance: f.provenance,
@@ -122,7 +86,7 @@ export async function GET(request: Request) {
             });
             return Object.values(summary.completeness).filter(Boolean).length >= 4;
           }).length,
-          partial: findings.filter((f) => {
+          partial: findings.filter((f: ReportFinding) => {
             const summary = buildFindingProofSummary({
               evidenceSummary: f.evidenceSummary,
               provenance: f.provenance,
@@ -134,7 +98,7 @@ export async function GET(request: Request) {
           }).length,
         },
       },
-      findings: findings.map((f) => ({
+      findings: findings.map((f: ReportFinding) => ({
         id: f.id,
         ruleId: f.ruleId,
         impact: f.impact,
@@ -174,7 +138,7 @@ export async function GET(request: Request) {
               outcomeSummary: f.verificationRuns[0].outcomeSummary,
             }
           : null,
-        governance: f.governanceDecisions.map((decision) => ({
+        governance: f.governanceDecisions.map((decision: ReportFinding["governanceDecisions"][number]) => ({
           id: decision.id,
           kind: decision.kind,
           status: decision.status,
@@ -183,7 +147,7 @@ export async function GET(request: Request) {
           expiresAt: decision.expiresAt,
           createdAt: decision.createdAt,
         })),
-        affectedPages: f.occurrences.map((o) => ({
+        affectedPages: f.occurrences.map((o: ReportFinding["occurrences"][number]) => ({
           url: o.page.url,
           title: o.page.title,
           selector: o.selector,

--- a/apps/web/src/lib/integrations/org-scoped-queries.ts
+++ b/apps/web/src/lib/integrations/org-scoped-queries.ts
@@ -1,0 +1,62 @@
+import { prisma } from "@/lib/db";
+import type { OrgMembershipCore } from "@/lib/route-data-boundary";
+import { runCanonicalOrgQuery } from "@/lib/server-org-boundary";
+
+export async function findGithubActionSite(ctx: OrgMembershipCore, siteId: string) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.site.findFirst({
+      where: {
+        id: siteId,
+        workspace: { organizationId },
+      },
+      include: {
+        workspace: {
+          include: { organization: true },
+        },
+      },
+    }),
+  );
+}
+
+export async function createPendingScanRun(siteId: string) {
+  return prisma.scanRun.create({
+    data: {
+      siteId,
+      status: "PENDING",
+    },
+  });
+}
+
+export async function listDeployWebhooks(ctx: OrgMembershipCore) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.deployWebhook.findMany({
+      where: { organizationId },
+      include: { site: { select: { id: true, name: true, domain: true } } },
+      orderBy: { createdAt: "desc" },
+    }),
+  );
+}
+
+export async function findActiveDeployWebhookByDomain(domain: string) {
+  return prisma.deployWebhook.findFirst({
+    where: {
+      isActive: true,
+      site: { domain },
+    },
+    include: {
+      site: {
+        include: {
+          workspace: {
+            include: {
+              organization: {
+                include: {
+                  subscription: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/apps/web/src/lib/public-scan/queries.ts
+++ b/apps/web/src/lib/public-scan/queries.ts
@@ -1,0 +1,29 @@
+import { prisma } from "@/lib/db";
+
+export async function findRecentPublicScanForRateLimit(input: {
+  domain: string;
+  ipHash: string;
+  rateLimitSeconds: number;
+}) {
+  return prisma.publicScanResult.findFirst({
+    where: {
+      domain: input.domain,
+      ipHash: input.ipHash,
+      createdAt: { gte: new Date(Date.now() - input.rateLimitSeconds * 1000) },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export async function createPublicScanResult(input: {
+  domain: string;
+  url: string;
+  status: "PENDING";
+  maxPages: number;
+  ipHash: string;
+  expiresAt: Date;
+}) {
+  return prisma.publicScanResult.create({
+    data: input,
+  });
+}

--- a/apps/web/src/lib/public-scan/target-validation.ts
+++ b/apps/web/src/lib/public-scan/target-validation.ts
@@ -1,0 +1,63 @@
+import { ApiError } from "@aros/shared";
+import { lookup } from "node:dns/promises";
+
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "0.0.0.0",
+  "169.254.169.254",
+]);
+
+function isPrivateIpv4(address: string): boolean {
+  const octets = address.split(".").map(Number);
+  if (octets.length !== 4 || octets.some((octet) => Number.isNaN(octet) || octet < 0 || octet > 255)) {
+    return false;
+  }
+
+  return (
+    octets[0] === 10 ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168) ||
+    octets[0] === 127 ||
+    (octets[0] === 169 && octets[1] === 254)
+  );
+}
+
+function isPrivateIpv6(address: string): boolean {
+  const normalized = address.toLowerCase();
+  return normalized === "::1" || normalized.startsWith("fc") || normalized.startsWith("fd") || normalized.startsWith("fe80:");
+}
+
+export function isPrivateOrLoopbackAddress(address: string): boolean {
+  return address.includes(":") ? isPrivateIpv6(address) : isPrivateIpv4(address);
+}
+
+export async function validatePublicScanTarget(hostname: string): Promise<void> {
+  const normalizedHostname = hostname.toLowerCase();
+
+  if (BLOCKED_HOSTNAMES.has(normalizedHostname) || normalizedHostname.endsWith(".local")) {
+    throw new ApiError(
+      "Private, loopback, and local network hosts are not allowed for public scans.",
+      "PUBLIC_SCAN_HOST_BLOCKED",
+      400,
+    );
+  }
+
+  let resolvedAddress: string;
+  try {
+    const { address } = await lookup(normalizedHostname);
+    resolvedAddress = address;
+  } catch {
+    throw ApiError.badRequest("Domain could not be resolved. Please enter a public hostname.");
+  }
+
+  if (isPrivateOrLoopbackAddress(resolvedAddress)) {
+    throw new ApiError(
+      "Resolved host points to a private or loopback address and cannot be scanned publicly.",
+      "PUBLIC_SCAN_HOST_BLOCKED",
+      400,
+      { hostname: normalizedHostname },
+    );
+  }
+}

--- a/apps/web/src/lib/public-scan/validity.test.ts
+++ b/apps/web/src/lib/public-scan/validity.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    publicScanResult: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
+import { getPublicScanEvidenceState, toPublicScanApiPayload } from "./validity";
+
+describe("public scan validity contract", () => {
+  it("classifies missing records as missing", () => {
+    expect(getPublicScanEvidenceState(null)).toBe("missing");
+  });
+
+  it("classifies expired records as expired", () => {
+    expect(
+      getPublicScanEvidenceState({ expiresAt: new Date("2020-01-01T00:00:00Z") }, new Date("2020-01-02T00:00:00Z")),
+    ).toBe("expired");
+  });
+
+  it("classifies unexpired records as valid", () => {
+    expect(
+      getPublicScanEvidenceState({ expiresAt: new Date("2020-01-03T00:00:00Z") }, new Date("2020-01-02T00:00:00Z")),
+    ).toBe("valid");
+  });
+
+  it("maps canonical API payload fields", () => {
+    const payload = toPublicScanApiPayload({
+      id: "scan_123",
+      domain: "example.com",
+      status: "COMPLETED",
+      score: 90,
+      totalViolations: 2,
+      criticalCount: 0,
+      seriousCount: 1,
+      moderateCount: 1,
+      minorCount: 0,
+      pagesScanned: 5,
+      violations: [],
+      screenshotKeys: [],
+      createdAt: new Date("2020-01-01T00:00:00Z"),
+      completedAt: new Date("2020-01-01T00:05:00Z"),
+      expiresAt: new Date("2020-01-02T00:00:00Z"),
+    });
+
+    expect(payload).toMatchObject({
+      id: "scan_123",
+      domain: "example.com",
+      status: "COMPLETED",
+      score: 90,
+      totalViolations: 2,
+    });
+    expect(payload).not.toHaveProperty("expiresAt");
+  });
+});

--- a/apps/web/src/lib/public-scan/validity.ts
+++ b/apps/web/src/lib/public-scan/validity.ts
@@ -1,0 +1,103 @@
+import { prisma } from "@/lib/db";
+
+export type PublicEvidenceState = "valid" | "expired" | "missing";
+
+type PublicScanCore = {
+  id: string;
+  domain: string;
+  status: string;
+  score: number | null;
+  totalViolations: number;
+  criticalCount: number;
+  seriousCount: number;
+  moderateCount: number;
+  minorCount: number;
+  pagesScanned: number;
+  violations: unknown;
+  screenshotKeys: unknown;
+  createdAt: Date;
+  completedAt: Date | null;
+  expiresAt: Date | null;
+};
+
+export function getPublicScanEvidenceState(
+  scan: Pick<PublicScanCore, "expiresAt"> | null,
+  now = new Date(),
+): PublicEvidenceState {
+  if (!scan) return "missing";
+  if (scan.expiresAt && scan.expiresAt <= now) return "expired";
+  return "valid";
+}
+
+export function toPublicScanApiPayload(scan: PublicScanCore) {
+  return {
+    id: scan.id,
+    domain: scan.domain,
+    status: scan.status,
+    score: scan.score,
+    totalViolations: scan.totalViolations,
+    criticalCount: scan.criticalCount,
+    seriousCount: scan.seriousCount,
+    moderateCount: scan.moderateCount,
+    minorCount: scan.minorCount,
+    pagesScanned: scan.pagesScanned,
+    violations: scan.violations,
+    screenshotKeys: scan.screenshotKeys,
+    createdAt: scan.createdAt,
+    completedAt: scan.completedAt,
+  };
+}
+
+export async function getPublicScanById(id: string): Promise<PublicScanCore | null> {
+  return prisma.publicScanResult.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      domain: true,
+      status: true,
+      score: true,
+      totalViolations: true,
+      criticalCount: true,
+      seriousCount: true,
+      moderateCount: true,
+      minorCount: true,
+      pagesScanned: true,
+      violations: true,
+      screenshotKeys: true,
+      createdAt: true,
+      completedAt: true,
+      expiresAt: true,
+    },
+  });
+}
+
+export async function getLatestValidPublicScanForDomain(
+  domain: string,
+  options: { requireCompleted: boolean },
+): Promise<PublicScanCore | null> {
+  return prisma.publicScanResult.findFirst({
+    where: {
+      domain,
+      expiresAt: { gt: new Date() },
+      ...(options.requireCompleted ? { status: "COMPLETED" } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      domain: true,
+      status: true,
+      score: true,
+      totalViolations: true,
+      criticalCount: true,
+      seriousCount: true,
+      moderateCount: true,
+      minorCount: true,
+      pagesScanned: true,
+      violations: true,
+      screenshotKeys: true,
+      createdAt: true,
+      completedAt: true,
+      expiresAt: true,
+    },
+  });
+}

--- a/apps/web/src/lib/reports/org-scoped-queries.ts
+++ b/apps/web/src/lib/reports/org-scoped-queries.ts
@@ -1,0 +1,44 @@
+import { prisma } from "@/lib/db";
+import type { OrgMembershipCore } from "@/lib/route-data-boundary";
+import { runCanonicalOrgQuery } from "@/lib/server-org-boundary";
+
+export async function listFindingsForReport(ctx: OrgMembershipCore, siteId?: string | null) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.canonicalFinding.findMany({
+      where: {
+        site: {
+          workspace: { organizationId },
+          ...(siteId ? { id: siteId } : {}),
+        },
+      },
+      include: {
+        occurrences: {
+          include: { page: { select: { url: true, title: true } } },
+          take: 100,
+        },
+        evidenceRecords: {
+          take: 20,
+          orderBy: [{ capturedAt: "desc" }, { createdAt: "desc" }],
+        },
+        verificationRuns: {
+          take: 10,
+          orderBy: [{ completedAt: "desc" }, { createdAt: "desc" }],
+        },
+        governanceDecisions: {
+          take: 10,
+          orderBy: [{ createdAt: "desc" }],
+          select: {
+            id: true,
+            kind: true,
+            status: true,
+            rationale: true,
+            justification: true,
+            expiresAt: true,
+            createdAt: true,
+          },
+        },
+      },
+      orderBy: [{ impact: "asc" }, { occurrenceCount: "desc" }],
+    }),
+  );
+}

--- a/scripts/check-tenant-boundary-critical.mjs
+++ b/scripts/check-tenant-boundary-critical.mjs
@@ -5,6 +5,13 @@ const CRITICAL_ENTRYPOINTS = [
   "src/app/api/comments/route.ts",
   "src/app/api/credits/route.ts",
   "src/app/api/impact/route.ts",
+  "src/app/api/reports/route.ts",
+  "src/app/api/reports/vpat/route.ts",
+  "src/app/api/github-action/route.ts",
+  "src/app/api/deploy-webhook/route.ts",
+  "src/app/api/public-scan/route.ts",
+  "src/app/api/public-scan/[id]/route.ts",
+  "src/app/api/badge/route.ts",
 ];
 
 const joined = CRITICAL_ENTRYPOINTS.join(" ");


### PR DESCRIPTION
### Motivation
- Prevent stale or expired public scan results from being treated as "latest/current" and centralize validity logic to avoid route-local drift. 
- Remove direct route-local Prisma access from high-risk integration/report entrypoints and enforce the canonical org-boundary pattern for tenant safety. 
- Harden anonymous public-scan intake against SSRF/abuse (embedded credentials, non-default ports) and ensure consistent behavior across public pages and badge output. 

### Description
- Added a canonical public-scan validity module (`apps/web/src/lib/public-scan/validity.ts`) that exports `getPublicScanEvidenceState`, `getPublicScanById`, `getLatestValidPublicScanForDomain`, and a payload mapper. 
- Moved SSRF/hostname resolution logic into `apps/web/src/lib/public-scan/target-validation.ts` and added query helpers in `apps/web/src/lib/public-scan/queries.ts`. 
- Updated public-scan endpoints and consumers to use the canonical contract: `/api/public-scan` (POST/GET), `/api/public-scan/[id]`, public page metadata/loader, and `/api/badge`. 
- Created org-scoped query modules `apps/web/src/lib/reports/org-scoped-queries.ts` and `apps/web/src/lib/integrations/org-scoped-queries.ts`, and migrated `/api/reports`, `/api/github-action`, and `/api/deploy-webhook` to call those scoped modules and `requireCanonicalOrgAccess` instead of doing direct `prisma` access in handlers. 
- Expanded the tenant-boundary release gate list in `scripts/check-tenant-boundary-critical.mjs` from 3 to 10 critical entrypoints. 
- Added regression tests: `apps/web/src/lib/public-scan/validity.test.ts` (validity contract) and new intake tests in `apps/web/src/app/api/public-scan/route.test.ts` for credentialed URLs and non-default ports. 

### Testing
- Ran `npm run verify:tenant-boundary` and it passed for the expanded list of 10 critical entrypoints. ✅
- Ran targeted unit tests `npm run test --workspace=apps/web -- src/app/api/public-scan/route.test.ts src/lib/public-scan/validity.test.ts` and both tests passed (all assertions green). ✅
- Built the web app with `npm run build --workspace=apps/web` and the build completed successfully (Next.js compile + page generation succeeded, existing lint warnings remained). ✅
- Ran workspace `npm run lint` which completed but shows remaining tenant-boundary warnings in uncovered server-action families (no rule suppression introduced). ⚠️
- Ran workspace `npm run typecheck` which failed with pre-existing, workspace-wide TypeScript/Prisma type export issues not introduced by this change. ❌
- Ran full `npm run test` and `npm run verify:release`; they failed due to pre-existing setup/type issues (not caused by these changes), notably `prisma:check` requiring generated client and several web tests depending on DB client generation. ❌

The changes focus on small, high-confidence refactors to centralize public evidence validity and harden tenant boundaries for launch‑critical surfaces; remaining workspace-wide type and test failures (Prisma client/type drift and server-action coverage) are acknowledged and outside the narrow scope of this pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe7b4e888832885de77fad997f469)