### PR TITLE
fix(operator): scope operator health to active org (multi-org)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "test:ct": "playwright test -c playwright-ct.config.ts",
     "test:e2e:update": "playwright test --update-snapshots",
     "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts",
-    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts"
+    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts src/lib/operator-org-resolution.test.ts"
   },
   "dependencies": {
     "@aros/config": "*",

--- a/apps/web/src/app/(dashboard)/system/operator/actions.ts
+++ b/apps/web/src/app/(dashboard)/system/operator/actions.ts
@@ -1,10 +1,13 @@
 "use server";
 
+import { cookies } from "next/headers";
 import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
-import { hasPermission } from "@aros/config";
 import type { MemberRole, SubscriptionStatus } from "@aros/db";
 import { ApiError } from "@aros/shared";
+import { resolveOperatorScopedMembership } from "@/lib/operator-org-resolution";
+
+const ACTIVE_ORG_COOKIE = "aros_active_org";
 
 const DAYS_30_MS = 30 * 24 * 60 * 60 * 1000;
 const DAYS_90_MS = 90 * 24 * 60 * 60 * 1000;
@@ -130,23 +133,36 @@ async function requireOperatorAccess(): Promise<{
 }> {
   const user = await requireSession();
 
-  const membership = await prisma.membership.findFirst({
+  const memberships = await prisma.membership.findMany({
     where: { userId: user.id },
-    include: { organization: { select: { id: true, name: true, slug: true } } },
+    select: { organizationId: true, role: true, createdAt: true },
   });
 
-  if (!membership) {
+  if (memberships.length === 0) {
     throw ApiError.forbidden("No organization membership found");
   }
 
-  if (!hasPermission(membership.role as MemberRole, "org:system:view")) {
+  const cookieStore = await cookies();
+  const preferredOrgId = cookieStore.get(ACTIVE_ORG_COOKIE)?.value;
+
+  const resolved = resolveOperatorScopedMembership(
+    memberships.map((m) => ({
+      organizationId: m.organizationId,
+      role: m.role,
+      createdAt: m.createdAt,
+    })),
+    preferredOrgId ?? undefined,
+    "org:system:view",
+  );
+
+  if (!resolved) {
     throw ApiError.forbidden("Missing permission: org:system:view");
   }
 
   return {
     user,
-    organizationId: membership.organizationId,
-    role: membership.role as MemberRole,
+    organizationId: resolved.organizationId,
+    role: resolved.role,
   };
 }
 

--- a/apps/web/src/lib/operator-org-resolution.test.ts
+++ b/apps/web/src/lib/operator-org-resolution.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveOperatorScopedMembership,
+  type OperatorMembershipRow,
+} from "./operator-org-resolution";
+
+const day = (n: number) => new Date(Date.UTC(2026, 0, n));
+
+describe("resolveOperatorScopedMembership", () => {
+  it("returns null when no membership has the permission", () => {
+    const rows: OperatorMembershipRow[] = [
+      {
+        organizationId: "a",
+        role: "REVIEWER",
+        createdAt: day(1),
+      },
+    ];
+    expect(
+      resolveOperatorScopedMembership(rows, "a", "org:system:view"),
+    ).toBeNull();
+  });
+
+  it("prefers active-org cookie when that org is eligible", () => {
+    const rows: OperatorMembershipRow[] = [
+      {
+        organizationId: "old",
+        role: "ADMIN",
+        createdAt: day(1),
+      },
+      {
+        organizationId: "new",
+        role: "ADMIN",
+        createdAt: day(10),
+      },
+    ];
+    expect(
+      resolveOperatorScopedMembership(rows, "new", "org:system:view"),
+    ).toEqual({ organizationId: "new", role: "ADMIN" });
+  });
+
+  it("ignores cookie when user is not eligible for that org", () => {
+    const rows: OperatorMembershipRow[] = [
+      {
+        organizationId: "eligible",
+        role: "ADMIN",
+        createdAt: day(2),
+      },
+      {
+        organizationId: "other",
+        role: "REVIEWER",
+        createdAt: day(1),
+      },
+    ];
+    expect(
+      resolveOperatorScopedMembership(rows, "other", "org:system:view"),
+    ).toEqual({ organizationId: "eligible", role: "ADMIN" });
+  });
+
+  it("falls back to oldest eligible membership when cookie missing", () => {
+    const rows: OperatorMembershipRow[] = [
+      {
+        organizationId: "second",
+        role: "ADMIN",
+        createdAt: day(5),
+      },
+      {
+        organizationId: "first",
+        role: "ADMIN",
+        createdAt: day(1),
+      },
+    ];
+    expect(
+      resolveOperatorScopedMembership(rows, undefined, "org:system:view"),
+    ).toEqual({ organizationId: "first", role: "ADMIN" });
+  });
+});

--- a/apps/web/src/lib/operator-org-resolution.ts
+++ b/apps/web/src/lib/operator-org-resolution.ts
@@ -1,0 +1,47 @@
+import { hasPermission, type Permission } from "@aros/config";
+import type { MemberRole } from "@aros/db";
+
+export type OperatorMembershipRow = {
+  organizationId: string;
+  role: MemberRole;
+  createdAt: Date;
+};
+
+/**
+ * Picks which org an operator console should scope to.
+ * Must match dashboard layout semantics: prefer `aros_active_org` when the user
+ * is eligible for that org, otherwise oldest membership that has the permission.
+ */
+export function resolveOperatorScopedMembership(
+  rows: OperatorMembershipRow[],
+  preferredOrganizationId: string | undefined,
+  permission: Permission,
+): { organizationId: string; role: MemberRole } | null {
+  const eligible = rows
+    .filter((row) => hasPermission(row.role, permission))
+    .sort(
+      (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+    );
+
+  if (eligible.length === 0) {
+    return null;
+  }
+
+  if (preferredOrganizationId) {
+    const match = eligible.find(
+      (row) => row.organizationId === preferredOrganizationId,
+    );
+    if (match) {
+      return {
+        organizationId: match.organizationId,
+        role: match.role,
+      };
+    }
+  }
+
+  const first = eligible[0];
+  return {
+    organizationId: first.organizationId,
+    role: first.role,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Operator console server actions previously used `prisma.membership.findFirst({ userId })` without ordering, so multi-org users with `org:system:view` could see **stale or wrong-org** operator health data (not aligned with the dashboard’s `aros_active_org` cookie).

## Changes

- **`resolveOperatorScopedMembership`** (`apps/web/src/lib/operator-org-resolution.ts`): pure helper matching dashboard semantics — prefer active org when the user has `org:system:view` there; otherwise oldest eligible membership.
- **`requireOperatorAccess`** in `apps/web/src/app/(dashboard)/system/operator/actions.ts`: load all memberships, resolve via helper + cookie.
- **Tests**: `operator-org-resolution.test.ts`; wired into `test:launch-critical`.

## Verification

- `npm install` (workspace had missing hoisted deps locally; CI should already have them)
- `npm run db:generate`
- `npm run verify:core` — pass (lint warnings pre-existing)
- `npm run verify:release` — pass

## Risk

Low: behavior change only for users in **multiple** orgs with operator permission; single-org users unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63bb564b-4690-4011-a1bd-302f31596600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63bb564b-4690-4011-a1bd-302f31596600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

