### PR TITLE
Product shine: canonical site URL, SEO/sitemap, trust pages, honest public scan framing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # ─── Core ─────────────────────────────────────
 NODE_ENV=development
+# Canonical site URL for OG metadata, sitemap, and billing return URLs (optional; falls back to NEXTAUTH_URL / VERCEL_URL)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/aros?schema=public
 REDIS_URL=redis://localhost:6379
 

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,8 +1,14 @@
 import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
 import { getSession } from '@/lib/session';
 import { LoginForm } from './login-form';
+import { pageTitle } from '@/lib/product-brand';
 
-export const metadata = { title: 'Sign In' };
+export const metadata: Metadata = {
+  title: pageTitle('Sign in'),
+  description: 'Sign in to your FlexibleAccessible workspace.',
+  robots: { index: false, follow: true },
+};
 
 export default async function LoginPage() {
   const user = await getSession();

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -1,8 +1,15 @@
 import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
 import { getSession } from '@/lib/session';
 import { SignupForm } from './signup-form';
+import { pageTitle } from '@/lib/product-brand';
 
-export const metadata = { title: 'Sign Up' };
+export const metadata: Metadata = {
+  title: pageTitle('Create workspace'),
+  description:
+    'Create a FlexibleAccessible workspace for private scans, findings, exports, and plan-gated API access.',
+  robots: { index: false, follow: true },
+};
 
 export default async function SignupPage() {
   const user = await getSession();

--- a/apps/web/src/app/(public)/scan/[domain]/page.tsx
+++ b/apps/web/src/app/(public)/scan/[domain]/page.tsx
@@ -5,6 +5,8 @@ import {
 } from "@/lib/public-scan/validity";
 import { Metadata } from "next";
 import { PublicScanResults } from "./public-scan-results";
+import { getAppBaseUrl } from "@/lib/site-url";
+import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
 
 interface PageProps {
   params: Promise<{ domain: string }>;
@@ -24,19 +26,24 @@ export async function generateMetadata({
   const score = hasCurrentEvidence ? scan!.score! : 0;
   const totalViolations = hasCurrentEvidence ? scan!.totalViolations : 0;
   const title = hasCurrentEvidence
-    ? `Accessibility Report: ${decoded} (Score: ${score})`
-    : `Accessibility Report: ${decoded} (No current evidence)`;
+    ? `Public scan sample: ${decoded}`
+    : `Public scan: ${decoded} (no current evidence)`;
   const description = hasCurrentEvidence
-    ? `Sampled automated scan: ${totalViolations} accessibility issues on ${decoded} (up to 5 pages). Not a WCAG conformance guarantee.`
-    : `No current, unexpired public scan evidence for ${decoded}. Run a new instant scan for fresh automated results.`;
-  const ogUrl = `/api/og?domain=${encodeURIComponent(decoded)}`;
+    ? `Sampled automated scan on ${decoded}: ${totalViolations} issues found in up to 5 pages (severity breakdown in the report). Not a WCAG conformance guarantee.`
+    : `No current, unexpired public scan evidence for ${decoded}. Run a new instant scan from ${PRODUCT_DISPLAY_NAME} for fresh automated results.`;
+  const ogPath = `/api/og?domain=${encodeURIComponent(decoded)}`;
+  const ogUrl = new URL(ogPath, getAppBaseUrl()).toString();
 
   return {
     title,
     description,
+    alternates: {
+      canonical: `/scan/${encodeURIComponent(decoded)}`,
+    },
     openGraph: {
       title,
       description,
+      url: `/scan/${encodeURIComponent(decoded)}`,
       images: [{ url: ogUrl, width: 1200, height: 630 }],
       type: "website",
     },

--- a/apps/web/src/app/(public)/scan/[domain]/public-scan-results.tsx
+++ b/apps/web/src/app/(public)/scan/[domain]/public-scan-results.tsx
@@ -56,10 +56,10 @@ function getScoreColor(score: number): string {
 }
 
 function getScoreLabel(score: number): string {
-  if (score >= 90) return "Good";
-  if (score >= 70) return "Needs Work";
-  if (score >= 50) return "Poor";
-  return "Critical";
+  if (score >= 90) return "Strong sample";
+  if (score >= 70) return "Mixed sample";
+  if (score >= 50) return "Weak sample";
+  return "High defect density";
 }
 
 function isCurrentPublicProof(scan: ScanData | null): boolean {
@@ -164,7 +164,7 @@ export function PublicScanResults({ domain, initialScan }: Props) {
               Sign In
             </Link>
             <Link href="/signup" className="btn-primary text-sm">
-              Get Full Report
+              Open workspace
             </Link>
           </div>
         </nav>
@@ -256,8 +256,12 @@ export function PublicScanResults({ domain, initialScan }: Props) {
                 >
                   {getScoreLabel(currentProof.score!)}
                 </p>
-                <p className="mt-1 text-sm text-slate-400">
-                  Accessibility Score
+                <p className="mt-1 text-sm text-slate-500">
+                  Automated sample index
+                </p>
+                <p className="mt-1 text-xs text-slate-400 max-w-[12rem] mx-auto">
+                  Higher means fewer detected issues in this sample—not WCAG
+                  conformance.
                 </p>
               </div>
 

--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -149,7 +149,7 @@ export async function GET(request: NextRequest) {
                 color: "#94a3b8",
               }}
             >
-              Score
+              Sample index
             </div>
           </div>
 

--- a/apps/web/src/app/docs/api/page.tsx
+++ b/apps/web/src/app/docs/api/page.tsx
@@ -1,24 +1,33 @@
 import Link from "next/link";
 import type { Metadata } from "next";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { pageTitle, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { getAppBaseUrl } from "@/lib/site-url";
 
 export const metadata: Metadata = {
-  title: "API & integrations",
-  description:
-    "How to integrate FlexibleAccessible today: MCP server, API keys, and webhooks. A standalone public REST API reference site is not shipped in this deployment.",
+  title: pageTitle("API & integrations"),
+  description: `How to integrate ${PRODUCT_DISPLAY_NAME} today: MCP server, org-scoped API keys, and webhooks. This deployment does not ship a separate public OpenAPI browser.`,
+  alternates: { canonical: "/docs/api" },
+  openGraph: {
+    title: pageTitle("API & integrations"),
+    description: `Integration paths for ${PRODUCT_DISPLAY_NAME}: MCP, API keys, and webhooks.`,
+    url: `${getAppBaseUrl()}/docs/api`,
+    type: "website",
+  },
 };
 
 export default function DocsApiPage() {
   return (
-    <div className="min-h-screen bg-slate-50">
-      <div className="mx-auto max-w-2xl px-6 py-16">
-        <p className="text-sm font-medium text-brand-600">Documentation</p>
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-2xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Documentation</p>
         <h1 className="mt-2 text-3xl font-bold text-slate-900">
           API and integrations
         </h1>
         <p className="mt-4 text-slate-600">
           This product ships integration through authenticated workspace features,
-          not a separate browsable public API reference site. Below is what the
-          repository actually supports today.
+          not a separate browsable public API reference site. Below is what this
+          repository supports today.
         </p>
 
         <ul className="mt-8 space-y-6 text-slate-700">
@@ -26,14 +35,14 @@ export default function DocsApiPage() {
             <h2 className="font-semibold text-slate-900">MCP server</h2>
             <p className="mt-1 text-sm">
               Run{" "}
-              <code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+              <code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-800">
                 npx @aros/mcp-server
               </code>{" "}
               for tool-based access. See the package README on npm for options.
             </p>
             <a
               href="https://www.npmjs.com/package/@aros/mcp-server"
-              className="mt-2 inline-block text-sm font-medium text-brand-600 hover:underline"
+              className="mt-2 inline-block text-sm font-medium text-brand-700 hover:underline"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -41,20 +50,22 @@ export default function DocsApiPage() {
             </a>
           </li>
           <li>
-            <h2 className="font-semibold text-slate-900">Organization API keys</h2>
+            <h2 className="font-semibold text-slate-900">
+              Organization API keys
+            </h2>
             <p className="mt-1 text-sm">
               After you sign in, create and rotate keys under Settings → API keys.
               Usage is org-scoped and subject to plan limits enforced on the server.
             </p>
             <Link
               href="/signup"
-              className="mt-2 inline-block text-sm font-medium text-brand-600 hover:underline"
+              className="mt-2 inline-block text-sm font-medium text-brand-700 hover:underline"
             >
               Create a workspace
             </Link>
           </li>
           <li>
-            <h2 className="font-semibold text-slate-900">Webhooks & CI</h2>
+            <h2 className="font-semibold text-slate-900">Webhooks &amp; CI</h2>
             <p className="mt-1 text-sm">
               Deploy hooks and GitHub Actions integrations are configured in the
               dashboard per site or repository; see in-app settings for the exact
@@ -68,14 +79,7 @@ export default function DocsApiPage() {
           machine-readable contracts, use the MCP package source or ask your
           operator for an export from this deployment.
         </p>
-
-        <Link
-          href="/"
-          className="mt-8 inline-block text-sm font-medium text-slate-600 hover:text-slate-900"
-        >
-          ← Back to home
-        </Link>
       </div>
-    </div>
+    </MarketingSiteChrome>
   );
 }

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -1,0 +1,559 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  AlertTriangle,
+  Bot,
+  ClipboardCheck,
+  FileBarChart,
+  Layers,
+  LineChart,
+  Search,
+  Wrench,
+} from "lucide-react";
+import { getPublicPlanCards } from "@/lib/public-packaging";
+import {
+  PRODUCT_DISPLAY_NAME,
+  PRODUCT_LEGAL_LINE,
+  PRODUCT_TAGLINE,
+} from "@/lib/product-brand";
+import {
+  beliefCards,
+  developerFeatures,
+  homeFaqs,
+  managedServices,
+  productFeatures,
+} from "@/lib/marketing-content";
+
+const featureIcons = [Search, Layers, Bot, Wrench, ClipboardCheck, FileBarChart] as const;
+const managedIcons = [Wrench, AlertTriangle, LineChart] as const;
+
+export function HomePageClient() {
+  const plans = getPublicPlanCards();
+  const [scanDomain, setScanDomain] = useState("");
+  const [scanning, setScanning] = useState(false);
+  const [scanError, setScanError] = useState("");
+  const router = useRouter();
+
+  const handleInstantScan = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!scanDomain.trim()) return;
+
+      setScanning(true);
+      setScanError("");
+
+      try {
+        const res = await fetch("/api/public-scan", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ domain: scanDomain.trim() }),
+        });
+
+        const json = await res.json();
+
+        if (!res.ok) {
+          if (res.status === 429) {
+            setScanError(
+              json.error?.message ??
+                "Please wait before scanning this domain again.",
+            );
+          } else {
+            setScanError(
+              json.error?.message ?? "Failed to start scan. Please try again.",
+            );
+          }
+          return;
+        }
+
+        if (json.data?.resultsUrl) {
+          router.push(json.data.resultsUrl);
+        }
+      } catch {
+        setScanError("Network error. Please try again.");
+      } finally {
+        setScanning(false);
+      }
+    },
+    [scanDomain, router],
+  );
+
+  return (
+    <div className="min-h-screen bg-[rgb(var(--color-canvas))] text-slate-900">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[9999] focus:rounded-lg focus:bg-brand-700 focus:px-4 focus:py-2 focus:text-white focus:outline-none focus:ring-2 focus:ring-brand-400"
+      >
+        Skip to main content
+      </a>
+
+      <header className="border-b border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))]/90 backdrop-blur-sm supports-[backdrop-filter]:bg-[rgb(var(--color-surface-elevated))]/80">
+        <nav
+          className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-4"
+          aria-label="Main"
+        >
+          <Link
+            href="/"
+            className="group flex flex-col leading-tight focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 rounded-md"
+          >
+            <span className="text-lg font-semibold tracking-tight text-brand-800">
+              {PRODUCT_DISPLAY_NAME}
+            </span>
+            <span className="text-xs font-medium text-slate-500 group-hover:text-slate-700">
+              {PRODUCT_TAGLINE}
+            </span>
+          </Link>
+          <div className="hidden items-center gap-8 sm:flex">
+            <Link
+              href="#proof"
+              className="text-sm font-medium text-slate-600 hover:text-slate-900"
+            >
+              Proof &amp; workflow
+            </Link>
+            <Link
+              href="#pricing"
+              className="text-sm font-medium text-slate-600 hover:text-slate-900"
+            >
+              Plans
+            </Link>
+            <Link
+              href="/trust"
+              className="text-sm font-medium text-slate-600 hover:text-slate-900"
+            >
+              Trust
+            </Link>
+            <Link
+              href="/docs/api"
+              className="text-sm font-medium text-slate-600 hover:text-slate-900"
+            >
+              Integrations
+            </Link>
+            <Link
+              href="/login"
+              className="text-sm font-medium text-slate-600 hover:text-slate-900"
+            >
+              Sign in
+            </Link>
+            <Link href="/signup" className="btn-primary">
+              Start workspace
+            </Link>
+          </div>
+          <Link href="/signup" className="btn-primary sm:hidden">
+            Start
+          </Link>
+        </nav>
+      </header>
+
+      <main id="main">
+        <section
+          className="relative overflow-hidden border-b border-[rgb(var(--color-border))] bg-gradient-to-b from-[rgb(var(--color-surface-elevated))] to-[rgb(var(--color-canvas))]"
+          aria-labelledby="hero-heading"
+        >
+          <div
+            className="pointer-events-none absolute inset-0 opacity-[0.22] motion-reduce:opacity-0"
+            aria-hidden="true"
+          >
+            <div className="absolute -left-24 top-0 h-72 w-72 rounded-full bg-brand-200/40 blur-3xl" />
+            <div className="absolute -right-16 bottom-0 h-64 w-64 rounded-full bg-teal-200/30 blur-3xl" />
+          </div>
+          <div className="relative mx-auto max-w-7xl px-6 py-section-md md:py-section-lg">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="text-sm font-semibold uppercase tracking-widest text-brand-800">
+                Accessibility operations platform
+              </p>
+              <h1
+                id="hero-heading"
+                className="mt-4 text-4xl font-bold leading-tight tracking-tight text-slate-900 md:text-5xl md:leading-tight"
+              >
+                Prove accessibility progress—don&apos;t just publish a score
+              </h1>
+              <p className="mx-auto mt-6 max-w-2xl text-lg text-slate-600">
+                Continuous scans, clustered issues, review trails, and exports
+                your agency or enterprise can stand behind. Built for teams who
+                ship fixes in code—not overlays.
+              </p>
+            </div>
+
+            <form
+              onSubmit={handleInstantScan}
+              className="mx-auto mt-12 max-w-xl"
+              aria-label="Instant public accessibility scan"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
+                <label htmlFor="scan-domain" className="sr-only">
+                  URL or domain to scan
+                </label>
+                <input
+                  id="scan-domain"
+                  type="text"
+                  value={scanDomain}
+                  onChange={(e) => setScanDomain(e.target.value)}
+                  placeholder="example.com or https://…"
+                  className="input flex-1 text-base"
+                  disabled={scanning}
+                  autoComplete="url"
+                  required
+                />
+                <button
+                  type="submit"
+                  className="btn-primary px-6 py-3 text-base whitespace-nowrap sm:shrink-0"
+                  disabled={scanning}
+                >
+                  {scanning ? "Starting…" : "Run public scan"}
+                </button>
+              </div>
+              {scanError && (
+                <p className="mt-3 text-sm text-red-700" role="alert">
+                  {scanError}
+                </p>
+              )}
+              <p className="mt-3 text-center text-sm text-slate-500">
+                No account needed. Sample depth and rate limits apply—see results
+                for caveats.
+              </p>
+            </form>
+
+            <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+              <Link href="/signup" className="btn-secondary text-base px-6 py-3">
+                Open private workspace
+              </Link>
+              <Link
+                href="#pricing"
+                className="text-sm font-semibold text-brand-800 underline-offset-4 hover:underline"
+              >
+                Compare plans
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section
+          className="border-b border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))] py-section-md"
+          aria-labelledby="anti-overlay-heading"
+        >
+          <div className="mx-auto max-w-4xl px-6 text-center">
+            <h2
+              id="anti-overlay-heading"
+              className="text-2xl font-bold text-slate-900"
+            >
+              Source-first. Never an overlay substitute.
+            </h2>
+            <p className="mx-auto mt-4 max-w-2xl text-slate-600">
+              {PRODUCT_DISPLAY_NAME} helps you remediate in templates,
+              components, and repositories. We do not sell runtime patches that
+              pretend away accessibility debt.
+            </p>
+          </div>
+        </section>
+
+        <section
+          id="proof"
+          className="mx-auto max-w-7xl px-6 py-section-lg"
+          aria-labelledby="developer-lane-heading"
+        >
+          <div className="grid items-center gap-12 md:grid-cols-2">
+            <div>
+              <h2
+                id="developer-lane-heading"
+                className="text-3xl font-bold text-slate-900"
+              >
+                Built for builders and operators
+              </h2>
+              <p className="mt-4 text-slate-600">
+                Wire scans into how your team already works—IDE, CI, ticketing,
+                and internal tools. Entitlements and org boundaries are enforced
+                on the server, not buried in client UI.
+              </p>
+              <ul className="mt-8 space-y-3">
+                {developerFeatures.map((feature) => (
+                  <li key={feature} className="flex items-start gap-3">
+                    <span
+                      className="mt-0.5 font-mono text-sm text-brand-700"
+                      aria-hidden="true"
+                    >
+                      &gt;
+                    </span>
+                    <span className="text-slate-700">{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-8 flex flex-wrap gap-4">
+                <Link href="/docs/api" className="btn-secondary">
+                  Integration guide
+                </Link>
+                <Link
+                  href="/signup"
+                  className="inline-flex items-center gap-1 font-semibold text-brand-800 underline-offset-4 hover:underline"
+                >
+                  Get API access on paid plans
+                  <span aria-hidden="true">&rarr;</span>
+                </Link>
+              </div>
+            </div>
+            <div className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-950 p-6 font-mono text-sm text-slate-300 shadow-lg">
+              <pre className="whitespace-pre text-[13px] leading-relaxed">{`# MCP (IDE-native)
+npx @aros/mcp-server
+
+# Authenticated API (org-scoped keys)
+curl -H "Authorization: Bearer $API_KEY" \\
+  $BASE_URL/api/...
+
+# CLI / CI
+npx @aros/cli scan --site example.com`}</pre>
+              <p className="mt-4 border-t border-slate-800 pt-4 text-xs text-slate-500">
+                Package names stay @aros/*; the product you use is{" "}
+                {PRODUCT_DISPLAY_NAME}.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section
+          className="border-y border-[rgb(var(--color-border))] bg-brand-50/40 py-section-lg"
+          aria-labelledby="managed-heading"
+        >
+          <div className="mx-auto max-w-7xl px-6">
+            <div className="mb-12 text-center">
+              <h2
+                id="managed-heading"
+                className="text-3xl font-bold text-slate-900"
+              >
+                Managed accessibility operations
+              </h2>
+              <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
+                When you want outcomes without hiring a full internal program
+                overnight—we embed with your release cadence and evidence
+                requirements.
+              </p>
+            </div>
+            <div className="grid gap-8 md:grid-cols-3">
+              {managedServices.map((service, i) => {
+                const Icon = managedIcons[i] ?? Wrench;
+                return (
+                  <article
+                    key={service.title}
+                    className="rounded-xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))] p-6 shadow-sm"
+                  >
+                    <div className="mb-3 text-brand-700" aria-hidden="true">
+                      <Icon className="h-8 w-8" strokeWidth={1.75} />
+                    </div>
+                    <h3 className="text-lg font-semibold text-slate-900">
+                      {service.title}
+                    </h3>
+                    <p className="mt-2 text-sm text-slate-600">
+                      {service.description}
+                    </p>
+                  </article>
+                );
+              })}
+            </div>
+            <div className="mt-12 text-center">
+              <Link
+                href="mailto:sales@aros.dev"
+                className="btn-primary px-8 py-3 text-base"
+              >
+                Talk to us about scope
+              </Link>
+              <p className="mt-3 text-sm text-slate-500">
+                Custom SOWs—procurement-friendly documentation on request
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section
+          id="features"
+          className="mx-auto max-w-7xl px-6 py-section-lg"
+          aria-labelledby="how-heading"
+        >
+          <h2
+            id="how-heading"
+            className="mb-4 text-center text-3xl font-bold text-slate-900"
+          >
+            How it works
+          </h2>
+          <p className="mx-auto mb-12 max-w-2xl text-center text-slate-600">
+            A recurring loop—scan, cluster, triage, prove—so accessibility stays
+            legible to engineering, design, and legal stakeholders.
+          </p>
+          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+            {productFeatures.map((feature, i) => {
+              const Icon = featureIcons[i] ?? Search;
+              return (
+                <article
+                  key={feature.title}
+                  className="card border-[rgb(var(--color-border))] transition-shadow hover:shadow-md"
+                >
+                  <div className="mb-3 text-brand-700" aria-hidden="true">
+                    <Icon className="h-8 w-8" strokeWidth={1.75} />
+                  </div>
+                  <h3 className="text-lg font-semibold text-slate-900">
+                    {feature.title}
+                  </h3>
+                  <p className="mt-2 text-sm text-slate-600">
+                    {feature.description}
+                  </p>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section
+          className="border-y border-[rgb(var(--color-border))] bg-slate-100/50 py-section-md"
+          aria-labelledby="beliefs-heading"
+        >
+          <div className="mx-auto max-w-4xl px-6">
+            <h2
+              id="beliefs-heading"
+              className="mb-8 text-center text-2xl font-bold text-slate-900"
+            >
+              What we will not pretend
+            </h2>
+            <div className="grid gap-6 md:grid-cols-2">
+              {beliefCards.map((b) => (
+                <div key={b.title} className="card">
+                  <h3 className="mb-2 font-semibold text-slate-900">
+                    {b.title}
+                  </h3>
+                  <p className="text-sm text-slate-600">{b.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section
+          id="pricing"
+          className="mx-auto max-w-7xl px-6 py-section-lg"
+          aria-labelledby="pricing-heading"
+        >
+          <h2
+            id="pricing-heading"
+            className="mb-4 text-center text-3xl font-bold text-slate-900"
+          >
+            Plans
+          </h2>
+          <p className="mx-auto mb-12 max-w-2xl text-center text-slate-600">
+            Free public scans invite you in; paid tiers unlock private workspaces,
+            history, automation, and API access—enforced server-side.
+          </p>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {plans.map((plan) => (
+              <div
+                key={plan.name}
+                className={`card flex flex-col ${plan.highlighted ? "ring-2 ring-brand-600 ring-offset-2" : ""}`}
+              >
+                <h3 className="text-lg font-semibold text-slate-900">
+                  {plan.name}
+                </h3>
+                <p className="mt-2">
+                  <span className="text-3xl font-bold text-slate-900">
+                    ${plan.priceMonthly}
+                  </span>
+                  {plan.priceMonthly > 0 && (
+                    <span className="text-slate-500">/mo</span>
+                  )}
+                </p>
+                <ul className="mt-4 flex-1 space-y-2" role="list">
+                  {plan.bullets.map((f) => (
+                    <li
+                      key={f}
+                      className="flex items-start gap-2 text-sm text-slate-600"
+                    >
+                      <span
+                        className="mt-0.5 text-brand-700"
+                        aria-hidden="true"
+                      >
+                        &#10003;
+                      </span>
+                      {f}
+                    </li>
+                  ))}
+                </ul>
+                <Link
+                  href="/signup"
+                  className={`mt-6 inline-flex w-full justify-center ${
+                    plan.highlighted ? "btn-primary" : "btn-secondary"
+                  }`}
+                  aria-label={`Get started with ${plan.name} plan`}
+                >
+                  {plan.tier === "FREE"
+                    ? "Run instant scan from home"
+                    : "Choose plan"}
+                </Link>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section
+          className="border-t border-[rgb(var(--color-border))] bg-slate-100/40 py-section-lg"
+          aria-labelledby="faq-heading"
+        >
+          <div className="mx-auto max-w-4xl px-6">
+            <h2
+              id="faq-heading"
+              className="mb-12 text-center text-3xl font-bold text-slate-900"
+            >
+              Questions
+            </h2>
+            <div className="space-y-4">
+              {homeFaqs.map((faq) => (
+                <details
+                  key={faq.question}
+                  className="group rounded-xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))] p-6 shadow-sm"
+                >
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 font-semibold text-slate-900">
+                    <span>{faq.question}</span>
+                    <span
+                      className="shrink-0 text-slate-400 group-open:rotate-180 motion-reduce:transition-none transition-transform"
+                      aria-hidden="true"
+                    >
+                      &#9662;
+                    </span>
+                  </summary>
+                  <p className="mt-4 leading-relaxed text-slate-600">
+                    {faq.answer}
+                  </p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))] py-10">
+        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-slate-800">
+              {PRODUCT_DISPLAY_NAME}
+            </p>
+            <p className="mt-1 max-w-md text-xs text-slate-500">
+              {PRODUCT_LEGAL_LINE}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-6 text-sm text-slate-500">
+            <Link href="/login" className="hover:text-slate-800">
+              Sign in
+            </Link>
+            <Link href="/signup" className="hover:text-slate-800">
+              Create account
+            </Link>
+            <Link href="/docs/api" className="hover:text-slate-800">
+              Docs
+            </Link>
+            <Link href="/trust" className="hover:text-slate-800">
+              Trust
+            </Link>
+            <Link href="/security" className="hover:text-slate-800">
+              Security
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,8 +6,10 @@ import {
   PRODUCT_SHORT_NAME,
   PRODUCT_TAGLINE,
 } from "@/lib/product-brand";
+import { getAppBaseUrl } from "@/lib/site-url";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(getAppBaseUrl()),
   title: {
     default: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
     template: `%s · ${PRODUCT_DISPLAY_NAME}`,

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,638 +1,92 @@
-"use client";
-
-import { useState, useCallback } from "react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { getPublicPlanCards } from "@/lib/public-packaging";
+import type { Metadata } from "next";
+import { HomePageClient } from "./home-page-client";
 import {
+  PRODUCT_DESCRIPTION,
   PRODUCT_DISPLAY_NAME,
-  PRODUCT_LEGAL_LINE,
   PRODUCT_TAGLINE,
 } from "@/lib/product-brand";
+import { getAppBaseUrl } from "@/lib/site-url";
+import { homeFaqs, productFeatures } from "@/lib/marketing-content";
 
-const developerFeatures = [
-  "MCP server with 20+ tools for IDE-native workflows",
-  "Scoped API keys with organization boundaries enforced server-side",
-  "CLI for CI gates and diff-friendly scan output",
-  "Webhooks when crawls complete—wire into your own runbooks",
-  "Same engine as the product UI—no mystery “AI score” API",
-];
+const baseUrl = getAppBaseUrl();
 
-const managedServices = [
-  {
-    icon: "\u{1F6E0}",
-    title: "Program setup & playbooks",
-    description:
-      "We help you define scan scope, severity policy, export templates, and stakeholder reporting rhythms so the work stays accountable.",
+export const metadata: Metadata = {
+  title: {
+    absolute: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
   },
-  {
-    icon: "\u{1F6A8}",
-    title: "Remediation partnership",
-    description:
-      "Engineers pair with your team on high-impact clusters—PRs, CMS patterns, and design-system fixes—not widget overlays.",
+  description: PRODUCT_DESCRIPTION,
+  alternates: {
+    canonical: "/",
   },
-  {
-    icon: "\u{1F4C8}",
-    title: "Ongoing operations",
-    description:
-      "Scheduled scans, regression alerts, and evidence packs for leadership—priced as a service, not shelf-ware.",
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: baseUrl,
+    siteName: PRODUCT_DISPLAY_NAME,
+    title: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
+    description: PRODUCT_DESCRIPTION,
   },
-];
-
-const faqs = [
-  {
-    question: "How is this different from another “AI accessibility” checker?",
-    answer:
-      "FlexibleAccessible is built as an operations surface: browser-accurate crawling, clustered findings so you fix root causes, review queues, exports, and API/MCP hooks. Where AI appears, it is bounded—draft suggestions with confidence and human review—not a black-box compliance promise.",
+  twitter: {
+    card: "summary_large_image",
+    title: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
+    description: PRODUCT_DESCRIPTION,
   },
-  {
-    question: "How is this different from accessibility overlays?",
-    answer:
-      "Overlays inject third-party widgets that do not repair underlying code and are widely rejected by the disability community. This product is source-first: fix HTML, CSS, ARIA, and components where they belong.",
-  },
-  {
-    question: "Do you guarantee WCAG or legal compliance?",
-    answer:
-      "No. Automated testing covers a fraction of WCAG. We surface evidence and workflow state; manual testing by experts and users with disabilities remains essential for any serious conformance claim.",
-  },
-  {
-    question: "What does the free instant scan include?",
-    answer:
-      "A bounded public sample of pages with clear limitations—enough to see signal, not a substitute for full-site monitoring, private workspaces, history, or exports. Upgrade for the complete operator workflow.",
-  },
-];
+};
 
 export default function HomePage() {
-  const plans = getPublicPlanCards();
-  const [scanDomain, setScanDomain] = useState("");
-  const [scanning, setScanning] = useState(false);
-  const [scanError, setScanError] = useState("");
-  const router = useRouter();
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: homeFaqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: faq.answer,
+      },
+    })),
+  };
 
-  const handleInstantScan = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      if (!scanDomain.trim()) return;
-
-      setScanning(true);
-      setScanError("");
-
-      try {
-        const res = await fetch("/api/public-scan", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ domain: scanDomain.trim() }),
-        });
-
-        const json = await res.json();
-
-        if (!res.ok) {
-          if (res.status === 429) {
-            setScanError(
-              json.error?.message ??
-                "Please wait before scanning this domain again.",
-            );
-          } else {
-            setScanError(
-              json.error?.message ?? "Failed to start scan. Please try again.",
-            );
-          }
-          return;
-        }
-
-        if (json.data?.resultsUrl) {
-          router.push(json.data.resultsUrl);
-        }
-      } catch {
-        setScanError("Network error. Please try again.");
-      } finally {
-        setScanning(false);
-      }
+  const softwareSchema = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: PRODUCT_DISPLAY_NAME,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Web",
+    description: PRODUCT_DESCRIPTION,
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+      description:
+        "Free instant public scan with limits; paid workspaces for full coverage.",
     },
-    [scanDomain, router],
-  );
+    featureList: productFeatures.map((f) => f.title),
+  };
+
+  const orgSchema = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: PRODUCT_DISPLAY_NAME,
+    url: baseUrl,
+    description: PRODUCT_DESCRIPTION,
+  };
 
   return (
-    <div className="min-h-screen bg-[rgb(var(--color-canvas))] text-slate-900">
-      <a
-        href="#main"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[9999] focus:rounded-lg focus:bg-brand-700 focus:px-4 focus:py-2 focus:text-white focus:outline-none focus:ring-2 focus:ring-brand-400"
-      >
-        Skip to main content
-      </a>
-
-      <header className="border-b border-slate-200/80 bg-white/90 backdrop-blur-sm supports-[backdrop-filter]:bg-white/75">
-        <nav
-          className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-4"
-          aria-label="Main"
-        >
-          <Link
-            href="/"
-            className="group flex flex-col leading-tight focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 rounded-md"
-          >
-            <span className="text-lg font-semibold tracking-tight text-brand-800">
-              {PRODUCT_DISPLAY_NAME}
-            </span>
-            <span className="text-xs font-medium text-slate-500 group-hover:text-slate-700">
-              {PRODUCT_TAGLINE}
-            </span>
-          </Link>
-          <div className="hidden items-center gap-8 sm:flex">
-            <Link
-              href="#proof"
-              className="text-sm font-medium text-slate-600 hover:text-slate-900"
-            >
-              Proof &amp; workflow
-            </Link>
-            <Link
-              href="#pricing"
-              className="text-sm font-medium text-slate-600 hover:text-slate-900"
-            >
-              Plans
-            </Link>
-            <Link
-              href="/docs/api"
-              className="text-sm font-medium text-slate-600 hover:text-slate-900"
-            >
-              Integrations
-            </Link>
-            <Link
-              href="/login"
-              className="text-sm font-medium text-slate-600 hover:text-slate-900"
-            >
-              Sign in
-            </Link>
-            <Link href="/signup" className="btn-primary">
-              Start workspace
-            </Link>
-          </div>
-          <Link href="/signup" className="btn-primary sm:hidden">
-            Start
-          </Link>
-        </nav>
-      </header>
-
-      <main id="main">
-        <section
-          className="relative overflow-hidden border-b border-slate-200/60 bg-gradient-to-b from-white to-[rgb(var(--color-canvas))]"
-          aria-labelledby="hero-heading"
-        >
-          <div
-            className="pointer-events-none absolute inset-0 opacity-[0.35]"
-            aria-hidden="true"
-          >
-            <div className="absolute -left-24 top-0 h-72 w-72 rounded-full bg-brand-200/40 blur-3xl" />
-            <div className="absolute -right-16 bottom-0 h-64 w-64 rounded-full bg-teal-200/30 blur-3xl" />
-          </div>
-          <div className="relative mx-auto max-w-7xl px-6 py-20 md:py-28">
-            <div className="mx-auto max-w-3xl text-center">
-              <p className="text-sm font-semibold uppercase tracking-widest text-brand-800">
-                Accessibility operations platform
-              </p>
-              <h1
-                id="hero-heading"
-                className="mt-4 text-4xl font-bold leading-tight tracking-tight text-slate-900 md:text-5xl md:leading-tight"
-              >
-                Prove accessibility progress—don&apos;t just publish a score
-              </h1>
-              <p className="mx-auto mt-6 max-w-2xl text-lg text-slate-600">
-                Continuous scans, clustered issues, review trails, and exports
-                your agency or enterprise can stand behind. Built for teams who
-                ship fixes in code—not overlays.
-              </p>
-            </div>
-
-            <form
-              onSubmit={handleInstantScan}
-              className="mx-auto mt-12 max-w-xl"
-              aria-label="Instant public accessibility scan"
-            >
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
-                <label htmlFor="scan-domain" className="sr-only">
-                  URL or domain to scan
-                </label>
-                <input
-                  id="scan-domain"
-                  type="text"
-                  value={scanDomain}
-                  onChange={(e) => setScanDomain(e.target.value)}
-                  placeholder="example.com or https://…"
-                  className="input flex-1 text-base"
-                  disabled={scanning}
-                  autoComplete="url"
-                  required
-                />
-                <button
-                  type="submit"
-                  className="btn-primary px-6 py-3 text-base whitespace-nowrap sm:shrink-0"
-                  disabled={scanning}
-                >
-                  {scanning ? "Starting…" : "Run public scan"}
-                </button>
-              </div>
-              {scanError && (
-                <p className="mt-3 text-sm text-red-700" role="alert">
-                  {scanError}
-                </p>
-              )}
-              <p className="mt-3 text-center text-sm text-slate-500">
-                No account needed. Sample depth and rate limits apply—see results
-                for caveats.
-              </p>
-            </form>
-
-            <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
-              <Link href="/signup" className="btn-secondary text-base px-6 py-3">
-                Open private workspace
-              </Link>
-              <Link
-                href="#pricing"
-                className="text-sm font-semibold text-brand-800 underline-offset-4 hover:underline"
-              >
-                Compare plans
-              </Link>
-            </div>
-          </div>
-        </section>
-
-        <section
-          className="border-b border-slate-200/80 bg-white py-16"
-          aria-labelledby="anti-overlay-heading"
-        >
-          <div className="mx-auto max-w-4xl px-6 text-center">
-            <h2
-              id="anti-overlay-heading"
-              className="text-2xl font-bold text-slate-900"
-            >
-              Source-first. Never an overlay substitute.
-            </h2>
-            <p className="mx-auto mt-4 max-w-2xl text-slate-600">
-              {PRODUCT_DISPLAY_NAME} helps you remediate in templates,
-              components, and repositories. We do not sell runtime patches that
-              pretend away accessibility debt.
-            </p>
-          </div>
-        </section>
-
-        <section
-          id="proof"
-          className="mx-auto max-w-7xl px-6 py-24"
-          aria-labelledby="developer-lane-heading"
-        >
-          <div className="grid items-center gap-12 md:grid-cols-2">
-            <div>
-              <h2
-                id="developer-lane-heading"
-                className="text-3xl font-bold text-slate-900"
-              >
-                Built for builders and operators
-              </h2>
-              <p className="mt-4 text-slate-600">
-                Wire scans into how your team already works—IDE, CI, ticketing,
-                and internal tools. Entitlements and org boundaries are enforced
-                on the server, not buried in client UI.
-              </p>
-              <ul className="mt-8 space-y-3">
-                {developerFeatures.map((feature) => (
-                  <li key={feature} className="flex items-start gap-3">
-                    <span
-                      className="mt-0.5 font-mono text-sm text-brand-700"
-                      aria-hidden="true"
-                    >
-                      &gt;
-                    </span>
-                    <span className="text-slate-700">{feature}</span>
-                  </li>
-                ))}
-              </ul>
-              <div className="mt-8 flex flex-wrap gap-4">
-                <Link href="/docs/api" className="btn-secondary">
-                  Integration guide
-                </Link>
-                <Link
-                  href="/signup"
-                  className="inline-flex items-center gap-1 font-semibold text-brand-800 underline-offset-4 hover:underline"
-                >
-                  Get API access on paid plans
-                  <span aria-hidden="true">&rarr;</span>
-                </Link>
-              </div>
-            </div>
-            <div className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-950 p-6 font-mono text-sm text-slate-300 shadow-lg">
-              <pre className="whitespace-pre text-[13px] leading-relaxed">{`# MCP (IDE-native)
-npx @aros/mcp-server
-
-# Authenticated API (org-scoped keys)
-curl -H "Authorization: Bearer $API_KEY" \\
-  $BASE_URL/api/...
-
-# CLI / CI
-npx @aros/cli scan --site example.com`}</pre>
-              <p className="mt-4 border-t border-slate-800 pt-4 text-xs text-slate-500">
-                Package names stay @aros/*; the product you use is{" "}
-                {PRODUCT_DISPLAY_NAME}.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        <section
-          className="border-y border-slate-200/80 bg-brand-50/40 py-24"
-          aria-labelledby="managed-heading"
-        >
-          <div className="mx-auto max-w-7xl px-6">
-            <div className="mb-12 text-center">
-              <h2
-                id="managed-heading"
-                className="text-3xl font-bold text-slate-900"
-              >
-                Managed accessibility operations
-              </h2>
-              <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
-                When you want outcomes without hiring a full internal program
-                overnight—we embed with your release cadence and evidence
-                requirements.
-              </p>
-            </div>
-            <div className="grid gap-8 md:grid-cols-3">
-              {managedServices.map((service) => (
-                <article
-                  key={service.title}
-                  className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
-                >
-                  <div className="mb-3 text-2xl" aria-hidden="true">
-                    {service.icon}
-                  </div>
-                  <h3 className="text-lg font-semibold text-slate-900">
-                    {service.title}
-                  </h3>
-                  <p className="mt-2 text-sm text-slate-600">
-                    {service.description}
-                  </p>
-                </article>
-              ))}
-            </div>
-            <div className="mt-12 text-center">
-              <Link
-                href="mailto:sales@aros.dev"
-                className="btn-primary px-8 py-3 text-base"
-              >
-                Talk to us about scope
-              </Link>
-              <p className="mt-3 text-sm text-slate-500">
-                Custom SOWs—procurement-friendly documentation on request
-              </p>
-            </div>
-          </div>
-        </section>
-
-        <section
-          id="features"
-          className="mx-auto max-w-7xl px-6 py-24"
-          aria-labelledby="how-heading"
-        >
-          <h2
-            id="how-heading"
-            className="mb-4 text-center text-3xl font-bold text-slate-900"
-          >
-            How it works
-          </h2>
-          <p className="mx-auto mb-12 max-w-2xl text-center text-slate-600">
-            A recurring loop—scan, cluster, triage, prove—so accessibility stays
-            legible to engineering, design, and legal stakeholders.
-          </p>
-          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-            {features.map((feature) => (
-              <article
-                key={feature.title}
-                className="card border-slate-200/90 transition-shadow hover:shadow-md"
-              >
-                <div className="mb-3 text-2xl" aria-hidden="true">
-                  {feature.icon}
-                </div>
-                <h3 className="text-lg font-semibold text-slate-900">
-                  {feature.title}
-                </h3>
-                <p className="mt-2 text-sm text-slate-600">
-                  {feature.description}
-                </p>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section
-          className="border-y border-slate-200/80 bg-slate-100/50 py-16"
-          aria-labelledby="beliefs-heading"
-        >
-          <div className="mx-auto max-w-4xl px-6">
-            <h2
-              id="beliefs-heading"
-              className="mb-8 text-center text-2xl font-bold text-slate-900"
-            >
-              What we will not pretend
-            </h2>
-            <div className="grid gap-6 md:grid-cols-2">
-              <div className="card">
-                <h3 className="mb-2 font-semibold text-slate-900">
-                  No magic compliance button
-                </h3>
-                <p className="text-sm text-slate-600">
-                  Automation finds many failures; it cannot certify your product
-                  for every WCAG success criterion. We are explicit about scope.
-                </p>
-              </div>
-              <div className="card">
-                <h3 className="mb-2 font-semibold text-slate-900">
-                  Native HTML first
-                </h3>
-                <p className="text-sm text-slate-600">
-                  Prefer semantic elements over ARIA sprawl. The best fix is often
-                  the smallest change that removes entire classes of bugs.
-                </p>
-              </div>
-              <div className="card">
-                <h3 className="mb-2 font-semibold text-slate-900">
-                  Human review is a feature
-                </h3>
-                <p className="text-sm text-slate-600">
-                  AI-assisted drafts stay in review queues with rationale and
-                  confidence—exports and PRs reflect human decisions.
-                </p>
-              </div>
-              <div className="card">
-                <h3 className="mb-2 font-semibold text-slate-900">
-                  Evidence you can attach
-                </h3>
-                <p className="text-sm text-slate-600">
-                  Reports and exports are designed for procurement and
-                  post-incident review—not vanity dashboards.
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section
-          id="pricing"
-          className="mx-auto max-w-7xl px-6 py-24"
-          aria-labelledby="pricing-heading"
-        >
-          <h2
-            id="pricing-heading"
-            className="mb-4 text-center text-3xl font-bold text-slate-900"
-          >
-            Plans
-          </h2>
-          <p className="mx-auto mb-12 max-w-2xl text-center text-slate-600">
-            Free public scans invite you in; paid tiers unlock private workspaces,
-            history, automation, and API access—enforced server-side.
-          </p>
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-            {plans.map((plan) => (
-              <div
-                key={plan.name}
-                className={`card flex flex-col ${plan.highlighted ? "ring-2 ring-brand-600 ring-offset-2" : ""}`}
-              >
-                <h3 className="text-lg font-semibold text-slate-900">
-                  {plan.name}
-                </h3>
-                <p className="mt-2">
-                  <span className="text-3xl font-bold text-slate-900">
-                    ${plan.priceMonthly}
-                  </span>
-                  {plan.priceMonthly > 0 && (
-                    <span className="text-slate-500">/mo</span>
-                  )}
-                </p>
-                <ul className="mt-4 flex-1 space-y-2" role="list">
-                  {plan.bullets.map((f) => (
-                    <li
-                      key={f}
-                      className="flex items-start gap-2 text-sm text-slate-600"
-                    >
-                      <span
-                        className="mt-0.5 text-brand-700"
-                        aria-hidden="true"
-                      >
-                        &#10003;
-                      </span>
-                      {f}
-                    </li>
-                  ))}
-                </ul>
-                <Link
-                  href="/signup"
-                  className={`mt-6 inline-flex w-full justify-center ${
-                    plan.highlighted ? "btn-primary" : "btn-secondary"
-                  }`}
-                  aria-label={`Get started with ${plan.name} plan`}
-                >
-                  {plan.tier === "FREE" ? "Try instant scan" : "Choose plan"}
-                </Link>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section
-          className="border-t border-slate-200/80 bg-slate-100/40 py-24"
-          aria-labelledby="faq-heading"
-        >
-          <div className="mx-auto max-w-4xl px-6">
-            <h2
-              id="faq-heading"
-              className="mb-12 text-center text-3xl font-bold text-slate-900"
-            >
-              Questions
-            </h2>
-            <div className="space-y-4">
-              {faqs.map((faq) => (
-                <details
-                  key={faq.question}
-                  className="group rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
-                >
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 font-semibold text-slate-900">
-                    <span>{faq.question}</span>
-                    <span
-                      className="shrink-0 text-slate-400 group-open:rotate-180 motion-reduce:transition-none transition-transform"
-                      aria-hidden="true"
-                    >
-                      &#9662;
-                    </span>
-                  </summary>
-                  <p className="mt-4 leading-relaxed text-slate-600">
-                    {faq.answer}
-                  </p>
-                </details>
-              ))}
-            </div>
-          </div>
-        </section>
-      </main>
-
-      <footer className="border-t border-slate-200 bg-white py-10">
-        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p className="text-sm font-semibold text-slate-800">
-              {PRODUCT_DISPLAY_NAME}
-            </p>
-            <p className="mt-1 max-w-md text-xs text-slate-500">
-              {PRODUCT_LEGAL_LINE}
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-6 text-sm text-slate-500">
-            <Link href="/login" className="hover:text-slate-800">
-              Sign in
-            </Link>
-            <Link href="/signup" className="hover:text-slate-800">
-              Create account
-            </Link>
-            <Link href="/docs/api" className="hover:text-slate-800">
-              Docs
-            </Link>
-          </div>
-        </div>
-      </footer>
-    </div>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(orgSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <HomePageClient />
+    </>
   );
 }
-
-const features = [
-  {
-    icon: "\u{1F50D}",
-    title: "Browser-accurate crawling",
-    description:
-      "Playwright renders like users’ browsers—CSR, SSR, and real accessibility trees—so findings match what ships.",
-  },
-  {
-    icon: "\u{1F9E9}",
-    title: "Clustered root causes",
-    description:
-      "Roll thousands of page hits into one component-level issue. Triage once, clear the blast radius with intent.",
-  },
-  {
-    icon: "\u{1F916}",
-    title: "Bounded assist, not autopilot",
-    description:
-      "Draft fixes with rationale and confidence where enabled. Nothing ships as “AI magic”—review and export are explicit gates.",
-  },
-  {
-    icon: "\u{1F527}",
-    title: "Fixes in your repo",
-    description:
-      "Map to source, open GitHub PRs, or export patches—so remediation lives in version control.",
-  },
-  {
-    icon: "\u{1F4CB}",
-    title: "Review & accountability",
-    description:
-      "Queues for what automation cannot judge: copy, context, keyboard flows, and assistive-tech nuance.",
-  },
-  {
-    icon: "\u{1F4CA}",
-    title: "Evidence for stakeholders",
-    description:
-      "Exports and report artifacts meant for agencies, execs, and procurement—not a single green score.",
-  },
-];

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+import { getAppBaseUrl } from "@/lib/site-url";
+
+export default function robots(): MetadataRoute.Robots {
+  const base = getAppBaseUrl();
+  const { host } = new URL(base);
+
+  return {
+    rules: {
+      userAgent: "*",
+      disallow: ["/dashboard/", "/settings/"],
+    },
+    sitemap: `${base}/sitemap.xml`,
+    host,
+  };
+}

--- a/apps/web/src/app/security/page.tsx
+++ b/apps/web/src/app/security/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { pageTitle, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { getAppBaseUrl } from "@/lib/site-url";
+
+export const metadata: Metadata = {
+  title: pageTitle("Security & privacy"),
+  description: `Security and privacy posture for ${PRODUCT_DISPLAY_NAME}: accounts, org boundaries, and what this page is not (a legal contract).`,
+  alternates: { canonical: "/security" },
+  openGraph: {
+    title: pageTitle("Security & privacy"),
+    description: `Security and privacy posture for ${PRODUCT_DISPLAY_NAME}.`,
+    url: `${getAppBaseUrl()}/security`,
+    type: "website",
+  },
+};
+
+export default function SecurityPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Security &amp; privacy</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          How we think about your data
+        </h1>
+        <p className="mt-4 text-slate-600">
+          This page summarizes practices and expectations for the product as
+          shipped from this repository. It is not a substitute for your
+          organization&apos;s procurement review, DPA, or legal counsel.
+        </p>
+
+        <ul className="mt-10 space-y-8 text-slate-700">
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Accounts and organizations
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Workspace data is scoped to organizations and memberships. API
+              keys and automation hooks inherit those boundaries on the server.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Crawling and scan artifacts
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Scans process publicly reachable content you configure (or submit
+              for instant scans). Retention and export behavior follow your plan
+              and in-app settings for this deployment.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              AI and third-party models
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              When enabled, draft assist may send bounded context to configured
+              model providers per your operator&apos;s environment. Review queues
+              exist so suggestions are not silent production changes.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Reporting issues
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              For security-sensitive reports, contact your deployment operator
+              through the channel they publish for this instance. We do not
+              publish a global vulnerability disclosure SLA here because hosted
+              deployments may differ.
+            </p>
+          </li>
+        </ul>
+
+        <p className="mt-12 text-sm text-slate-500">
+          Why we ship this page: buyers and security teams need a straight
+          description of scope—not marketing claims dressed as certifications.{" "}
+          <Link href="/trust" className="font-medium text-brand-700 hover:underline">
+            Trust overview
+          </Link>
+          ·{" "}
+          <Link href="/" className="font-medium text-brand-700 hover:underline">
+            Home
+          </Link>
+        </p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+import { getAppBaseUrl } from "@/lib/site-url";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = getAppBaseUrl();
+  const lastModified = new Date();
+
+  const paths = [
+    "",
+    "/docs/api",
+    "/login",
+    "/signup",
+    "/trust",
+    "/security",
+  ] as const;
+
+  return paths.map((path) => ({
+    url: `${base}${path}`,
+    lastModified,
+    changeFrequency: path === "" ? "weekly" : "monthly",
+    priority: path === "" ? 1 : 0.7,
+  }));
+}

--- a/apps/web/src/app/trust/page.tsx
+++ b/apps/web/src/app/trust/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { pageTitle, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { getAppBaseUrl } from "@/lib/site-url";
+
+export const metadata: Metadata = {
+  title: pageTitle("Trust"),
+  description: `How ${PRODUCT_DISPLAY_NAME} handles evidence, automation limits, and buyer expectations—without fake compliance promises.`,
+  alternates: { canonical: "/trust" },
+  openGraph: {
+    title: pageTitle("Trust"),
+    description: `How ${PRODUCT_DISPLAY_NAME} handles evidence, automation limits, and buyer expectations.`,
+    url: `${getAppBaseUrl()}/trust`,
+    type: "website",
+  },
+};
+
+export default function TrustPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Trust</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          Evidence-first, scope-honest
+        </h1>
+        <p className="mt-4 text-slate-600">
+          {PRODUCT_DISPLAY_NAME} is built for teams that need defensible
+          accessibility operations: what was scanned, what failed, what changed,
+          and what still needs human judgment.
+        </p>
+
+        <ul className="mt-10 space-y-8 text-slate-700">
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              What automation can and cannot do
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Automated checks surface many failures and regressions; they do not
+              replace manual audit, assistive technology testing, or legal
+              advice. We say so on every public sample and in-product where it
+              matters.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Public scans are intentionally bounded
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Instant scans sample a small number of pages with rate limits and
+              expiry. They are for orientation and sharing signal—not a substitute
+              for monitored coverage, history, exports, or private workspaces.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              AI is optional and review-gated
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Where draft assist is enabled, it is bounded by plan limits and
+              requires human review before it affects exports or remediation
+              workflows. There is no “autopilot compliance” story.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Access and entitlements
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              API keys, crawl limits, and paid surfaces are enforced on the
+              server. Client UI is not a security boundary for billing or
+              organization data.
+            </p>
+          </li>
+        </ul>
+
+        <p className="mt-12 text-sm text-slate-500">
+          For data handling and security practices, see{" "}
+          <Link href="/security" className="font-medium text-brand-700 hover:underline">
+            Security &amp; privacy
+          </Link>
+          . For integration paths, see{" "}
+          <Link href="/docs/api" className="font-medium text-brand-700 hover:underline">
+            API &amp; integrations
+          </Link>
+          .
+        </p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/components/marketing/marketing-site-chrome.tsx
+++ b/apps/web/src/components/marketing/marketing-site-chrome.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  PRODUCT_DISPLAY_NAME,
+  PRODUCT_LEGAL_LINE,
+  PRODUCT_TAGLINE,
+} from "@/lib/product-brand";
+
+export function MarketingSiteChrome({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-[rgb(var(--color-canvas))] text-slate-900">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[9999] focus:rounded-lg focus:bg-brand-700 focus:px-4 focus:py-2 focus:text-white focus:outline-none focus:ring-2 focus:ring-brand-400"
+      >
+        Skip to main content
+      </a>
+
+      <header className="border-b border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))]/90 backdrop-blur-sm supports-[backdrop-filter]:bg-[rgb(var(--color-surface-elevated))]/80">
+        <nav
+          className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-6 py-4"
+          aria-label="Main"
+        >
+          <Link
+            href="/"
+            className="group flex flex-col leading-tight focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 rounded-md"
+          >
+            <span className="text-lg font-semibold tracking-tight text-brand-800">
+              {PRODUCT_DISPLAY_NAME}
+            </span>
+            <span className="text-xs font-medium text-slate-500 group-hover:text-slate-700">
+              {PRODUCT_TAGLINE}
+            </span>
+          </Link>
+          <div className="flex flex-wrap items-center gap-6 text-sm font-medium text-slate-600">
+            <Link href="/#proof" className="hover:text-slate-900">
+              Product
+            </Link>
+            <Link href="/trust" className="hover:text-slate-900">
+              Trust
+            </Link>
+            <Link href="/docs/api" className="hover:text-slate-900">
+              Integrations
+            </Link>
+            <Link href="/login" className="hover:text-slate-900">
+              Sign in
+            </Link>
+            <Link href="/signup" className="btn-primary text-sm">
+              Start workspace
+            </Link>
+          </div>
+        </nav>
+      </header>
+
+      <main id="main">{children}</main>
+
+      <footer className="border-t border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))] py-10">
+        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-slate-800">
+              {PRODUCT_DISPLAY_NAME}
+            </p>
+            <p className="mt-1 max-w-md text-xs text-slate-500">
+              {PRODUCT_LEGAL_LINE}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-6 text-sm text-slate-500">
+            <Link href="/" className="hover:text-slate-800">
+              Home
+            </Link>
+            <Link href="/trust" className="hover:text-slate-800">
+              Trust
+            </Link>
+            <Link href="/security" className="hover:text-slate-800">
+              Security
+            </Link>
+            <Link href="/docs/api" className="hover:text-slate-800">
+              Docs
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/lib/billing.test.ts
+++ b/apps/web/src/lib/billing.test.ts
@@ -1,56 +1,12 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { getAppBaseUrl } from './billing';
+import { describe, expect, it } from "vitest";
+import { getBillingPlanCards, getAppBaseUrl } from "./billing";
 
-const originalNextAuthUrl = process.env.NEXTAUTH_URL;
-const originalVercelUrl = process.env.VERCEL_URL;
-
-afterEach(() => {
-  if (originalNextAuthUrl === undefined) {
-    delete process.env.NEXTAUTH_URL;
-  } else {
-    process.env.NEXTAUTH_URL = originalNextAuthUrl;
-  }
-
-  if (originalVercelUrl === undefined) {
-    delete process.env.VERCEL_URL;
-  } else {
-    process.env.VERCEL_URL = originalVercelUrl;
-  }
-});
-
-describe('getAppBaseUrl', () => {
-  it('prefers NEXTAUTH_URL when configured', () => {
-    process.env.NEXTAUTH_URL = 'https://app.aros.dev/some/path?with=query';
-    process.env.VERCEL_URL = 'preview.aros.dev';
-
-    expect(getAppBaseUrl()).toBe('https://app.aros.dev');
+describe("billing re-exports", () => {
+  it("exposes getAppBaseUrl from site-url module", () => {
+    expect(typeof getAppBaseUrl).toBe("function");
   });
 
-  it('falls back to VERCEL_URL when NEXTAUTH_URL is missing', () => {
-    delete process.env.NEXTAUTH_URL;
-    process.env.VERCEL_URL = 'preview.aros.dev';
-
-    expect(getAppBaseUrl()).toBe('https://preview.aros.dev');
-  });
-
-  it('uses localhost fallback when env vars are missing', () => {
-    delete process.env.NEXTAUTH_URL;
-    delete process.env.VERCEL_URL;
-
-    expect(getAppBaseUrl()).toBe('http://localhost:3000');
-  });
-
-  it('falls back when NEXTAUTH_URL is not a valid url', () => {
-    process.env.NEXTAUTH_URL = 'not-a-url';
-    process.env.VERCEL_URL = 'preview.aros.dev';
-
-    expect(getAppBaseUrl()).toBe('https://preview.aros.dev');
-  });
-
-  it('falls back when NEXTAUTH_URL protocol is unsupported', () => {
-    process.env.NEXTAUTH_URL = 'ftp://app.aros.dev';
-    delete process.env.VERCEL_URL;
-
-    expect(getAppBaseUrl()).toBe('http://localhost:3000');
+  it("getBillingPlanCards returns four tiers", () => {
+    expect(getBillingPlanCards()).toHaveLength(4);
   });
 });

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -2,6 +2,8 @@ import { PLANS } from '@aros/config';
 import type { PlanTier } from '@aros/db';
 import type { OrgSubscriptionSnapshot } from './auth-guard';
 
+export { getAppBaseUrl } from './site-url';
+
 export const PAID_PLAN_TIERS: PlanTier[] = [
   'STARTER',
   'PROFESSIONAL',
@@ -20,30 +22,6 @@ export function getBillingPlanCards() {
     ...PLANS[tier],
     isPaid: tier !== 'FREE',
   }));
-}
-
-export function getAppBaseUrl(): string {
-  const normalizedNextAuthUrl = normalizeConfiguredBaseUrl(process.env.NEXTAUTH_URL);
-  if (normalizedNextAuthUrl) return normalizedNextAuthUrl;
-
-  const normalizedVercelUrl = normalizeConfiguredBaseUrl(
-    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined,
-  );
-  if (normalizedVercelUrl) return normalizedVercelUrl;
-
-  return 'http://localhost:3000';
-}
-
-function normalizeConfiguredBaseUrl(input: string | undefined): string | null {
-  if (!input) return null;
-
-  try {
-    const parsed = new URL(input);
-    if (!['http:', 'https:'].includes(parsed.protocol)) return null;
-    return parsed.origin;
-  } catch {
-    return null;
-  }
 }
 
 export function isStripeBillingConfigured(): boolean {

--- a/apps/web/src/lib/marketing-content.ts
+++ b/apps/web/src/lib/marketing-content.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared marketing copy and section data for the public home page and JSON-LD.
+ * Keeps narrative consistent across structured data and on-page content.
+ */
+import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+
+export const developerFeatures = [
+  "MCP server with 20+ tools for IDE-native workflows",
+  "Scoped API keys with organization boundaries enforced server-side",
+  "CLI for CI gates and diff-friendly scan output",
+  "Webhooks when crawls complete—wire into your own runbooks",
+  "Same engine as the product UI—no mystery “AI score” API",
+] as const;
+
+export const managedServices = [
+  {
+    title: "Program setup & playbooks",
+    description:
+      "Define scan scope, severity policy, export templates, and stakeholder reporting rhythms so the work stays accountable.",
+  },
+  {
+    title: "Remediation partnership",
+    description:
+      "Engineers pair with your team on high-impact clusters—PRs, CMS patterns, and design-system fixes—not widget overlays.",
+  },
+  {
+    title: "Ongoing operations",
+    description:
+      "Scheduled scans, regression alerts, and evidence packs for leadership—priced as a service, not shelf-ware.",
+  },
+] as const;
+
+export const productFeatures = [
+  {
+    title: "Browser-accurate crawling",
+    description:
+      "Playwright renders like users’ browsers—CSR, SSR, and real accessibility trees—so findings match what ships.",
+  },
+  {
+    title: "Clustered root causes",
+    description:
+      "Roll thousands of page hits into one component-level issue. Triage once, clear the blast radius with intent.",
+  },
+  {
+    title: "Bounded assist, not autopilot",
+    description:
+      "Draft fixes with rationale and confidence where enabled. Nothing ships as “AI magic”—review and export are explicit gates.",
+  },
+  {
+    title: "Fixes in your repo",
+    description:
+      "Map to source, open GitHub PRs, or export patches—so remediation lives in version control.",
+  },
+  {
+    title: "Review & accountability",
+    description:
+      "Queues for what automation cannot judge: copy, context, keyboard flows, and assistive-tech nuance.",
+  },
+  {
+    title: "Evidence for stakeholders",
+    description:
+      "Exports and report artifacts meant for agencies, execs, and procurement—not a single green score.",
+  },
+] as const;
+
+export const beliefCards = [
+  {
+    title: "No magic compliance button",
+    description:
+      "Automation finds many failures; it cannot certify your product for every WCAG success criterion. We are explicit about scope.",
+  },
+  {
+    title: "Native HTML first",
+    description:
+      "Prefer semantic elements over ARIA sprawl. The best fix is often the smallest change that removes entire classes of bugs.",
+  },
+  {
+    title: "Human review is a feature",
+    description:
+      "AI-assisted drafts stay in review queues with rationale and confidence—exports and PRs reflect human decisions.",
+  },
+  {
+    title: "Evidence you can attach",
+    description:
+      "Reports and exports are designed for procurement and post-incident review—not vanity dashboards.",
+  },
+] as const;
+
+export const homeFaqs = [
+  {
+    question: "How is this different from another “AI accessibility” checker?",
+    answer:
+      `${PRODUCT_DISPLAY_NAME} is built as an operations surface: browser-accurate crawling, clustered findings so you fix root causes, review queues, exports, and API/MCP hooks. Where AI appears, it is bounded—draft suggestions with confidence and human review—not a black-box compliance promise.`,
+  },
+  {
+    question: "How is this different from accessibility overlays?",
+    answer:
+      "Overlays inject third-party widgets that do not repair underlying code and are widely rejected by the disability community. This product is source-first: fix HTML, CSS, ARIA, and components where they belong.",
+  },
+  {
+    question: "Do you guarantee WCAG or legal compliance?",
+    answer:
+      "No. Automated testing covers a fraction of WCAG. We surface evidence and workflow state; manual testing by experts and users with disabilities remains essential for any serious conformance claim.",
+  },
+  {
+    question: "What does the free instant scan include?",
+    answer:
+      "A bounded public sample of pages with clear limitations—enough to see signal, not a substitute for full-site monitoring, private workspaces, history, or exports. Upgrade for the complete operator workflow.",
+  },
+] as const;

--- a/apps/web/src/lib/site-url.test.ts
+++ b/apps/web/src/lib/site-url.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getAppBaseUrl } from "./site-url";
+
+const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+const originalVercelUrl = process.env.VERCEL_URL;
+const originalPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+afterEach(() => {
+  if (originalNextAuthUrl === undefined) {
+    delete process.env.NEXTAUTH_URL;
+  } else {
+    process.env.NEXTAUTH_URL = originalNextAuthUrl;
+  }
+
+  if (originalVercelUrl === undefined) {
+    delete process.env.VERCEL_URL;
+  } else {
+    process.env.VERCEL_URL = originalVercelUrl;
+  }
+
+  if (originalPublicAppUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  } else {
+    process.env.NEXT_PUBLIC_APP_URL = originalPublicAppUrl;
+  }
+});
+
+describe("getAppBaseUrl", () => {
+  it("prefers NEXT_PUBLIC_APP_URL when configured", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://flexibleaccessible.example/path";
+    process.env.NEXTAUTH_URL = "https://app.aros.dev";
+    process.env.VERCEL_URL = "preview.aros.dev";
+
+    expect(getAppBaseUrl()).toBe("https://flexibleaccessible.example");
+  });
+
+  it("prefers NEXTAUTH_URL when NEXT_PUBLIC_APP_URL is missing", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    process.env.NEXTAUTH_URL = "https://app.aros.dev/some/path?with=query";
+    process.env.VERCEL_URL = "preview.aros.dev";
+
+    expect(getAppBaseUrl()).toBe("https://app.aros.dev");
+  });
+
+  it("falls back to VERCEL_URL when NEXTAUTH_URL is missing", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.NEXTAUTH_URL;
+    process.env.VERCEL_URL = "preview.aros.dev";
+
+    expect(getAppBaseUrl()).toBe("https://preview.aros.dev");
+  });
+
+  it("uses localhost fallback when env vars are missing", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.NEXTAUTH_URL;
+    delete process.env.VERCEL_URL;
+
+    expect(getAppBaseUrl()).toBe("http://localhost:3000");
+  });
+
+  it("falls back when NEXTAUTH_URL is not a valid url", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    process.env.NEXTAUTH_URL = "not-a-url";
+    process.env.VERCEL_URL = "preview.aros.dev";
+
+    expect(getAppBaseUrl()).toBe("https://preview.aros.dev");
+  });
+
+  it("falls back when NEXTAUTH_URL protocol is unsupported", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    process.env.NEXTAUTH_URL = "ftp://app.aros.dev";
+    delete process.env.VERCEL_URL;
+
+    expect(getAppBaseUrl()).toBe("http://localhost:3000");
+  });
+});

--- a/apps/web/src/lib/site-url.ts
+++ b/apps/web/src/lib/site-url.ts
@@ -1,0 +1,32 @@
+/**
+ * Canonical public origin for the web app (metadata, OG URLs, billing redirects, share links).
+ * Prefer NEXT_PUBLIC_APP_URL in production so previews and metadata stay correct when NEXTAUTH_URL is unset.
+ */
+export function getAppBaseUrl(): string {
+  const explicit = normalizeConfiguredBaseUrl(process.env.NEXT_PUBLIC_APP_URL);
+  if (explicit) return explicit;
+
+  const normalizedNextAuthUrl = normalizeConfiguredBaseUrl(
+    process.env.NEXTAUTH_URL,
+  );
+  if (normalizedNextAuthUrl) return normalizedNextAuthUrl;
+
+  const normalizedVercelUrl = normalizeConfiguredBaseUrl(
+    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined,
+  );
+  if (normalizedVercelUrl) return normalizedVercelUrl;
+
+  return "http://localhost:3000";
+}
+
+function normalizeConfiguredBaseUrl(input: string | undefined): string | null {
+  if (!input) return null;
+
+  try {
+    const parsed = new URL(input);
+    if (!["http:", "https:"].includes(parsed.protocol)) return null;
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -9,6 +9,7 @@
     --color-muted: 100 116 139;
     --color-border: 226 232 240;
     --color-card: 255 255 255;
+    --color-surface-elevated: 255 255 255;
     --color-accent: 13 148 136;
     --color-canvas: 248 250 252;
   }
@@ -64,7 +65,7 @@
   }
 
   .card {
-    @apply rounded-xl border border-slate-200 bg-white p-6 shadow-sm;
+    @apply rounded-xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-card))] p-6 shadow-sm;
   }
 
   .badge {

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -4,6 +4,10 @@ const config: Config = {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
     extend: {
+      spacing: {
+        'section-md': '4rem',
+        'section-lg': '6rem',
+      },
       colors: {
         brand: {
           50: '#f0fdfa',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This milestone tightens **FlexibleAccessible** as a credible, accessibility-native product surface: canonical URLs for metadata and billing, technical SEO basics, shared marketing chrome, truthful trust/security pages, and copy/labels that avoid overstating what a public sample scan means.

## Changes

- **`NEXT_PUBLIC_APP_URL`** (optional) takes precedence in `getAppBaseUrl()` so OG, sitemap, `metadataBase`, and Stripe return URLs align with the public hostname when `NEXTAUTH_URL` is unset. Documented in `.env.example`. `billing` re-exports `getAppBaseUrl` for existing imports.
- **Home**: server `page.tsx` adds **JSON-LD** (Organization, SoftwareApplication, FAQPage from shared `marketing-content.ts`); interactive UI lives in `home-page-client.tsx`. Hero blur respects **reduced motion**. Feature icons use **Lucide** instead of emoji; nav adds **Trust**; free plan CTA clarifies instant scan entry.
- **SEO**: `sitemap.ts`, `robots.ts` (disallow dashboard/settings only—API remains crawlable for OG), root `metadataBase`, home canonical + OG/twitter, improved metadata on `/docs/api`, `/trust`, `/security`.
- **New pages**: `/trust` and `/security`—scope-honest, non-certification copy; cross-linked from footer and docs chrome.
- **Shared chrome**: `MarketingSiteChrome` for docs + trust + security (consistent header/footer, skip link).
- **Public scan**: metadata titles/descriptions de-emphasize “score” as a compliance signal; **absolute** OG image URLs; results UI uses **“automated sample index”** + honest subcopy; header CTA **“Open workspace”** (was “Get full report”); OG image label **“Sample index”**.

## Verification

`npm install`, `npm run db:generate`, `npm run verify:core` — **pass** (pre-existing ESLint tenant-boundary warnings unchanged).

## Deploy note

Set **`NEXT_PUBLIC_APP_URL`** to the production origin in hosted environments for correct absolute URLs in metadata and social previews.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d490b50-06fe-4efd-a8b1-daaaa01dfad8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d490b50-06fe-4efd-a8b1-daaaa01dfad8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

