### PR TITLE
Harden tenant-boundary coverage and public-scan evidence semantics

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/billing/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/billing/actions.ts
@@ -1,9 +1,13 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { requireOrgAccess } from "@/lib/auth-guard";
-import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/session";
 import { getAppBaseUrl, getStripePriceIdForPlan } from "@/lib/billing";
+import { requireOrgAccess } from "@/lib/auth-guard";
+import {
+  getBillingCustomer,
+  getOrCreateBillingCustomer,
+} from "@/lib/billing/org-scoped-queries";
 import type { PlanTier } from "@aros/db";
 
 function redirectWithError(message: string) {
@@ -11,6 +15,7 @@ function redirectWithError(message: string) {
 }
 
 export async function startSubscriptionCheckoutAction(formData: FormData) {
+  const user = await requireSession();
   const organizationId =
     (formData.get("organizationId") as string | null) ?? "";
   const requestedPlanRaw = (formData.get("plan") as string | null) ?? "";
@@ -48,27 +53,19 @@ export async function startSubscriptionCheckoutAction(formData: FormData) {
   const stripe = new StripeCtor(process.env.STRIPE_SECRET_KEY);
   const baseUrl = getAppBaseUrl();
 
-  let billingCustomer = await prisma.billingCustomer.findUnique({
-    where: { organizationId: ctx.organizationId },
+  const billingCustomer = await getOrCreateBillingCustomer(ctx, {
+    createStripeCustomerId: async () => {
+      const customer = await stripe.customers.create({
+        email: user.email,
+        name: user.name ?? undefined,
+        metadata: {
+          organizationId: ctx.organizationId,
+          userId: user.id,
+        },
+      });
+      return customer.id;
+    },
   });
-
-  if (!billingCustomer) {
-    const customer = await stripe.customers.create({
-      email: ctx.user.email,
-      name: ctx.user.name ?? undefined,
-      metadata: {
-        organizationId: ctx.organizationId,
-        userId: ctx.user.id,
-      },
-    });
-
-    billingCustomer = await prisma.billingCustomer.create({
-      data: {
-        organizationId: ctx.organizationId,
-        stripeCustomerId: customer.id,
-      },
-    });
-  }
 
   const session = await stripe.checkout.sessions.create({
     mode: "subscription",
@@ -84,7 +81,7 @@ export async function startSubscriptionCheckoutAction(formData: FormData) {
     metadata: {
       organizationId: ctx.organizationId,
       requestedPlan,
-      userId: ctx.user.id,
+      userId: user.id,
     },
     success_url: `${baseUrl}/settings/billing?checkout=success`,
     cancel_url: `${baseUrl}/settings/billing?checkout=cancelled`,
@@ -106,9 +103,7 @@ export async function openBillingPortalAction(formData: FormData) {
     redirectWithError("Billing is not configured for this deployment.");
   }
 
-  const billingCustomer = await prisma.billingCustomer.findUnique({
-    where: { organizationId: ctx.organizationId },
-  });
+  const billingCustomer = await getBillingCustomer(ctx);
 
   if (!billingCustomer) {
     redirect("/settings/billing?status=no_customer");

--- a/apps/web/src/app/(public)/scan/[domain]/page.tsx
+++ b/apps/web/src/app/(public)/scan/[domain]/page.tsx
@@ -14,10 +14,15 @@ export async function generateMetadata({
 
   const scan = await getLatestValidPublicScanForDomain(decoded, { requireCompleted: true });
 
+  const hasCurrentEvidence = Boolean(scan);
   const score = scan?.score ?? 0;
-  const total = scan?.totalViolations ?? 0;
-  const title = `Accessibility Report: ${decoded} (Score: ${score})`;
-  const description = `Found ${total} accessibility issues on ${decoded}. Scan powered by AROS - source-level accessibility remediation.`;
+  const totalViolations = scan?.totalViolations ?? 0;
+  const title = hasCurrentEvidence
+    ? `Accessibility Report: ${decoded} (Score: ${score})`
+    : `Accessibility Report: ${decoded} (No current evidence)`;
+  const description = hasCurrentEvidence
+    ? `Found ${totalViolations} accessibility issues on ${decoded}. Scan powered by AROS - source-level accessibility remediation.`
+    : `No current scan evidence is available for ${decoded}. Run a new public scan to generate fresh accessibility evidence.`;
   const ogUrl = `/api/og?domain=${encodeURIComponent(decoded)}&score=${score}&critical=${scan?.criticalCount ?? 0}&serious=${scan?.seriousCount ?? 0}&moderate=${scan?.moderateCount ?? 0}&minor=${scan?.minorCount ?? 0}`;
 
   return {

--- a/apps/web/src/app/api/ai-copilot/route.ts
+++ b/apps/web/src/app/api/ai-copilot/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
-import { requireOrgAccess } from "@/lib/auth-guard";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
+import {
+  getCopilotFindingContext,
+  logAiCopilotUsage,
+  requireAiEnabled,
+} from "@/lib/ai/org-scoped-queries";
 import { apiError } from "@/lib/api-utils";
-import { ApiError } from "@aros/shared";
 
 export const runtime = "nodejs";
 
@@ -26,54 +29,14 @@ export async function POST(request: Request) {
     const body = await request.json();
     const parsed = chatSchema.parse(body);
 
-    const ctx = await requireOrgAccess(
+    const ctx = await requireCanonicalOrgAccess(
       parsed.organizationId,
       "finding:manage",
       { requirePaid: true },
     );
 
     // Load finding context for RAG
-    const finding = await prisma.canonicalFinding.findFirst({
-      where: {
-        id: parsed.findingId,
-        site: { workspace: { organizationId: ctx.organizationId } },
-      },
-      include: {
-        occurrences: {
-          take: 3,
-          include: { page: { select: { url: true, title: true } } },
-        },
-        suggestions: {
-          take: 3,
-          orderBy: { createdAt: "desc" },
-          select: {
-            type: true,
-            suggestedCode: true,
-            rationale: true,
-            confidence: true,
-            status: true,
-          },
-        },
-        cluster: {
-          select: {
-            name: true,
-            description: true,
-            pageCount: true,
-            findingCount: true,
-          },
-        },
-      },
-    });
-
-    if (!finding) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: { code: "NOT_FOUND", message: "Finding not found" },
-        },
-        { status: 404 },
-      );
-    }
+    const finding = await getCopilotFindingContext(ctx, parsed.findingId);
 
     // Build context prompt
     const systemPrompt =
@@ -98,11 +61,8 @@ ${finding.occurrences.map((o) => `- Page: ${o.page.url}\n  Selector: ${o.selecto
 ${parsed.message}`;
 
     // Check AI entitlement
-    const subscription = await prisma.subscription.findUnique({
-      where: { organizationId: ctx.organizationId },
-    });
-
-    if (!subscription?.aiEnabled) {
+    const aiEnabled = await requireAiEnabled(ctx);
+    if (!aiEnabled) {
       return NextResponse.json(
         {
           success: false,
@@ -168,16 +128,9 @@ ${parsed.message}`;
     });
 
     // Log AI usage
-    await prisma.aiUsageLog.create({
-      data: {
-        organizationId: ctx.organizationId,
-        userId: user.id,
-        model: anthropicKey ? "claude-sonnet-4-20250514" : "gpt-4o",
-        promptTokens: 0,
-        completionTokens: 0,
-        totalTokens: 0,
-        purpose: "copilot-chat",
-      },
+    await logAiCopilotUsage(ctx, {
+      userId: user.id,
+      model: anthropicKey ? "claude-sonnet-4-20250514" : "gpt-4o",
     });
 
     return new NextResponse(stream, {

--- a/apps/web/src/app/api/public-scan/[id]/route.test.ts
+++ b/apps/web/src/app/api/public-scan/[id]/route.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findUniqueMock } = vi.hoisted(() => ({
+  findUniqueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    publicScanResult: {
+      findUnique: findUniqueMock,
+    },
+  },
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/public-scan/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 410 with machine-visible expired semantics", async () => {
+    findUniqueMock.mockResolvedValueOnce({
+      id: "scan_1",
+      domain: "example.com",
+      status: "COMPLETED",
+      score: 80,
+      totalViolations: 1,
+      criticalCount: 0,
+      seriousCount: 1,
+      moderateCount: 0,
+      minorCount: 0,
+      pagesScanned: 1,
+      violations: [],
+      screenshotKeys: [],
+      createdAt: new Date(Date.now() - 120_000),
+      completedAt: new Date(Date.now() - 60_000),
+      expiresAt: new Date(Date.now() - 30_000),
+    });
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "scan_1" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(410);
+    expect(payload).toMatchObject({
+      success: false,
+      error: {
+        code: "SCAN_EXPIRED",
+        details: {
+          evidenceState: "expired",
+          expired: true,
+        },
+      },
+    });
+  });
+});

--- a/apps/web/src/app/api/public-scan/[id]/route.ts
+++ b/apps/web/src/app/api/public-scan/[id]/route.ts
@@ -21,12 +21,20 @@ export async function GET(
       return apiError(ApiError.notFound("Scan not found"));
     }
     if (getPublicScanEvidenceState(scan) === "expired") {
-      return apiError(
-        new ApiError(
-          "Scan result has expired. Start a new scan to generate fresh evidence.",
-          "SCAN_EXPIRED",
-          410,
-        ),
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "SCAN_EXPIRED",
+            message:
+              "Scan result has expired. Start a new scan to generate fresh evidence.",
+            details: {
+              evidenceState: "expired",
+              expired: true,
+            },
+          },
+        },
+        { status: 410 },
       );
     }
 

--- a/apps/web/src/app/api/public-scan/route.test.ts
+++ b/apps/web/src/app/api/public-scan/route.test.ts
@@ -56,6 +56,7 @@ describe("GET /api/public-scan?id=...", () => {
 
     expect(response.status).toBe(410);
     expect(payload.error?.code).toBe("SCAN_EXPIRED");
+    expect(payload.error?.details?.evidenceState).toBe("expired");
   });
 
   it("rejects URLs with embedded credentials", async () => {
@@ -84,5 +85,33 @@ describe("GET /api/public-scan?id=...", () => {
 
     expect(response.status).toBe(400);
     expect(payload.error?.message).toMatch(/default http/i);
+  });
+
+  it("rejects URLs with query strings", async () => {
+    const request = new Request("http://localhost/api/public-scan", {
+      method: "POST",
+      body: JSON.stringify({ domain: "https://example.com/?foo=bar" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error?.message).toMatch(/query strings/i);
+  });
+
+  it("rejects URLs with fragments", async () => {
+    const request = new Request("http://localhost/api/public-scan", {
+      method: "POST",
+      body: JSON.stringify({ domain: "https://example.com/#section" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error?.message).toMatch(/fragments/i);
   });
 });

--- a/apps/web/src/app/api/public-scan/route.ts
+++ b/apps/web/src/app/api/public-scan/route.ts
@@ -13,10 +13,14 @@ const PUBLIC_SCAN_MAX_PAGES = 5;
 const RATE_LIMIT_SECONDS = 300; // 5 minutes between scans per IP+domain
 
 const scanSchema = z.object({
-  domain: z.string().min(1, "Domain is required").max(253),
+  domain: z.string().min(1, "Domain is required").max(2048),
 });
 
 async function normalizePublicScanDomain(rawDomain: string): Promise<{ domain: string; url: string }> {
+  if (rawDomain.length > 2048) {
+    throw ApiError.badRequest("URL is too long");
+  }
+
   const candidate = rawDomain.startsWith("http://") || rawDomain.startsWith("https://")
     ? rawDomain
     : `https://${rawDomain}`;
@@ -30,6 +34,9 @@ async function normalizePublicScanDomain(rawDomain: string): Promise<{ domain: s
   }
   if (parsed.port && parsed.port !== "80" && parsed.port !== "443") {
     throw ApiError.badRequest("Only default HTTP(S) ports are allowed");
+  }
+  if (parsed.search || parsed.hash) {
+    throw ApiError.badRequest("Query strings and URL fragments are not allowed");
   }
   if (!parsed.hostname || !parsed.hostname.includes(".")) {
     throw ApiError.badRequest("Invalid domain format");
@@ -163,7 +170,21 @@ export async function GET(request: Request) {
       return apiError(ApiError.notFound("Scan not found"));
     }
     if (getPublicScanEvidenceState(scan) === "expired") {
-      return apiError(new ApiError("Scan result has expired. Start a new scan to generate fresh evidence.", "SCAN_EXPIRED", 410));
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "SCAN_EXPIRED",
+            message:
+              "Scan result has expired. Start a new scan to generate fresh evidence.",
+            details: {
+              evidenceState: "expired",
+              expired: true,
+            },
+          },
+        },
+        { status: 410 },
+      );
     }
 
     return apiSuccess(toPublicScanApiPayload(scan));

--- a/apps/web/src/lib/ai/org-scoped-queries.ts
+++ b/apps/web/src/lib/ai/org-scoped-queries.ts
@@ -1,0 +1,81 @@
+import { ApiError } from "@aros/shared";
+import { prisma } from "@/lib/db";
+import type { OrgMembershipCore } from "@/lib/route-data-boundary";
+import { runCanonicalOrgQuery } from "@/lib/server-org-boundary";
+
+export async function getCopilotFindingContext(
+  ctx: OrgMembershipCore,
+  findingId: string,
+) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) => {
+    const finding = await prisma.canonicalFinding.findFirst({
+      where: {
+        id: findingId,
+        site: { workspace: { organizationId } },
+      },
+      include: {
+        occurrences: {
+          take: 3,
+          include: { page: { select: { url: true, title: true } } },
+        },
+        suggestions: {
+          take: 3,
+          orderBy: { createdAt: "desc" },
+          select: {
+            type: true,
+            suggestedCode: true,
+            rationale: true,
+            confidence: true,
+            status: true,
+          },
+        },
+        cluster: {
+          select: {
+            name: true,
+            description: true,
+            pageCount: true,
+            findingCount: true,
+          },
+        },
+      },
+    });
+
+    if (!finding) {
+      throw ApiError.notFound("Finding not found");
+    }
+
+    return finding;
+  });
+}
+
+export async function requireAiEnabled(ctx: OrgMembershipCore) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) => {
+    const subscription = await prisma.subscription.findUnique({
+      where: { organizationId },
+      select: { aiEnabled: true },
+    });
+    return Boolean(subscription?.aiEnabled);
+  });
+}
+
+export async function logAiCopilotUsage(
+  ctx: OrgMembershipCore,
+  input: {
+    userId: string;
+    model: string;
+  },
+) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.aiUsageLog.create({
+      data: {
+        organizationId,
+        userId: input.userId,
+        model: input.model,
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        purpose: "copilot-chat",
+      },
+    }),
+  );
+}

--- a/apps/web/src/lib/billing/org-scoped-queries.ts
+++ b/apps/web/src/lib/billing/org-scoped-queries.ts
@@ -1,0 +1,36 @@
+import { prisma } from "@/lib/db";
+import type { OrgMembershipCore } from "@/lib/route-data-boundary";
+import { runCanonicalOrgQuery } from "@/lib/server-org-boundary";
+
+export async function getBillingCustomer(ctx: OrgMembershipCore) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.billingCustomer.findUnique({
+      where: { organizationId },
+    }),
+  );
+}
+
+export async function getOrCreateBillingCustomer(
+  ctx: OrgMembershipCore,
+  input: {
+    createStripeCustomerId: () => Promise<string>;
+  },
+) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) => {
+    const existing = await prisma.billingCustomer.findUnique({
+      where: { organizationId },
+    });
+
+    if (existing) {
+      return existing;
+    }
+
+    const stripeCustomerId = await input.createStripeCustomerId();
+    return prisma.billingCustomer.create({
+      data: {
+        organizationId,
+        stripeCustomerId,
+      },
+    });
+  });
+}

--- a/scripts/check-tenant-boundary-critical.mjs
+++ b/scripts/check-tenant-boundary-critical.mjs
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 const CRITICAL_ENTRYPOINTS = [
+  "src/app/(dashboard)/settings/billing/actions.ts",
   "src/app/api/comments/route.ts",
   "src/app/api/credits/route.ts",
   "src/app/api/impact/route.ts",
   "src/app/api/reports/route.ts",
   "src/app/api/reports/vpat/route.ts",
+  "src/app/api/ai-copilot/route.ts",
+  "src/app/api/findings/summary/route.ts",
+  "src/app/api/webhooks/stripe/route.ts",
   "src/app/api/github-action/route.ts",
   "src/app/api/deploy-webhook/route.ts",
   "src/app/api/public-scan/route.ts",
@@ -14,22 +18,27 @@ const CRITICAL_ENTRYPOINTS = [
   "src/app/api/badge/route.ts",
 ];
 
-const joined = CRITICAL_ENTRYPOINTS.join(" ");
-
 let stdout = "[]";
 try {
-  stdout = execSync(`npx eslint --format json ${joined}`, {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    cwd: "apps/web",
-  });
+  stdout = execFileSync(
+    "npx",
+    ["eslint", "--format", "json", ...CRITICAL_ENTRYPOINTS],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      cwd: "apps/web",
+    },
+  );
 } catch (error) {
   stdout = error.stdout?.toString() ?? "[]";
 }
 
+const jsonStart = stdout.indexOf("[");
+const normalizedJson = jsonStart >= 0 ? stdout.slice(jsonStart) : stdout;
+
 let report;
 try {
-  report = JSON.parse(stdout);
+  report = JSON.parse(normalizedJson);
 } catch {
   console.error("[verify:tenant-boundary] Failed to parse eslint JSON output.");
   process.exit(1);


### PR DESCRIPTION
### Motivation

- Reduce high-risk route-local Prisma access on launch-critical families (AI copilot, billing) by routing data access into canonical org-scoped modules to prevent cross-tenant leakage.  
- Make anonymous public-scan intake more robust against abuse and canonicalize stale/expired evidence semantics so clients cannot be silently shown stale results.  
- Expand the deterministic tenant-boundary release gate to block more critical server entrypoints and make the gate execution robust in CI.

### Description

- Added org-scoped query helpers: `apps/web/src/lib/ai/org-scoped-queries.ts` and `apps/web/src/lib/billing/org-scoped-queries.ts` and moved route-level DB responsibilities into them.  
- Migrated `POST /api/ai-copilot` to use `requireCanonicalOrgAccess` and the new AI org-scoped helpers (`getCopilotFindingContext`, `requireAiEnabled`, `logAiCopilotUsage`) and removed direct `prisma` reads/writes from the handler.  
- Reworked billing server actions in `apps/web/src/app/(dashboard)/settings/billing/actions.ts` to use `getBillingCustomer` / `getOrCreateBillingCustomer` so customer creation/lookup runs inside `runCanonicalOrgQuery` instead of inline Prisma calls.  
- Hardened public-scan intake (`apps/web/src/app/api/public-scan/route.ts`): increased input length limit, reject URLs containing query strings or fragments, reject embedded credentials/non-default ports, and return machine-visible 410 semantics for expired scans; mirrored the 410 machine-visible response in `apps/web/src/app/api/public-scan/[id]/route.ts`.  
- Made public results metadata truthful when no current valid evidence exists (`apps/web/src/app/(public)/scan/[domain]/page.tsx`).  
- Added regression tests: extended `/api/public-scan` tests and added `apps/web/src/app/api/public-scan/[id]/route.test.ts` to assert expired 410 payload details and the new input rejection cases.  
- Expanded and hardened tenant-boundary verification script (`scripts/check-tenant-boundary-critical.mjs`) to include billing, ai-copilot, findings summary and stripe webhook routes, use `execFileSync` for robust invocation, and normalize JSON parsing of eslint output.

### Testing

- Ran targeted unit tests: `npm run test --workspace=apps/web -- src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts` — all tests passed.  
- Ran tenant-boundary gate: `npm run verify:tenant-boundary` — gate passed for the expanded critical entrypoints after the changes.  
- Ran lint: `npm run lint` — lint executed; new migrations removed warnings in touched files but other unrelated tenant-boundary warnings remain elsewhere (pre-existing).  
- Attempted full release verification: `npm run verify:core` / `npm run verify:release` and `npm run typecheck` — these fail due to pre-existing workspace issues (missing generated Prisma client in this environment and wide typecheck errors) and are not caused by these changes.  

Files of note: `apps/web/src/app/api/ai-copilot/route.ts`, `apps/web/src/app/(dashboard)/settings/billing/actions.ts`, `apps/web/src/app/api/public-scan/route.ts`, `apps/web/src/app/api/public-scan/[id]/route.ts`, `apps/web/src/app/(public)/scan/[domain]/page.tsx`, `apps/web/src/lib/ai/org-scoped-queries.ts`, `apps/web/src/lib/billing/org-scoped-queries.ts`, `apps/web/src/app/api/public-scan/route.test.ts`, `apps/web/src/app/api/public-scan/[id]/route.test.ts`, `scripts/check-tenant-boundary-critical.mjs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cffae70fb08328abae5ab198f88d84)