### PR TITLE
Harden tenant boundaries and public-scan validity release gates

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,8 @@
     "test:e2e": "playwright test",
     "test:ct": "playwright test -c playwright-ct.config.ts",
     "test:e2e:update": "playwright test --update-snapshots",
-    "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts"
+    "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts",
+    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts"
   },
   "dependencies": {
     "@aros/config": "*",

--- a/apps/web/src/app/api/github-action/route.ts
+++ b/apps/web/src/app/api/github-action/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: Request) {
       siteId: site.id,
       siteName: site.name,
       status: "PENDING",
-      pollUrl: `/api/github-action/status/${scanRun.id}`,
+      pollUrl: `/api/github-action/status/${scanRun.id}?organizationId=${encodeURIComponent(parsed.organizationId)}`,
       failThreshold: parsed.failThreshold,
       failOn: parsed.failOn,
       pullRequestNumber: parsed.pullRequestNumber,

--- a/apps/web/src/app/api/github-action/status/[scanRunId]/route.test.ts
+++ b/apps/web/src/app/api/github-action/status/[scanRunId]/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  requireSessionMock,
+  requireCanonicalOrgAccessMock,
+  findGithubActionScanRunMock,
+  getScanRunSeverityCountsMock,
+} = vi.hoisted(() => ({
+  requireSessionMock: vi.fn(),
+  requireCanonicalOrgAccessMock: vi.fn(),
+  findGithubActionScanRunMock: vi.fn(),
+  getScanRunSeverityCountsMock: vi.fn(),
+}));
+
+vi.mock("@/lib/session", () => ({
+  requireSession: requireSessionMock,
+}));
+
+vi.mock("@/lib/server-org-boundary", () => ({
+  requireCanonicalOrgAccess: requireCanonicalOrgAccessMock,
+}));
+
+vi.mock("@/lib/integrations/org-scoped-queries", () => ({
+  findGithubActionScanRun: findGithubActionScanRunMock,
+  getScanRunSeverityCounts: getScanRunSeverityCountsMock,
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/github-action/status/[scanRunId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireSessionMock.mockResolvedValue({ id: "user_1" });
+  });
+
+  it("fails closed when organizationId is missing", async () => {
+    requireCanonicalOrgAccessMock.mockRejectedValue({ code: "BAD_REQUEST" });
+
+    const response = await GET(
+      new Request("http://localhost/api/github-action/status/scan_1"),
+      { params: Promise.resolve({ scanRunId: "scan_1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "organizationId is required",
+    });
+  });
+
+  it("returns severity counts only for canonically scoped scan", async () => {
+    requireCanonicalOrgAccessMock.mockResolvedValue({ organizationId: "org_1", role: "ADMIN" });
+    findGithubActionScanRunMock.mockResolvedValue({
+      id: "scan_1",
+      status: "COMPLETED",
+      pagesScanned: 10,
+      siteId: "site_1",
+      startedAt: null,
+      completedAt: null,
+    });
+    getScanRunSeverityCountsMock.mockResolvedValue([
+      { impact: "CRITICAL", _count: { _all: 2 } },
+      { impact: "SERIOUS", _count: { _all: 1 } },
+    ]);
+
+    const response = await GET(
+      new Request("http://localhost/api/github-action/status/scan_1?organizationId=org_1"),
+      { params: Promise.resolve({ scanRunId: "scan_1" }) },
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.data.severityCounts).toEqual({ CRITICAL: 2, SERIOUS: 1 });
+    expect(payload.data.score).toBe(95);
+    expect(findGithubActionScanRunMock).toHaveBeenCalledWith(
+      { organizationId: "org_1", role: "ADMIN" },
+      "scan_1",
+    );
+  });
+});

--- a/apps/web/src/app/api/github-action/status/[scanRunId]/route.ts
+++ b/apps/web/src/app/api/github-action/status/[scanRunId]/route.ts
@@ -1,66 +1,48 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
 import { apiSuccess, apiError } from "@/lib/api-utils";
 import { ApiError } from "@aros/shared";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
+import {
+  findGithubActionScanRun,
+  getScanRunSeverityCounts,
+} from "@/lib/integrations/org-scoped-queries";
 
 /**
- * GET /api/github-action/status/[scanRunId]
+ * GET /api/github-action/status/[scanRunId]?organizationId=...
  * Poll scan status for GitHub Action. Returns findings summary when complete.
- * Requires authentication and tenant isolation via session + organization membership.
+ * Requires authentication and canonical organization membership context.
  */
 export async function GET(
-  _request: Request,
+  request: Request,
   context: { params: Promise<{ scanRunId: string }> },
 ) {
   try {
-    const user = await requireSession();
+    await requireSession();
     const { scanRunId } = await context.params;
+    const { searchParams } = new URL(request.url);
+    const organizationId = searchParams.get("organizationId");
 
-    const scanRun = await prisma.scanRun.findUnique({
-      where: { id: scanRunId },
-      include: {
-        site: {
-          include: {
-            workspace: {
-              include: {
-                organization: {
-                  include: {
-                    memberships: {
-                      where: { userId: user.id },
-                      take: 1,
-                    },
-                    subscription: true,
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
+    if (!organizationId) {
+      return NextResponse.json({ error: "organizationId is required" }, { status: 400 });
+    }
+
+    const ctx = await requireCanonicalOrgAccess(organizationId, "scan:view", {
+      requirePaid: true,
     });
+
+    const scanRun = await findGithubActionScanRun(ctx, scanRunId);
 
     if (!scanRun) {
       return apiError(ApiError.notFound("Scan not found"));
     }
 
-    const membership = scanRun.site.workspace.organization.memberships;
-    if (membership.length === 0) {
-      return apiError(ApiError.forbidden("Access denied to this organization"));
-    }
-
-    const { site, ...scanRunData } = scanRun;
-
     if (scanRun.status === "COMPLETED") {
-      const findings = await prisma.rawViolation.groupBy({
-        by: ["impact"],
-        where: { scanRunId },
-        _count: { _all: true },
-      });
+      const findings = await getScanRunSeverityCounts(ctx, scanRunId);
 
       const severityCounts: Record<string, number> = {};
-      for (const f of findings) {
-        severityCounts[f.impact] = f._count._all;
+      for (const finding of findings) {
+        severityCounts[finding.impact] = finding._count._all;
       }
 
       const critical = severityCounts.CRITICAL ?? 0;
@@ -74,13 +56,13 @@ export async function GET(
       );
 
       return apiSuccess({
-        ...scanRunData,
+        ...scanRun,
         score,
         severityCounts,
       });
     }
 
-    return apiSuccess(scanRunData);
+    return apiSuccess(scanRun);
   } catch (error) {
     return apiError(error);
   }

--- a/apps/web/src/app/api/public-scan/route.ts
+++ b/apps/web/src/app/api/public-scan/route.ts
@@ -6,6 +6,7 @@ import { getPublicScanById, getPublicScanEvidenceState, toPublicScanApiPayload }
 import { createPublicScanResult, findRecentPublicScanForRateLimit } from "@/lib/public-scan/queries";
 import { validatePublicScanTarget } from "@/lib/public-scan/target-validation";
 import { createHash } from "crypto";
+import { toASCII } from "node:punycode";
 
 export const runtime = "nodejs";
 
@@ -42,7 +43,10 @@ async function normalizePublicScanDomain(rawDomain: string): Promise<{ domain: s
     throw ApiError.badRequest("Invalid domain format");
   }
 
-  const normalizedDomain = parsed.hostname.toLowerCase().replace(/\.$/, "");
+  const normalizedDomain = toASCII(parsed.hostname.toLowerCase().replace(/\.$/, ""));
+  if (!normalizedDomain) {
+    throw ApiError.badRequest("Invalid domain format");
+  }
   await validatePublicScanTarget(normalizedDomain);
   return {
     domain: normalizedDomain,

--- a/apps/web/src/app/api/reports/vpat/route.test.ts
+++ b/apps/web/src/app/api/reports/vpat/route.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  requireSessionMock,
+  requireCanonicalOrgAccessMock,
+  findVpatSiteMock,
+  getOrganizationNameMock,
+  generateVpatReportMock,
+  createVpatReportRecordMock,
+} = vi.hoisted(() => ({
+  requireSessionMock: vi.fn(),
+  requireCanonicalOrgAccessMock: vi.fn(),
+  findVpatSiteMock: vi.fn(),
+  getOrganizationNameMock: vi.fn(),
+  generateVpatReportMock: vi.fn(),
+  createVpatReportRecordMock: vi.fn(),
+}));
+
+vi.mock("@/lib/session", () => ({
+  requireSession: requireSessionMock,
+}));
+
+vi.mock("@/lib/server-org-boundary", () => ({
+  requireCanonicalOrgAccess: requireCanonicalOrgAccessMock,
+}));
+
+vi.mock("@/lib/reports/org-scoped-queries", () => ({
+  findVpatSite: findVpatSiteMock,
+  getOrganizationName: getOrganizationNameMock,
+  createVpatReportRecord: createVpatReportRecordMock,
+}));
+
+vi.mock("@/lib/vpat/generator", () => ({
+  generateVpatReport: generateVpatReportMock,
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/reports/vpat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireSessionMock.mockResolvedValue({ id: "user_1" });
+  });
+
+  it("returns 400 for missing organization context", async () => {
+    const response = await GET(new Request("http://localhost/api/reports/vpat?siteId=site_1"));
+    expect(response.status).toBe(400);
+  });
+
+  it("uses canonical org context and scoped queries", async () => {
+    requireCanonicalOrgAccessMock.mockResolvedValue({ organizationId: "org_1", role: "OWNER" });
+    findVpatSiteMock.mockResolvedValue({ id: "site_1", name: "Main", domain: "example.com" });
+    getOrganizationNameMock.mockResolvedValue({ name: "Acme" });
+    generateVpatReportMock.mockResolvedValue({
+      summary: { supports: 1, partiallySupports: 2, doesNotSupport: 3 },
+      rows: [],
+    });
+
+    const response = await GET(
+      new Request("http://localhost/api/reports/vpat?organizationId=org_1&siteId=site_1"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(findVpatSiteMock).toHaveBeenCalledWith(
+      { organizationId: "org_1", role: "OWNER" },
+      "site_1",
+    );
+    expect(createVpatReportRecordMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/reports/vpat/route.ts
+++ b/apps/web/src/app/api/reports/vpat/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
-import { requireOrgAccess } from "@/lib/auth-guard";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
 import { apiSuccess, apiError } from "@/lib/api-utils";
-import { ApiError } from "@aros/shared";
 import { generateVpatReport } from "@/lib/vpat/generator";
-import { runOrgScopedQuery } from "@/lib/route-data-boundary";
+import { ApiError } from "@aros/shared";
+import {
+  createVpatReportRecord,
+  findVpatSite,
+  getOrganizationName,
+} from "@/lib/reports/org-scoped-queries";
 
 /**
  * GET /api/reports/vpat?organizationId=xxx&siteId=yyy&format=json
@@ -14,76 +17,35 @@ import { runOrgScopedQuery } from "@/lib/route-data-boundary";
  */
 export async function GET(request: Request) {
   try {
-    const user = await requireSession();
+    await requireSession();
     const { searchParams } = new URL(request.url);
     const organizationId = searchParams.get("organizationId");
     const siteId = searchParams.get("siteId");
     const format = searchParams.get("format") ?? "json";
 
     if (!organizationId || !siteId) {
-      return apiError({
-        message: "organizationId and siteId required",
-        code: "BAD_REQUEST",
-      });
+      return apiError(ApiError.badRequest("organizationId and siteId required"));
     }
 
-    const ctx = await requireOrgAccess(organizationId, "reports:export", {
+    const ctx = await requireCanonicalOrgAccess(organizationId, "reports:export", {
       requirePaid: true,
     });
 
-    const result = await runOrgScopedQuery(ctx, async (orgId) => {
-      const site = await prisma.site.findFirst({
-        where: {
-          id: siteId,
-          workspace: { organizationId: orgId },
-        },
-      });
-
-      if (!site) return { error: "Site not found", code: 404 };
-
-      const org = await prisma.organization.findUnique({
-        where: { id: orgId },
-        select: { name: true },
-      });
-
-      const report = await generateVpatReport(siteId, orgId, org?.name);
-
-      if (format === "csv") {
-        return { report, site, format: "csv" };
-      }
-
-      // Store as Report record
-      await prisma.report.create({
-        data: {
-          siteId,
-          type: "VPAT",
-          title: `VPAT Report - ${site.name}`,
-          content: report as unknown as object,
-          summary: `${report.summary.supports} criteria supported, ${report.summary.partiallySupports} partially, ${report.summary.doesNotSupport} not supported`,
-        },
-      });
-
-      return { report };
-    });
-
-    if (!result.ok) {
-      return apiError({ message: result.message, code: "INTERNAL_SERVER_ERROR" });
+    const site = await findVpatSite(ctx, siteId);
+    if (!site) {
+      return apiError(ApiError.notFound("Site not found"));
     }
 
-    const { data } = result;
+    const org = await getOrganizationName(ctx);
+    const report = await generateVpatReport(siteId, organizationId, org?.name);
 
-    if ("error" in data) {
-      return apiError({ message: data.error, code: data.code === 404 ? "NOT_FOUND" : "BAD_REQUEST" });
-    }
-
-    if ("format" in data && data.format === "csv") {
-      const { report, site } = data;
+    if (format === "csv") {
       const header =
         "WCAG Criteria,Level,Conformance Status,Explanation,Open Findings\n";
       const rows = report.rows
         .map(
-          (r) =>
-            `"${r.criteria}","${r.level}","${r.conformanceStatus}","${r.explanation.replace(/"/g, '""')}","${r.findings.length}"`,
+          (row) =>
+            `"${row.criteria}","${row.level}","${row.conformanceStatus}","${row.explanation.replace(/"/g, '""')}","${row.findings.length}"`,
         )
         .join("\n");
 
@@ -97,7 +59,14 @@ export async function GET(request: Request) {
       });
     }
 
-    return apiSuccess(data.report);
+    await createVpatReportRecord(ctx, {
+      siteId,
+      siteName: site.name,
+      report: report as unknown as object,
+      summaryText: `${report.summary.supports} criteria supported, ${report.summary.partiallySupports} partially, ${report.summary.doesNotSupport} not supported`,
+    });
+
+    return apiSuccess(report);
   } catch (error) {
     return apiError(error);
   }

--- a/apps/web/src/lib/integrations/org-scoped-queries.ts
+++ b/apps/web/src/lib/integrations/org-scoped-queries.ts
@@ -60,3 +60,41 @@ export async function findActiveDeployWebhookByDomain(domain: string) {
     },
   });
 }
+
+export async function findGithubActionScanRun(ctx: OrgMembershipCore, scanRunId: string) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.scanRun.findFirst({
+      where: {
+        id: scanRunId,
+        site: {
+          workspace: { organizationId },
+        },
+      },
+      select: {
+        id: true,
+        status: true,
+        startedAt: true,
+        completedAt: true,
+        pagesScanned: true,
+        siteId: true,
+      },
+    }),
+  );
+}
+
+export async function getScanRunSeverityCounts(ctx: OrgMembershipCore, scanRunId: string) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.rawViolation.groupBy({
+      by: ["impact"],
+      where: {
+        scanRunId,
+        scanRun: {
+          site: {
+            workspace: { organizationId },
+          },
+        },
+      },
+      _count: { _all: true },
+    }),
+  );
+}

--- a/apps/web/src/lib/public-scan/target-validation.test.ts
+++ b/apps/web/src/lib/public-scan/target-validation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { validatePublicScanTarget } from "./target-validation";
+
+describe("validatePublicScanTarget", () => {
+  it("rejects ip literal hosts", async () => {
+    await expect(validatePublicScanTarget("127.0.0.1")).rejects.toMatchObject({
+      code: "PUBLIC_SCAN_HOST_BLOCKED",
+      statusCode: 400,
+    });
+  });
+
+  it("rejects local domains", async () => {
+    await expect(validatePublicScanTarget("internal.local")).rejects.toMatchObject({
+      code: "PUBLIC_SCAN_HOST_BLOCKED",
+      statusCode: 400,
+    });
+  });
+
+  it("rejects unresolvable hostnames", async () => {
+    await expect(validatePublicScanTarget("not-a-real-hostname.invalid"))
+      .rejects.toMatchObject({ statusCode: 400 });
+  });
+});

--- a/apps/web/src/lib/public-scan/target-validation.ts
+++ b/apps/web/src/lib/public-scan/target-validation.ts
@@ -1,5 +1,7 @@
 import { ApiError } from "@aros/shared";
 import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import { toASCII } from "node:punycode";
 
 const BLOCKED_HOSTNAMES = new Set([
   "localhost",
@@ -20,6 +22,7 @@ function isPrivateIpv4(address: string): boolean {
     (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
     (octets[0] === 192 && octets[1] === 168) ||
     octets[0] === 127 ||
+    octets[0] === 0 ||
     (octets[0] === 169 && octets[1] === 254)
   );
 }
@@ -34,9 +37,17 @@ export function isPrivateOrLoopbackAddress(address: string): boolean {
 }
 
 export async function validatePublicScanTarget(hostname: string): Promise<void> {
-  const normalizedHostname = hostname.toLowerCase();
+  const normalizedHostname = toASCII(hostname.toLowerCase().replace(/\.$/, ""));
 
-  if (BLOCKED_HOSTNAMES.has(normalizedHostname) || normalizedHostname.endsWith(".local")) {
+  if (!normalizedHostname) {
+    throw ApiError.badRequest("Invalid domain format");
+  }
+
+  if (
+    BLOCKED_HOSTNAMES.has(normalizedHostname) ||
+    normalizedHostname.endsWith(".local") ||
+    isIP(normalizedHostname) !== 0
+  ) {
     throw new ApiError(
       "Private, loopback, and local network hosts are not allowed for public scans.",
       "PUBLIC_SCAN_HOST_BLOCKED",
@@ -44,15 +55,19 @@ export async function validatePublicScanTarget(hostname: string): Promise<void> 
     );
   }
 
-  let resolvedAddress: string;
+  let resolvedAddresses: string[];
   try {
-    const { address } = await lookup(normalizedHostname);
-    resolvedAddress = address;
+    const lookupResults = await lookup(normalizedHostname, { all: true, verbatim: true });
+    resolvedAddresses = lookupResults.map((result) => result.address);
   } catch {
     throw ApiError.badRequest("Domain could not be resolved. Please enter a public hostname.");
   }
 
-  if (isPrivateOrLoopbackAddress(resolvedAddress)) {
+  if (resolvedAddresses.length === 0) {
+    throw ApiError.badRequest("Domain could not be resolved. Please enter a public hostname.");
+  }
+
+  if (resolvedAddresses.some((address) => isPrivateOrLoopbackAddress(address))) {
     throw new ApiError(
       "Resolved host points to a private or loopback address and cannot be scanned publicly.",
       "PUBLIC_SCAN_HOST_BLOCKED",

--- a/apps/web/src/lib/public-scan/validity.test.ts
+++ b/apps/web/src/lib/public-scan/validity.test.ts
@@ -17,13 +17,31 @@ describe("public scan validity contract", () => {
 
   it("classifies expired records as expired", () => {
     expect(
-      getPublicScanEvidenceState({ expiresAt: new Date("2020-01-01T00:00:00Z") }, new Date("2020-01-02T00:00:00Z")),
+      getPublicScanEvidenceState(
+        { status: "COMPLETED", completedAt: new Date("2020-01-01T00:00:00Z"), expiresAt: new Date("2020-01-01T00:00:00Z") },
+        new Date("2020-01-02T00:00:00Z"),
+      ),
     ).toBe("expired");
   });
 
-  it("classifies unexpired records as valid", () => {
+  it("classifies failed records as failed", () => {
     expect(
-      getPublicScanEvidenceState({ expiresAt: new Date("2020-01-03T00:00:00Z") }, new Date("2020-01-02T00:00:00Z")),
+      getPublicScanEvidenceState({ status: "FAILED", completedAt: null, expiresAt: null }),
+    ).toBe("failed");
+  });
+
+  it("classifies non-complete records as incomplete", () => {
+    expect(
+      getPublicScanEvidenceState({ status: "RUNNING", completedAt: null, expiresAt: null }),
+    ).toBe("incomplete");
+  });
+
+  it("classifies completed unexpired records as valid", () => {
+    expect(
+      getPublicScanEvidenceState(
+        { status: "COMPLETED", completedAt: new Date("2020-01-01T00:00:00Z"), expiresAt: new Date("2020-01-03T00:00:00Z") },
+        new Date("2020-01-02T00:00:00Z"),
+      ),
     ).toBe("valid");
   });
 
@@ -50,6 +68,7 @@ describe("public scan validity contract", () => {
       id: "scan_123",
       domain: "example.com",
       status: "COMPLETED",
+      evidenceState: "expired",
       score: 90,
       totalViolations: 2,
     });

--- a/apps/web/src/lib/public-scan/validity.ts
+++ b/apps/web/src/lib/public-scan/validity.ts
@@ -1,6 +1,11 @@
 import { prisma } from "@/lib/db";
 
-export type PublicEvidenceState = "valid" | "expired" | "missing";
+export type PublicEvidenceState =
+  | "valid"
+  | "expired"
+  | "missing"
+  | "incomplete"
+  | "failed";
 
 type PublicScanCore = {
   id: string;
@@ -21,11 +26,13 @@ type PublicScanCore = {
 };
 
 export function getPublicScanEvidenceState(
-  scan: Pick<PublicScanCore, "expiresAt"> | null,
+  scan: Pick<PublicScanCore, "expiresAt" | "status" | "completedAt"> | null,
   now = new Date(),
 ): PublicEvidenceState {
   if (!scan) return "missing";
   if (scan.expiresAt && scan.expiresAt <= now) return "expired";
+  if (scan.status === "FAILED") return "failed";
+  if (scan.status !== "COMPLETED" || !scan.completedAt) return "incomplete";
   return "valid";
 }
 
@@ -34,6 +41,7 @@ export function toPublicScanApiPayload(scan: PublicScanCore) {
     id: scan.id,
     domain: scan.domain,
     status: scan.status,
+    evidenceState: getPublicScanEvidenceState(scan),
     score: scan.score,
     totalViolations: scan.totalViolations,
     criticalCount: scan.criticalCount,
@@ -79,7 +87,12 @@ export async function getLatestValidPublicScanForDomain(
     where: {
       domain,
       expiresAt: { gt: new Date() },
-      ...(options.requireCompleted ? { status: "COMPLETED" } : {}),
+      ...(options.requireCompleted
+        ? {
+            status: "COMPLETED",
+            completedAt: { not: null },
+          }
+        : {}),
     },
     orderBy: { createdAt: "desc" },
     select: {

--- a/apps/web/src/lib/reports/org-scoped-queries.ts
+++ b/apps/web/src/lib/reports/org-scoped-queries.ts
@@ -42,3 +42,45 @@ export async function listFindingsForReport(ctx: OrgMembershipCore, siteId?: str
     }),
   );
 }
+
+export async function findVpatSite(ctx: OrgMembershipCore, siteId: string) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.site.findFirst({
+      where: {
+        id: siteId,
+        workspace: { organizationId },
+      },
+      select: {
+        id: true,
+        name: true,
+        domain: true,
+      },
+    }),
+  );
+}
+
+export async function getOrganizationName(ctx: OrgMembershipCore) {
+  return runCanonicalOrgQuery(ctx, async (organizationId) =>
+    prisma.organization.findUnique({
+      where: { id: organizationId },
+      select: { name: true },
+    }),
+  );
+}
+
+export async function createVpatReportRecord(
+  ctx: OrgMembershipCore,
+  input: { siteId: string; siteName: string; summaryText: string; report: object },
+) {
+  return runCanonicalOrgQuery(ctx, async () =>
+    prisma.report.create({
+      data: {
+        siteId: input.siteId,
+        type: "VPAT",
+        title: `VPAT Report - ${input.siteName}`,
+        content: input.report,
+        summary: input.summaryText,
+      },
+    }),
+  );
+}

--- a/docs/verification-gates.md
+++ b/docs/verification-gates.md
@@ -12,8 +12,9 @@ Runs in this exact order:
 
 ## Tier 2 — Release gate (`npm run verify:release`)
 
-Includes Tier 1 and adds release-blocking tenant isolation + env-bound integration tests:
+Includes Tier 1 and adds release-blocking tenant isolation + launch-critical truth checks + env-bound integration tests:
 - `npm run verify:tenant-boundary` (fails if critical server entrypoints regress with tenant-boundary lint violations)
+- `npm run test:launch-critical` (targeted suites for public-scan validity/expiry truth and canonical org-boundary regression checks on critical routes)
 - `npm run test:integration` (currently `apps/web` Vitest integration suite)
 
 ## Tier 3 — Browser/system gate (CI + optional local)

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "test:integration": "npm run test:integration --workspace=apps/web",
     "test:release": "npm run test && npm run test:integration",
     "verify:core": "npm run prisma:check && npm run prisma:imports && npm run lint && npm run typecheck && npm run test && npm run build",
-    "verify:release": "npm run verify:core && npm run verify:tenant-boundary && npm run test:integration",
-    "verify:tenant-boundary": "node scripts/check-tenant-boundary-critical.mjs"
+    "verify:release": "npm run verify:core && npm run verify:tenant-boundary && npm run test:launch-critical && npm run test:integration",
+    "verify:tenant-boundary": "node scripts/check-tenant-boundary-critical.mjs",
+    "test:launch-critical": "npm run test:launch-critical --workspace=apps/web"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",

--- a/scripts/check-tenant-boundary-critical.mjs
+++ b/scripts/check-tenant-boundary-critical.mjs
@@ -12,6 +12,7 @@ const CRITICAL_ENTRYPOINTS = [
   "src/app/api/findings/summary/route.ts",
   "src/app/api/webhooks/stripe/route.ts",
   "src/app/api/github-action/route.ts",
+  "src/app/api/github-action/status/[scanRunId]/route.ts",
   "src/app/api/deploy-webhook/route.ts",
   "src/app/api/public-scan/route.ts",
   "src/app/api/public-scan/[id]/route.ts",


### PR DESCRIPTION
### Motivation
- Prevent route-local tenancy heuristics and fail-open org access on high-risk server entrypoints by moving critical routes to canonical org-boundary patterns. 
- Close adjacent anonymous public-scan abuse/SSRF seams by tightening intake normalization and resolver checks. 
- Make public-facing "latest/current" semantics explicit and machine-visible so expired/failed/incomplete evidence cannot be silently presented as current. 

### Description
- Require canonical org context for GitHub Action status polling and migrate its DB reads into org-scoped helpers (`findGithubActionScanRun`, `getScanRunSeverityCounts`) while adding a test for the canonical requirement. 
- Migrate VPAT report generation off route-local Prisma into `requireCanonicalOrgAccess` + `reports` org-scoped query helpers and add scoped tests. 
- Harden public-scan intake by adding IDNA normalization (`toASCII`) at parse time, blocking IP literals, rejecting `.local`, resolving all DNS answers (`lookup(..., { all: true, verbatim: true })`), and failing closed if any answer is private/loopback. 
- Canonicalize public evidence semantics by expanding `PublicEvidenceState` to `valid | expired | missing | incomplete | failed`, exposing `evidenceState` in API payloads, and tightening `getLatestValidPublicScanForDomain` to optionally require `COMPLETED` + non-null `completedAt`. 
- Wire the canonical boundaries through codepaths and release gates by updating `pollUrl` to include `organizationId`, adding org-scoped query modules (`integrations` and `reports`), extending the tenant-boundary checker to include the new GitHub Action status route, adding focused launch-critical test suites, and updating `verify:release` to run a `test:launch-critical` step. 

### Testing
- Ran the focused launch-critical suite with `npm run test:launch-critical` (workspace `apps/web`) and all targeted tests passed. 
- Ran the tenant-boundary gate `npm run verify:tenant-boundary` and it passed for the expanded critical entrypoints list. 
- Ran `npm run lint` which completed but reported existing tenant-boundary warnings in other non-migrated server-action families. 
- Ran `npm run build` which completed successfully for the web app. 
- `npm run typecheck` failed (pre-existing multi-workspace type errors unrelated to these targeted hardenings). 
- Full workspace `npm run test` and `npm run verify:release` are failing due to pre-existing test/typecheck failures outside the scope of these changes, so `verify:release` remains red until those legacy issues are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00a74ce648328a33db5603ba5d110)