### PR TITLE
Public scan evidence truth, OG parity, org-boundary HTTP semantics, release build fixes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "test:ct": "playwright test -c playwright-ct.config.ts",
     "test:e2e:update": "playwright test --update-snapshots",
     "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts",
-    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts"
+    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts"
   },
   "dependencies": {
     "@aros/config": "*",

--- a/apps/web/src/app/(dashboard)/settings/api-keys/actions.test.ts
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/actions.test.ts
@@ -328,6 +328,9 @@ describe("createApiKeyAction", () => {
 describe("revokeApiKeyAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(redirect).mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
   });
 
   it("revokes active API key", async () => {
@@ -351,13 +354,14 @@ describe("revokeApiKeyAction", () => {
     formData.set("organizationId", "org_123");
     formData.set("keyId", "key_123");
 
-    await revokeApiKeyAction(formData);
+    await expect(revokeApiKeyAction(formData)).rejects.toThrow("NEXT_REDIRECT");
 
     expect(prisma.apiKey.update).toHaveBeenCalledWith({
       where: { id: "key_123" },
       data: { isActive: false },
     });
-    expect(redirect).toHaveBeenCalledWith("/settings/api-keys?status=revoked");
+    const q = new URLSearchParams({ status: "revoked" }).toString();
+    expect(redirect).toHaveBeenCalledWith(`/settings/api-keys?${q}`);
   });
 
   it("returns error when key not found", async () => {
@@ -375,12 +379,12 @@ describe("revokeApiKeyAction", () => {
     formData.set("organizationId", "org_123");
     formData.set("keyId", "key_nonexistent");
 
-    await revokeApiKeyAction(formData);
+    await expect(revokeApiKeyAction(formData)).rejects.toThrow("NEXT_REDIRECT");
 
-    expect(redirect).toHaveBeenCalledWith(
-      "/settings/api-keys?error=" +
-        encodeURIComponent("API key not found or already revoked"),
-    );
+    const q = new URLSearchParams({
+      error: "API key not found or already revoked",
+    }).toString();
+    expect(redirect).toHaveBeenCalledWith(`/settings/api-keys?${q}`);
   });
 
   it("rejects for DEVELOPER role", async () => {
@@ -396,12 +400,12 @@ describe("revokeApiKeyAction", () => {
     formData.set("organizationId", "org_123");
     formData.set("keyId", "key_123");
 
-    await revokeApiKeyAction(formData);
+    await expect(revokeApiKeyAction(formData)).rejects.toThrow("NEXT_REDIRECT");
 
-    expect(redirect).toHaveBeenCalledWith(
-      "/settings/api-keys?error=" +
-        encodeURIComponent("Only admins and owners can revoke API keys"),
-    );
+    const q = new URLSearchParams({
+      error: "Only admins and owners can revoke API keys",
+    }).toString();
+    expect(redirect).toHaveBeenCalledWith(`/settings/api-keys?${q}`);
   });
 
   it("requires keyId", async () => {
@@ -417,12 +421,12 @@ describe("revokeApiKeyAction", () => {
     formData.set("organizationId", "org_123");
     // No keyId set
 
-    await revokeApiKeyAction(formData);
+    await expect(revokeApiKeyAction(formData)).rejects.toThrow("NEXT_REDIRECT");
 
-    expect(redirect).toHaveBeenCalledWith(
-      "/settings/api-keys?error=" +
-        encodeURIComponent("API key ID is required"),
-    );
+    const q = new URLSearchParams({
+      error: "API key ID is required",
+    }).toString();
+    expect(redirect).toHaveBeenCalledWith(`/settings/api-keys?${q}`);
   });
 });
 

--- a/apps/web/src/app/(dashboard)/settings/api-keys/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { prisma } from "@/lib/db";
@@ -11,6 +12,11 @@ import crypto from "node:crypto";
 
 const API_KEY_PREFIX = "arsk_live_";
 const KEY_BYTES = 32; // 64 hex chars
+
+function redirectApiKeysQuery(params: Record<string, string>): never {
+  const q = new URLSearchParams(params).toString();
+  redirect(`/settings/api-keys?${q}` as Route);
+}
 
 /**
  * Generate a secure random API key with SHA-256 hash for storage.
@@ -289,19 +295,15 @@ export async function revokeApiKeyAction(formData: FormData): Promise<void> {
   const keyId = (formData.get("keyId") as string) ?? "";
 
   if (!keyId) {
-    redirect(
-      "/settings/api-keys?error=" +
-        encodeURIComponent("API key ID is required"),
-    );
+    redirectApiKeysQuery({ error: "API key ID is required" });
   }
 
   // Permission check
   const ctx = await requireOrgAccess(organizationId);
   if (!hasPermission(ctx.role, "integrations:manage")) {
-    redirect(
-      "/settings/api-keys?error=" +
-        encodeURIComponent("Only admins and owners can revoke API keys"),
-    );
+    redirectApiKeysQuery({
+      error: "Only admins and owners can revoke API keys",
+    });
   }
 
   // Soft delete by setting isActive to false
@@ -315,10 +317,9 @@ export async function revokeApiKeyAction(formData: FormData): Promise<void> {
     });
 
     if (!key) {
-      redirect(
-        "/settings/api-keys?error=" +
-          encodeURIComponent("API key not found or already revoked"),
-      );
+      redirectApiKeysQuery({
+        error: "API key not found or already revoked",
+      });
     }
 
     await prisma.apiKey.update({
@@ -327,15 +328,12 @@ export async function revokeApiKeyAction(formData: FormData): Promise<void> {
     });
 
     revalidatePath("/settings/api-keys");
-    redirect("/settings/api-keys?status=revoked");
+    redirectApiKeysQuery({ status: "revoked" });
   } catch (error) {
     if (error instanceof ApiError) {
-      redirect("/settings/api-keys?error=" + encodeURIComponent(error.message));
+      redirectApiKeysQuery({ error: error.message });
     }
-    redirect(
-      "/settings/api-keys?error=" +
-        encodeURIComponent("Failed to revoke API key"),
-    );
+    redirectApiKeysQuery({ error: "Failed to revoke API key" });
   }
 }
 

--- a/apps/web/src/app/(dashboard)/system/operator/health-cards.tsx
+++ b/apps/web/src/app/(dashboard)/system/operator/health-cards.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Route } from "next";
 import Link from "next/link";
 import type {
   StaleSite,
@@ -74,7 +75,7 @@ function MetricCard({
       {description && <p className="mt-3 text-sm opacity-80">{description}</p>}
       {href && actionLabel && (
         <Link
-          href={href}
+          href={href as Route}
           className="mt-4 inline-flex items-center text-sm font-medium underline underline-offset-2 hover:opacity-80"
         >
           {actionLabel} →
@@ -86,7 +87,7 @@ function MetricCard({
   if (href && !actionLabel) {
     return (
       <Link
-        href={href}
+        href={href as Route}
         className="block transition-transform hover:scale-[1.02]"
       >
         {content}

--- a/apps/web/src/app/(dashboard)/system/operator/work-queue.tsx
+++ b/apps/web/src/app/(dashboard)/system/operator/work-queue.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Route } from "next";
 import Link from "next/link";
 import { useTransition } from "react";
 import type { WorkQueueItem } from "./actions";
@@ -81,7 +82,7 @@ function WorkQueueItemCard({
           </div>
           <div className="mt-3 flex items-center gap-2">
             <Link
-              href={item.actionHref}
+              href={item.actionHref as Route}
               className="inline-flex items-center rounded-md bg-brand-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-700 transition-colors"
             >
               {item.actionLabel}
@@ -214,7 +215,7 @@ export function WorkQueueCompact({ items, limit = 5 }: WorkQueueCompactProps) {
       {displayItems.map((item) => (
         <Link
           key={item.id}
-          href={item.actionHref}
+          href={item.actionHref as Route}
           className="flex items-center gap-3 rounded-lg border border-slate-200 p-3 hover:border-slate-300 hover:bg-slate-50 transition-colors"
         >
           <span className="text-lg">{typeIcons[item.type]}</span>

--- a/apps/web/src/app/(public)/scan/[domain]/page.tsx
+++ b/apps/web/src/app/(public)/scan/[domain]/page.tsx
@@ -1,4 +1,8 @@
-import { getLatestValidPublicScanForDomain } from "@/lib/public-scan/validity";
+import {
+  getLatestValidPublicScanForDomain,
+  getPublicScanEvidenceState,
+  type PublicEvidenceState,
+} from "@/lib/public-scan/validity";
 import { Metadata } from "next";
 import { PublicScanResults } from "./public-scan-results";
 
@@ -12,18 +16,20 @@ export async function generateMetadata({
   const { domain } = await params;
   const decoded = decodeURIComponent(domain);
 
-  const scan = await getLatestValidPublicScanForDomain(decoded, { requireCompleted: true });
-
-  const hasCurrentEvidence = Boolean(scan);
-  const score = scan?.score ?? 0;
-  const totalViolations = scan?.totalViolations ?? 0;
+  const scan = await getLatestValidPublicScanForDomain(decoded, {
+    requireCompleted: true,
+  });
+  const hasCurrentEvidence =
+    Boolean(scan) && getPublicScanEvidenceState(scan) === "valid";
+  const score = hasCurrentEvidence ? scan!.score! : 0;
+  const totalViolations = hasCurrentEvidence ? scan!.totalViolations : 0;
   const title = hasCurrentEvidence
     ? `Accessibility Report: ${decoded} (Score: ${score})`
     : `Accessibility Report: ${decoded} (No current evidence)`;
   const description = hasCurrentEvidence
-    ? `Found ${totalViolations} accessibility issues on ${decoded}. Scan powered by AROS - source-level accessibility remediation.`
-    : `No current scan evidence is available for ${decoded}. Run a new public scan to generate fresh accessibility evidence.`;
-  const ogUrl = `/api/og?domain=${encodeURIComponent(decoded)}&score=${score}&critical=${scan?.criticalCount ?? 0}&serious=${scan?.seriousCount ?? 0}&moderate=${scan?.moderateCount ?? 0}&minor=${scan?.minorCount ?? 0}`;
+    ? `Sampled automated scan: ${totalViolations} accessibility issues on ${decoded} (up to 5 pages). Not a WCAG conformance guarantee.`
+    : `No current, unexpired public scan evidence for ${decoded}. Run a new instant scan for fresh automated results.`;
+  const ogUrl = `/api/og?domain=${encodeURIComponent(decoded)}`;
 
   return {
     title,
@@ -47,7 +53,12 @@ export default async function PublicScanPage({ params }: PageProps) {
   const { domain } = await params;
   const decoded = decodeURIComponent(domain);
 
-  const scan = await getLatestValidPublicScanForDomain(decoded, { requireCompleted: false });
+  const scan = await getLatestValidPublicScanForDomain(decoded, {
+    requireCompleted: false,
+  });
+  const evidenceState: PublicEvidenceState | null = scan
+    ? getPublicScanEvidenceState(scan)
+    : null;
 
   return (
     <PublicScanResults
@@ -58,6 +69,7 @@ export default async function PublicScanPage({ params }: PageProps) {
               id: scan.id,
               domain: scan.domain,
               status: scan.status,
+              evidenceState,
               score: scan.score,
               totalViolations: scan.totalViolations,
               criticalCount: scan.criticalCount,
@@ -68,6 +80,7 @@ export default async function PublicScanPage({ params }: PageProps) {
               violations: scan.violations as Record<string, unknown>[] | null,
               createdAt: scan.createdAt.toISOString(),
               completedAt: scan.completedAt?.toISOString() ?? null,
+              expiresAt: scan.expiresAt?.toISOString() ?? null,
             }
           : null
       }

--- a/apps/web/src/app/(public)/scan/[domain]/public-scan-results.tsx
+++ b/apps/web/src/app/(public)/scan/[domain]/public-scan-results.tsx
@@ -3,10 +3,18 @@
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 
+type PublicEvidenceState =
+  | "valid"
+  | "expired"
+  | "missing"
+  | "incomplete"
+  | "failed";
+
 interface ScanData {
   id: string;
   domain: string;
   status: string;
+  evidenceState?: PublicEvidenceState | null;
   score: number | null;
   totalViolations: number;
   criticalCount: number;
@@ -17,6 +25,7 @@ interface ScanData {
   violations: Record<string, unknown>[] | null;
   createdAt: string;
   completedAt: string | null;
+  expiresAt?: string | null;
 }
 
 interface Props {
@@ -52,37 +61,88 @@ function getScoreLabel(score: number): string {
   return "Critical";
 }
 
+function isCurrentPublicProof(scan: ScanData | null): boolean {
+  return (
+    scan?.status === "COMPLETED" &&
+    scan.score !== null &&
+    scan.evidenceState === "valid"
+  );
+}
+
 export function PublicScanResults({ domain, initialScan }: Props) {
   const [scan, setScan] = useState<ScanData | null>(initialScan);
-  const [polling, setPolling] = useState(
-    !initialScan || initialScan.status !== "COMPLETED",
-  );
+  const [polling, setPolling] = useState(() => {
+    if (!initialScan?.id) return false;
+    if (initialScan.status === "FAILED") return false;
+    if (initialScan.evidenceState === "expired") return false;
+    if (isCurrentPublicProof(initialScan)) return false;
+    if (initialScan.status === "COMPLETED") return false;
+    return true;
+  });
 
   const fetchScan = useCallback(async () => {
-    if (!scan?.id && !initialScan?.id) return;
-    const id = scan?.id ?? initialScan?.id;
+    const pollId = scan?.id ?? initialScan?.id;
+    if (!pollId) return;
     try {
-      const res = await fetch(`/api/public-scan/${id}`);
+      const res = await fetch(`/api/public-scan/${pollId}`);
       const json = await res.json();
+      if (res.status === 410) {
+        setPolling(false);
+        setScan((prev) =>
+          prev
+            ? { ...prev, evidenceState: "expired" }
+            : {
+                id: pollId,
+                domain,
+                status: "COMPLETED",
+                evidenceState: "expired",
+                score: null,
+                totalViolations: 0,
+                criticalCount: 0,
+                seriousCount: 0,
+                moderateCount: 0,
+                minorCount: 0,
+                pagesScanned: 0,
+                violations: null,
+                createdAt: new Date().toISOString(),
+                completedAt: null,
+                expiresAt: null,
+              },
+        );
+        return;
+      }
       if (json.success) {
         setScan(json.data);
-        if (json.data.status === "COMPLETED" || json.data.status === "FAILED") {
+        const done =
+          json.data.status === "FAILED" ||
+          json.data.evidenceState === "expired" ||
+          isCurrentPublicProof(json.data);
+        if (done) {
           setPolling(false);
         }
       }
     } catch {
       // Silent poll failure; will retry
     }
-  }, [scan?.id, initialScan?.id]);
+  }, [domain, scan?.id, initialScan?.id]);
+
+  useEffect(() => {
+    if (!initialScan?.id && !scan?.id) {
+      setPolling(false);
+    }
+  }, [initialScan?.id, scan?.id]);
 
   useEffect(() => {
     if (!polling) return;
+    void fetchScan();
     const interval = setInterval(fetchScan, 2000);
     return () => clearInterval(interval);
   }, [polling, fetchScan]);
 
+  const currentProof =
+    scan !== null && isCurrentPublicProof(scan) ? scan : null;
   const violations: Record<string, unknown>[] =
-    (scan?.violations as Record<string, unknown>[] | null) ?? [];
+    (currentProof?.violations as Record<string, unknown>[] | null) ?? [];
 
   return (
     <div className="min-h-screen bg-white">
@@ -120,7 +180,12 @@ export function PublicScanResults({ domain, initialScan }: Props) {
 
         {/* Loading State */}
         {polling && (!scan || scan.status !== "COMPLETED") && (
-          <div className="text-center py-20">
+          <div
+            className="text-center py-20"
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+          >
             <div className="inline-block h-12 w-12 animate-spin rounded-full border-4 border-slate-200 border-t-brand-600" />
             <p className="mt-4 text-lg text-slate-600">Scanning {domain}...</p>
             <p className="mt-2 text-sm text-slate-400">
@@ -143,22 +208,46 @@ export function PublicScanResults({ domain, initialScan }: Props) {
           </div>
         )}
 
-        {/* Results */}
-        {scan?.status === "COMPLETED" && scan.score !== null && (
+        {scan?.status === "COMPLETED" && scan.evidenceState === "expired" && (
+          <div className="card border-amber-200 bg-amber-50 py-10 px-6 text-center">
+            <p className="text-lg font-semibold text-amber-900">
+              This public scan evidence has expired
+            </p>
+            <p className="mt-2 text-sm text-amber-800 max-w-lg mx-auto">
+              Shared previews and badges only reflect unexpired completed scans.
+              Start a new instant scan from the home page to refresh results.
+            </p>
+            <Link href="/" className="btn-primary mt-6 inline-block">
+              Run a new scan
+            </Link>
+          </div>
+        )}
+
+        {/* Results — only when server classifies evidence as current */}
+        {currentProof && (
           <div className="space-y-8">
+            {currentProof.expiresAt && (
+              <p className="text-sm text-slate-500">
+                Public evidence valid until{" "}
+                <time dateTime={currentProof.expiresAt}>
+                  {new Date(currentProof.expiresAt).toLocaleString()}
+                </time>
+                . Sampled up to 5 pages; not a WCAG conformance guarantee.
+              </p>
+            )}
             {/* Score + Summary */}
             <div className="grid md:grid-cols-3 gap-6">
               {/* Score Card */}
               <div className="card text-center md:col-span-1">
                 <div
-                  className={`text-6xl font-extrabold ${getScoreColor(scan.score)}`}
+                  className={`text-6xl font-extrabold ${getScoreColor(currentProof.score!)}`}
                 >
-                  {scan.score}
+                  {currentProof.score}
                 </div>
                 <p
-                  className={`mt-2 font-semibold ${getScoreColor(scan.score)}`}
+                  className={`mt-2 font-semibold ${getScoreColor(currentProof.score!)}`}
                 >
-                  {getScoreLabel(scan.score)}
+                  {getScoreLabel(currentProof.score!)}
                 </p>
                 <p className="mt-1 text-sm text-slate-400">
                   Accessibility Score
@@ -168,26 +257,26 @@ export function PublicScanResults({ domain, initialScan }: Props) {
               {/* Severity Breakdown */}
               <div className="card md:col-span-2">
                 <h2 className="text-lg font-semibold text-slate-900 mb-4">
-                  Issues Found: {scan.totalViolations}
+                  Issues Found: {currentProof.totalViolations}
                 </h2>
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                   {[
                     {
                       label: "Critical",
-                      count: scan.criticalCount,
+                      count: currentProof.criticalCount,
                       key: "critical",
                     },
                     {
                       label: "Serious",
-                      count: scan.seriousCount,
+                      count: currentProof.seriousCount,
                       key: "serious",
                     },
                     {
                       label: "Moderate",
-                      count: scan.moderateCount,
+                      count: currentProof.moderateCount,
                       key: "moderate",
                     },
-                    { label: "Minor", count: scan.minorCount, key: "minor" },
+                    { label: "Minor", count: currentProof.minorCount, key: "minor" },
                   ].map(({ label, count, key }) => (
                     <div
                       key={key}
@@ -199,8 +288,8 @@ export function PublicScanResults({ domain, initialScan }: Props) {
                   ))}
                 </div>
                 <p className="mt-4 text-sm text-slate-400">
-                  Scanned {scan.pagesScanned} page
-                  {scan.pagesScanned !== 1 ? "s" : ""}
+                  Scanned {currentProof.pagesScanned} page
+                  {currentProof.pagesScanned !== 1 ? "s" : ""}
                 </p>
               </div>
             </div>
@@ -254,15 +343,16 @@ export function PublicScanResults({ domain, initialScan }: Props) {
             {/* CTA */}
             <div className="card bg-brand-50 border-brand-200 text-center py-12">
               <h2 className="text-2xl font-bold text-slate-900">
-                Want to fix these issues?
+                Want deeper coverage and exports?
               </h2>
               <p className="mt-2 text-slate-600 max-w-xl mx-auto">
-                Get AI-powered remediation suggestions, component clustering,
-                GitHub PR export, and full evidence reports.
+                Create a workspace for private crawls, tracked findings,
+                remediation workflows, and plan-gated exports — with
+                server-enforced limits.
               </p>
               <div className="mt-6 flex items-center justify-center gap-4">
                 <Link href="/signup" className="btn-primary px-6 py-3">
-                  Start Free — Fix These Issues
+                  Create workspace
                 </Link>
                 <Link href="/" className="btn-secondary px-6 py-3">
                   Scan Another Site

--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -1,182 +1,216 @@
 import { ImageResponse } from "next/og";
 import { NextRequest } from "next/server";
+import { toASCII } from "node:punycode";
+import { getPublicOgRenderModel } from "@/lib/public-scan/og-render-model";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
+
+function isValidDomainParam(domain: string): boolean {
+  if (domain.length > 253) return false;
+  if (domain.includes("/") || domain.includes("\\") || domain.includes(" ")) {
+    return false;
+  }
+  try {
+    const parsed = new URL(`https://${domain}`);
+    return Boolean(parsed.hostname && parsed.hostname.includes("."));
+  } catch {
+    return false;
+  }
+}
 
 /**
- * GET /api/og?domain=example.com&score=85&critical=2&serious=5
- * Generates an Open Graph image for social sharing of scan results.
- * Used as the og:image meta tag on public scan results pages.
+ * GET /api/og?domain=example.com
+ * Open Graph image for public scan share cards. Renders only from current,
+ * non-expired completed public scan data — query-string scores are ignored
+ * so social previews cannot overstate evidence we do not hold.
  */
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = request.nextUrl;
-  const domain = searchParams.get("domain") ?? "unknown";
-  const score = parseInt(searchParams.get("score") ?? "0", 10);
-  const critical = parseInt(searchParams.get("critical") ?? "0", 10);
-  const serious = parseInt(searchParams.get("serious") ?? "0", 10);
-  const moderate = parseInt(searchParams.get("moderate") ?? "0", 10);
-  const minor = parseInt(searchParams.get("minor") ?? "0", 10);
-  const total = critical + serious + moderate + minor;
+    const rawDomain = searchParams.get("domain")?.trim();
 
-  const scoreColor =
-    score >= 90
-      ? "#22c55e"
-      : score >= 70
-        ? "#eab308"
-        : score >= 50
-          ? "#f97316"
-          : "#ef4444";
+    if (!rawDomain) {
+      return new Response("Missing domain parameter", { status: 400 });
+    }
+
+    let displayDomain = rawDomain;
+    try {
+      displayDomain = toASCII(rawDomain.toLowerCase().replace(/\.$/, ""));
+    } catch {
+      displayDomain = rawDomain;
+    }
+
+    if (!isValidDomainParam(displayDomain)) {
+      return new Response("Invalid domain parameter", { status: 400 });
+    }
+
+    const model = await getPublicOgRenderModel(displayDomain);
 
     return new ImageResponse(
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        width: "100%",
-        height: "100%",
-        backgroundColor: "#0f172a",
-        padding: "60px",
-        fontFamily: "system-ui, sans-serif",
-      }}
-    >
-      {/* Header */}
       <div
         style={{
           display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          marginBottom: "40px",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          backgroundColor: "#0f172a",
+          padding: "60px",
+          fontFamily: "system-ui, sans-serif",
         }}
       >
         <div
           style={{
             display: "flex",
-            fontSize: "24px",
-            color: "#94a3b8",
-            fontWeight: 600,
-          }}
-        >
-          AROS Accessibility Scan
-        </div>
-        <div
-          style={{
-            display: "flex",
-            fontSize: "18px",
-            color: "#64748b",
-          }}
-        >
-          {new Date().toLocaleDateString()}
-        </div>
-      </div>
-
-      {/* Domain */}
-      <div
-        style={{
-          display: "flex",
-          fontSize: "42px",
-          color: "#f8fafc",
-          fontWeight: 700,
-          marginBottom: "32px",
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-        }}
-      >
-        {domain}
-      </div>
-
-      {/* Score + Breakdown */}
-      <div style={{ display: "flex", gap: "48px", alignItems: "center" }}>
-        {/* Score Circle */}
-        <div
-          style={{
-            display: "flex",
-            width: "200px",
-            height: "200px",
-            borderRadius: "50%",
-            border: `8px solid ${scoreColor}`,
+            justifyContent: "space-between",
             alignItems: "center",
-            justifyContent: "center",
-            flexDirection: "column",
+            marginBottom: "40px",
           }}
         >
           <div
             style={{
               display: "flex",
-              fontSize: "72px",
-              fontWeight: 800,
-              color: scoreColor,
+              fontSize: "24px",
+              color: "#94a3b8",
+              fontWeight: 600,
             }}
           >
-            {score}
+            AROS public scan preview
           </div>
           <div
             style={{
               display: "flex",
               fontSize: "18px",
-              color: "#94a3b8",
+              color: "#64748b",
             }}
           >
-            Score
+            {new Date().toLocaleDateString()}
           </div>
         </div>
 
-        {/* Severity Breakdown */}
-        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+        <div
+          style={{
+            display: "flex",
+            fontSize: "42px",
+            color: "#f8fafc",
+            fontWeight: 700,
+            marginBottom: "24px",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {model.displayDomain}
+        </div>
+
+        {!model.hasCurrentProof && (
           <div
             style={{
               display: "flex",
-              fontSize: "28px",
-              color: "#f8fafc",
-              fontWeight: 600,
+              fontSize: "22px",
+              color: "#94a3b8",
+              marginBottom: "32px",
+              maxWidth: "900px",
+              lineHeight: 1.4,
             }}
           >
-            {total} issues found
+            Run a fresh instant scan on the site to generate shareable
+            accessibility evidence. Previews only reflect unexpired completed
+            scans.
           </div>
-          {[
-            { label: "Critical", count: critical, color: "#ef4444" },
-            { label: "Serious", count: serious, color: "#f97316" },
-            { label: "Moderate", count: moderate, color: "#eab308" },
-            { label: "Minor", count: minor, color: "#22c55e" },
-          ].map(({ label, count, color }) => (
-            <div
-              key={label}
-              style={{ display: "flex", gap: "12px", alignItems: "center" }}
-            >
-              <div
-                style={{
-                  width: "16px",
-                  height: "16px",
-                  borderRadius: "4px",
-                  backgroundColor: color,
-                }}
-              />
-              <div
-                style={{ display: "flex", fontSize: "22px", color: "#e2e8f0" }}
-              >
-                {label}: {count}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
+        )}
 
-      {/* Footer */}
-      <div
-        style={{
-          display: "flex",
-          marginTop: "auto",
-          fontSize: "18px",
-          color: "#64748b",
-        }}
-      >
-        Scan your site free at aros.dev
-      </div>
-    </div>,
-    {
-      width: 1200,
-      height: 630,
-    },
+        <div style={{ display: "flex", gap: "48px", alignItems: "center" }}>
+          <div
+            style={{
+              display: "flex",
+              width: "200px",
+              height: "200px",
+              borderRadius: "50%",
+              border: `8px solid ${model.scoreColor}`,
+              alignItems: "center",
+              justifyContent: "center",
+              flexDirection: "column",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                fontSize: "72px",
+                fontWeight: 800,
+                color: model.scoreColor,
+              }}
+            >
+              {model.scoreDisplay}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                fontSize: "18px",
+                color: "#94a3b8",
+              }}
+            >
+              Score
+            </div>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+            <div
+              style={{
+                display: "flex",
+                fontSize: "28px",
+                color: "#f8fafc",
+                fontWeight: 600,
+              }}
+            >
+              {model.headline}
+            </div>
+            {model.hasCurrentProof &&
+              [
+                { label: "Critical", count: model.critical, color: "#ef4444" },
+                { label: "Serious", count: model.serious, color: "#f97316" },
+                { label: "Moderate", count: model.moderate, color: "#eab308" },
+                { label: "Minor", count: model.minor, color: "#22c55e" },
+              ].map(({ label, count, color }) => (
+                <div
+                  key={label}
+                  style={{ display: "flex", gap: "12px", alignItems: "center" }}
+                >
+                  <div
+                    style={{
+                      width: "16px",
+                      height: "16px",
+                      borderRadius: "4px",
+                      backgroundColor: color,
+                    }}
+                  />
+                  <div
+                    style={{
+                      display: "flex",
+                      fontSize: "22px",
+                      color: "#e2e8f0",
+                    }}
+                  >
+                    {label}: {count}
+                  </div>
+                </div>
+              ))}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            marginTop: "auto",
+            fontSize: "18px",
+            color: "#64748b",
+          }}
+        >
+          Automated sampling — not a WCAG conformance guarantee
+        </div>
+      </div>,
+      {
+        width: 1200,
+        height: 630,
+      },
     );
   } catch {
     return new Response("Failed to generate OG image", { status: 500 });

--- a/apps/web/src/app/api/public-scan/route.test.ts
+++ b/apps/web/src/app/api/public-scan/route.test.ts
@@ -47,6 +47,7 @@ describe("GET /api/public-scan?id=...", () => {
       id: "scan_1",
       domain: "example.com",
       status: "COMPLETED",
+      completedAt: new Date(Date.now() - 120_000),
       expiresAt: new Date(Date.now() - 60_000),
     });
 

--- a/apps/web/src/app/api/public-scan/route.ts
+++ b/apps/web/src/app/api/public-scan/route.ts
@@ -7,6 +7,7 @@ import { createPublicScanResult, findRecentPublicScanForRateLimit } from "@/lib/
 import { validatePublicScanTarget } from "@/lib/public-scan/target-validation";
 import { createHash } from "crypto";
 import { toASCII } from "node:punycode";
+import { PUBLIC_SCAN_EVIDENCE_TTL_MS } from "@aros/config";
 
 export const runtime = "nodejs";
 
@@ -116,7 +117,7 @@ export async function POST(request: Request) {
       status: "PENDING",
       maxPages: PUBLIC_SCAN_MAX_PAGES,
       ipHash,
-      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      expiresAt: new Date(Date.now() + PUBLIC_SCAN_EVIDENCE_TTL_MS),
     });
 
     // Enqueue the scan job (fire and forget - client polls for results)

--- a/apps/web/src/app/docs/api/page.tsx
+++ b/apps/web/src/app/docs/api/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "API & integrations",
+  description:
+    "How to integrate AROS today: MCP server, API keys, and webhooks. Reference docs for a standalone public REST API are not shipped in this deployment.",
+};
+
+export default function DocsApiPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="mx-auto max-w-2xl px-6 py-16">
+        <p className="text-sm font-medium text-brand-600">Documentation</p>
+        <h1 className="mt-2 text-3xl font-bold text-slate-900">
+          API and integrations
+        </h1>
+        <p className="mt-4 text-slate-600">
+          This product ships integration through authenticated workspace features,
+          not a separate browsable public API reference site. Below is what the
+          repository actually supports today.
+        </p>
+
+        <ul className="mt-8 space-y-6 text-slate-700">
+          <li>
+            <h2 className="font-semibold text-slate-900">MCP server</h2>
+            <p className="mt-1 text-sm">
+              Run{" "}
+              <code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+                npx @aros/mcp-server
+              </code>{" "}
+              for tool-based access. See the package README on npm for options.
+            </p>
+            <a
+              href="https://www.npmjs.com/package/@aros/mcp-server"
+              className="mt-2 inline-block text-sm font-medium text-brand-600 hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View @aros/mcp-server on npm
+            </a>
+          </li>
+          <li>
+            <h2 className="font-semibold text-slate-900">Organization API keys</h2>
+            <p className="mt-1 text-sm">
+              After you sign in, create and rotate keys under Settings → API keys.
+              Usage is org-scoped and subject to plan limits enforced on the server.
+            </p>
+            <Link
+              href="/signup"
+              className="mt-2 inline-block text-sm font-medium text-brand-600 hover:underline"
+            >
+              Create a workspace
+            </Link>
+          </li>
+          <li>
+            <h2 className="font-semibold text-slate-900">Webhooks & CI</h2>
+            <p className="mt-1 text-sm">
+              Deploy hooks and GitHub Actions integrations are configured in the
+              dashboard per site or repository; see in-app settings for the exact
+              endpoints and secrets your deployment exposes.
+            </p>
+          </li>
+        </ul>
+
+        <p className="mt-10 text-sm text-slate-500">
+          A standalone public OpenAPI browser is not part of this build. If you need
+          machine-readable contracts, use the MCP package source or ask your
+          operator for an export from this deployment.
+        </p>
+
+        <Link
+          href="/"
+          className="mt-8 inline-block text-sm font-medium text-slate-600 hover:text-slate-900"
+        >
+          ← Back to home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/public-scan/og-render-model.test.ts
+++ b/apps/web/src/lib/public-scan/og-render-model.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getLatestMock, getStateMock } = vi.hoisted(() => ({
+  getLatestMock: vi.fn(),
+  getStateMock: vi.fn(),
+}));
+
+vi.mock("./validity", () => ({
+  getLatestValidPublicScanForDomain: getLatestMock,
+  getPublicScanEvidenceState: getStateMock,
+}));
+
+import { getPublicOgRenderModel } from "./og-render-model";
+
+describe("getPublicOgRenderModel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns placeholder model when there is no current valid scan", async () => {
+    getLatestMock.mockResolvedValueOnce(null);
+    getStateMock.mockReturnValueOnce("missing");
+
+    const model = await getPublicOgRenderModel("example.com");
+
+    expect(getLatestMock).toHaveBeenCalledWith("example.com", {
+      requireCompleted: true,
+    });
+    expect(model.hasCurrentProof).toBe(false);
+    expect(model.scoreDisplay).toBe("—");
+    expect(model.headline).toMatch(/no current public scan evidence/i);
+    expect(model.scoreColor).toBe("#64748b");
+  });
+
+  it("returns score model when evidence is valid", async () => {
+    getLatestMock.mockResolvedValueOnce({
+      score: 82,
+      criticalCount: 0,
+      seriousCount: 1,
+      moderateCount: 2,
+      minorCount: 0,
+    });
+    getStateMock.mockReturnValueOnce("valid");
+
+    const model = await getPublicOgRenderModel("example.com");
+
+    expect(model.hasCurrentProof).toBe(true);
+    expect(model.scoreDisplay).toBe("82");
+    expect(model.total).toBe(3);
+    expect(model.headline).toContain("3");
+  });
+});

--- a/apps/web/src/lib/public-scan/og-render-model.ts
+++ b/apps/web/src/lib/public-scan/og-render-model.ts
@@ -1,0 +1,65 @@
+import {
+  getLatestValidPublicScanForDomain,
+  getPublicScanEvidenceState,
+} from "./validity";
+
+export type PublicOgRenderModel = {
+  displayDomain: string;
+  hasCurrentProof: boolean;
+  score: number | null;
+  critical: number;
+  serious: number;
+  moderate: number;
+  minor: number;
+  total: number;
+  headline: string;
+  scoreDisplay: string;
+  scoreColor: string;
+};
+
+export async function getPublicOgRenderModel(
+  displayDomain: string,
+): Promise<PublicOgRenderModel> {
+  const scan = await getLatestValidPublicScanForDomain(displayDomain, {
+    requireCompleted: true,
+  });
+  const evidenceState = getPublicScanEvidenceState(scan);
+  const hasCurrentProof = evidenceState === "valid" && scan?.score !== null;
+
+  const score = hasCurrentProof ? (scan!.score as number) : null;
+  const critical = hasCurrentProof ? scan!.criticalCount : 0;
+  const serious = hasCurrentProof ? scan!.seriousCount : 0;
+  const moderate = hasCurrentProof ? scan!.moderateCount : 0;
+  const minor = hasCurrentProof ? scan!.minorCount : 0;
+  const total = critical + serious + moderate + minor;
+
+  const scoreColor = !hasCurrentProof
+    ? "#64748b"
+    : score! >= 90
+      ? "#22c55e"
+      : score! >= 70
+        ? "#eab308"
+        : score! >= 50
+          ? "#f97316"
+          : "#ef4444";
+
+  const headline = !hasCurrentProof
+    ? "No current public scan evidence"
+    : `${total} automated issues (sampled pages)`;
+
+  const scoreDisplay = hasCurrentProof ? String(score) : "—";
+
+  return {
+    displayDomain,
+    hasCurrentProof,
+    score,
+    critical,
+    serious,
+    moderate,
+    minor,
+    total,
+    headline,
+    scoreDisplay,
+    scoreColor,
+  };
+}

--- a/apps/web/src/lib/public-scan/validity.test.ts
+++ b/apps/web/src/lib/public-scan/validity.test.ts
@@ -45,6 +45,15 @@ describe("public scan validity contract", () => {
     ).toBe("valid");
   });
 
+  it("treats completed rows without expiresAt as expired (fail closed)", () => {
+    expect(
+      getPublicScanEvidenceState(
+        { status: "COMPLETED", completedAt: new Date("2020-01-01T00:00:00Z"), expiresAt: null },
+        new Date("2020-01-02T00:00:00Z"),
+      ),
+    ).toBe("expired");
+  });
+
   it("maps canonical API payload fields", () => {
     const payload = toPublicScanApiPayload({
       id: "scan_123",
@@ -71,7 +80,32 @@ describe("public scan validity contract", () => {
       evidenceState: "expired",
       score: 90,
       totalViolations: 2,
+      expiresAt: new Date("2020-01-02T00:00:00Z"),
+      evidenceExpiresAt: null,
     });
-    expect(payload).not.toHaveProperty("expiresAt");
+  });
+
+  it("exposes evidence expiry on API payload when evidence is valid", () => {
+    const exp = new Date("2030-01-05T00:00:00Z");
+    const payload = toPublicScanApiPayload({
+      id: "scan_456",
+      domain: "example.com",
+      status: "COMPLETED",
+      score: 88,
+      totalViolations: 1,
+      criticalCount: 0,
+      seriousCount: 0,
+      moderateCount: 1,
+      minorCount: 0,
+      pagesScanned: 3,
+      violations: [],
+      screenshotKeys: [],
+      createdAt: new Date("2030-01-01T00:00:00Z"),
+      completedAt: new Date("2030-01-01T00:05:00Z"),
+      expiresAt: exp,
+    });
+
+    expect(payload.evidenceState).toBe("valid");
+    expect(payload.evidenceExpiresAt).toEqual(exp);
   });
 });

--- a/apps/web/src/lib/public-scan/validity.ts
+++ b/apps/web/src/lib/public-scan/validity.ts
@@ -1,3 +1,4 @@
+import { PUBLIC_SCAN_EVIDENCE_TTL_MS } from "@aros/config";
 import { prisma } from "@/lib/db";
 
 export type PublicEvidenceState =
@@ -30,18 +31,20 @@ export function getPublicScanEvidenceState(
   now = new Date(),
 ): PublicEvidenceState {
   if (!scan) return "missing";
-  if (scan.expiresAt && scan.expiresAt <= now) return "expired";
   if (scan.status === "FAILED") return "failed";
   if (scan.status !== "COMPLETED" || !scan.completedAt) return "incomplete";
+  // Fail closed: completed rows must carry a future expiry to be treated as current public proof.
+  if (!scan.expiresAt || scan.expiresAt <= now) return "expired";
   return "valid";
 }
 
 export function toPublicScanApiPayload(scan: PublicScanCore) {
+  const evidenceState = getPublicScanEvidenceState(scan);
   return {
     id: scan.id,
     domain: scan.domain,
     status: scan.status,
-    evidenceState: getPublicScanEvidenceState(scan),
+    evidenceState,
     score: scan.score,
     totalViolations: scan.totalViolations,
     criticalCount: scan.criticalCount,
@@ -53,6 +56,9 @@ export function toPublicScanApiPayload(scan: PublicScanCore) {
     screenshotKeys: scan.screenshotKeys,
     createdAt: scan.createdAt,
     completedAt: scan.completedAt,
+    expiresAt: scan.expiresAt,
+    evidenceExpiresAt:
+      evidenceState === "valid" && scan.expiresAt ? scan.expiresAt : null,
   };
 }
 
@@ -86,6 +92,7 @@ export async function getLatestValidPublicScanForDomain(
   return prisma.publicScanResult.findFirst({
     where: {
       domain,
+      // NULL expiresAt is never current evidence (legacy or inconsistent rows).
       expiresAt: { gt: new Date() },
       ...(options.requireCompleted
         ? {

--- a/apps/web/src/lib/route-data-boundary.test.ts
+++ b/apps/web/src/lib/route-data-boundary.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveDashboardOrgMembership, runOrgScopedQuery } from "./route-data-boundary";
 import { prisma } from "./db";
 import { cookies } from "next/headers";
+import { ApiError } from "@aros/shared";
 
 vi.mock("./db", () => ({
   prisma: {
@@ -100,5 +101,20 @@ describe("route-data-boundary", () => {
 
     expect(result).toEqual({ ok: true, data: { id: "result" } });
     expect(query).toHaveBeenCalledWith("org-safe");
+  });
+
+  it("preserves AppError status when callback throws (e.g. NOT_FOUND)", async () => {
+    const query = vi.fn().mockRejectedValueOnce(ApiError.notFound("Finding not found"));
+    const result = await runOrgScopedQuery(
+      { organizationId: "org-safe", role: "ADMIN" },
+      query,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Finding not found",
+      statusCode: 404,
+      code: "NOT_FOUND",
+    });
   });
 });

--- a/apps/web/src/lib/route-data-boundary.ts
+++ b/apps/web/src/lib/route-data-boundary.ts
@@ -2,6 +2,7 @@ import { prisma } from "./db";
 import { cookies } from "next/headers";
 import type { MemberRole } from "@aros/db";
 import type { RoutePlatformTruth } from "@aros/core-services";
+import { AppError } from "@aros/shared";
 
 const ACTIVE_ORG_COOKIE = "aros_active_org";
 
@@ -68,7 +69,13 @@ export async function resolveDashboardOrgMembership(
 
 export type OrgScopedQueryResult<T> =
   | { ok: true; data: T }
-  | { ok: false; message: string };
+  | {
+      ok: false;
+      message: string;
+      /** Present when the scoped callback threw an AppError (e.g. NOT_FOUND). */
+      statusCode?: number;
+      code?: string;
+    };
 
 export async function runOrgScopedQuery<T>(
   ctx: OrgMembershipCore,
@@ -82,6 +89,15 @@ export async function runOrgScopedQuery<T>(
     const data = await fn(ctx.organizationId);
     return { ok: true, data };
   } catch (e) {
+    if (e instanceof AppError) {
+      console.error("[route-data-boundary] org-scoped query failed", e);
+      return {
+        ok: false,
+        message: e.message,
+        statusCode: e.statusCode,
+        code: e.code,
+      };
+    }
     const message = e instanceof Error ? e.message : "Database error";
     console.error("[route-data-boundary] org-scoped query failed", e);
     return { ok: false, message };

--- a/apps/web/src/lib/server-org-boundary.test.ts
+++ b/apps/web/src/lib/server-org-boundary.test.ts
@@ -50,6 +50,23 @@ describe("server-org-boundary", () => {
     });
   });
 
+  it("rethrows AppError-shaped failures from org wrapper (correct HTTP semantics)", async () => {
+    vi.mocked(runOrgScopedQuery).mockResolvedValueOnce({
+      ok: false,
+      message: "Finding not found",
+      statusCode: 404,
+      code: "NOT_FOUND",
+    });
+
+    await expect(
+      runCanonicalOrgQuery({ organizationId: "org-1", role: "ADMIN" } as any, async () => "never"),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      statusCode: 404,
+      message: "Finding not found",
+    });
+  });
+
   it("returns data when org wrapper succeeds", async () => {
     vi.mocked(runOrgScopedQuery).mockResolvedValueOnce({ ok: true, data: { count: 4 } });
 

--- a/apps/web/src/lib/server-org-boundary.ts
+++ b/apps/web/src/lib/server-org-boundary.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "@aros/shared";
+import { ApiError, AppError } from "@aros/shared";
 import { requireOrgAccess } from "@/lib/auth-guard";
 import { runOrgScopedQuery, type OrgMembershipCore } from "@/lib/route-data-boundary";
 import type { Permission } from "@aros/config";
@@ -26,6 +26,9 @@ export async function runCanonicalOrgQuery<T>(
 ): Promise<T> {
   const result = await runOrgScopedQuery(ctx, query);
   if (!result.ok) {
+    if (result.statusCode != null && result.code != null) {
+      throw new AppError(result.message, result.code, result.statusCode);
+    }
     throw ApiError.forbidden(result.message);
   }
   return result.data;

--- a/apps/worker/src/jobs/public-scan.ts
+++ b/apps/worker/src/jobs/public-scan.ts
@@ -1,3 +1,4 @@
+import { PUBLIC_SCAN_EVIDENCE_TTL_MS } from "@aros/config";
 import { Job } from "bullmq";
 import { prisma } from "@aros/db";
 import { chromium, type Browser } from "playwright";
@@ -142,6 +143,7 @@ export async function handlePublicScanJob(job: Job<PublicScanJobData>) {
         ((b.count as number) ?? 0) - ((a.count as number) ?? 0),
     );
 
+    const completedAt = new Date();
     await prisma.publicScanResult.update({
       where: { id: publicScanResultId },
       data: {
@@ -154,7 +156,8 @@ export async function handlePublicScanJob(job: Job<PublicScanJobData>) {
         minorCount,
         pagesScanned,
         violations: allViolations.slice(0, 50) as any,
-        completedAt: new Date(),
+        completedAt,
+        expiresAt: new Date(completedAt.getTime() + PUBLIC_SCAN_EVIDENCE_TTL_MS),
       },
     });
 
@@ -163,11 +166,13 @@ export async function handlePublicScanJob(job: Job<PublicScanJobData>) {
     );
   } catch (err) {
     console.error(`[PublicScan] Failed ${publicScanResultId}:`, err);
+    const failedAt = new Date();
     await prisma.publicScanResult.update({
       where: { id: publicScanResultId },
       data: {
         status: "FAILED",
-        completedAt: new Date(),
+        completedAt: failedAt,
+        expiresAt: new Date(failedAt.getTime() + PUBLIC_SCAN_EVIDENCE_TTL_MS),
       },
     });
     throw err;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -8,4 +8,5 @@ export {
   type EnvDiagnostics,
 } from './env';
 export { PLANS, type PlanConfig, type PlanTier } from './plans';
+export { PUBLIC_SCAN_EVIDENCE_TTL_MS } from './public-scan';
 export { PERMISSIONS, hasPermission, type Permission } from './permissions';

--- a/packages/config/src/public-scan.ts
+++ b/packages/config/src/public-scan.ts
@@ -1,0 +1,5 @@
+/**
+ * Canonical time-to-live for anonymous public scan artifacts (DB row + API).
+ * Must stay aligned with POST /api/public-scan record creation and worker completion updates.
+ */
+export const PUBLIC_SCAN_EVIDENCE_TTL_MS = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This pass closes high-trust seams around **anonymous public scan evidence**, **social/OG previews**, **canonical org-scoped error semantics**, and **release-bar blockers** (Next.js typed routes + missing docs route).

## Changes

### Public proof / buyer trust
- **Fail-closed expiry**: `COMPLETED` public scans without `expiresAt` are treated as **expired** (no silent “valid forever” from legacy worker rows).
- **Canonical TTL**: `PUBLIC_SCAN_EVIDENCE_TTL_MS` in `@aros/config`; aligned with `POST /api/public-scan` and worker completion updates (worker now sets `expiresAt` on complete/fail).
- **API payload**: includes `expiresAt` and `evidenceExpiresAt` (null unless evidence is valid).
- **OG route** (`/api/og`): moved to **nodejs**, loads **only from DB** via `domain` — **query-string scores are ignored** (no URL spoofing of social cards). Extracted `getPublicOgRenderModel` for unit tests.
- **Public scan UI**: gates score/violations on `evidenceState === "valid"`; handles **410**; shows expiry + sampling/WCAG disclaimer; loading uses `role="status"` / `aria-live`; CTA copy matches plan-gated reality.

### Trust / tenant boundary
- **`runOrgScopedQuery`**: when the callback throws `AppError`, the result carries **`statusCode` + `code`** instead of collapsing to a generic message.
- **`runCanonicalOrgQuery`**: rethrows that error so **404 NOT_FOUND** (e.g. missing finding) is not misreported as **403**.

### Product truth / release bar
- **`/docs/api`**: new page explaining what integrations the repo actually ships (MCP, org API keys, webhooks) — home page link is no longer a dead route.
- **Next 15 typed routes**: `redirect` helper for API key revoke; `Route` casts for operator dashboard links.

## Verification

`npm run verify:core` (prisma check/imports, lint warnings only, typecheck, full workspace tests, `next build`) — **pass**.

## Risk

- OG images now require DB access at request time (intentional for truth). Edge OG is removed.
- Existing completed public scans without `expiresAt` will show as **expired** until re-scanned (intentional fail-closed).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cacbfce-3f56-46e3-9752-0588b6c1e703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cacbfce-3f56-46e3-9752-0588b6c1e703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

