### PR TITLE
Product shine: default OG images, site metadata helper, app design tokens

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -12,8 +12,9 @@ import { hasPermission } from "@aros/config";
 import { EmptyState } from "@aros/ui";
 import { buildOnboardingStatus } from "@/lib/onboarding-status";
 import { getEntitlementState } from "@/lib/auth-guard";
+import { pageTitle } from "@/lib/product-brand";
 
-export const metadata = { title: "Dashboard" };
+export const metadata = { title: pageTitle("Dashboard") };
 
 export default async function DashboardPage() {
   const user = await requireSession();

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -129,7 +129,7 @@ export default async function DashboardLayout({
       >
         Skip to main content
       </a>
-      <div className="flex min-h-dvh overflow-hidden bg-slate-50 md:h-screen">
+      <div className="flex min-h-dvh overflow-hidden bg-[rgb(var(--color-app-canvas))] md:h-screen">
         <Sidebar
           orgs={orgs}
           user={user}

--- a/apps/web/src/app/(public)/scan/[domain]/page.tsx
+++ b/apps/web/src/app/(public)/scan/[domain]/page.tsx
@@ -31,19 +31,22 @@ export async function generateMetadata({
   const description = hasCurrentEvidence
     ? `Sampled automated scan on ${decoded}: ${totalViolations} issues found in up to 5 pages (severity breakdown in the report). Not a WCAG conformance guarantee.`
     : `No current, unexpired public scan evidence for ${decoded}. Run a new instant scan from ${PRODUCT_DISPLAY_NAME} for fresh automated results.`;
+  const base = getAppBaseUrl();
   const ogPath = `/api/og?domain=${encodeURIComponent(decoded)}`;
-  const ogUrl = new URL(ogPath, getAppBaseUrl()).toString();
+  const ogUrl = new URL(ogPath, base).toString();
+  const pagePath = `/scan/${encodeURIComponent(decoded)}`;
+  const pageUrl = new URL(pagePath, base).toString();
 
   return {
     title,
     description,
     alternates: {
-      canonical: `/scan/${encodeURIComponent(decoded)}`,
+      canonical: pagePath,
     },
     openGraph: {
       title,
       description,
-      url: `/scan/${encodeURIComponent(decoded)}`,
+      url: pageUrl,
       images: [{ url: ogUrl, width: 1200, height: 630 }],
       type: "website",
     },

--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -2,9 +2,19 @@ import { ImageResponse } from "next/og";
 import { NextRequest } from "next/server";
 import { toASCII } from "node:punycode";
 import { getPublicOgRenderModel } from "@/lib/public-scan/og-render-model";
-import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import {
+  PRODUCT_DISPLAY_NAME,
+  PRODUCT_TAGLINE,
+} from "@/lib/product-brand";
+import { SITE_OG_BULLET_LINES, SITE_OG_IMAGE_SIZE } from "@/lib/site-metadata";
 
 export const runtime = "nodejs";
+
+const BRAND_HEX = "#0d9488";
+const CANVAS_HEX = "#f8fafc";
+const SLATE_900 = "#0f172a";
+const SLATE_600 = "#475569";
+const SLATE_500 = "#64748b";
 
 function isValidDomainParam(domain: string): boolean {
   if (domain.length > 253) return false;
@@ -19,19 +29,128 @@ function isValidDomainParam(domain: string): boolean {
   }
 }
 
+function siteOgImageResponse() {
+  return new ImageResponse(
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        backgroundColor: CANVAS_HEX,
+        padding: "56px 64px",
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "16px",
+          marginBottom: "36px",
+        }}
+      >
+        <div
+          style={{
+            width: "14px",
+            height: "56px",
+            borderRadius: "8px",
+            backgroundColor: BRAND_HEX,
+          }}
+        />
+        <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+          <div
+            style={{
+              fontSize: "38px",
+              fontWeight: 800,
+              color: SLATE_900,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {PRODUCT_DISPLAY_NAME}
+          </div>
+          <div
+            style={{
+              fontSize: "26px",
+              fontWeight: 600,
+              color: SLATE_600,
+              lineHeight: 1.35,
+              maxWidth: "980px",
+            }}
+          >
+            {PRODUCT_TAGLINE}
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "18px",
+          flex: 1,
+          justifyContent: "center",
+        }}
+      >
+        {SITE_OG_BULLET_LINES.map((line) => (
+          <div
+            key={line}
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              gap: "16px",
+              fontSize: "24px",
+              color: SLATE_600,
+              lineHeight: 1.4,
+            }}
+          >
+            <span style={{ color: BRAND_HEX, fontWeight: 700 }}>—</span>
+            <span>{line}</span>
+          </div>
+        ))}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          marginTop: "auto",
+          paddingTop: "28px",
+          borderTop: `2px solid #e2e8f0`,
+          fontSize: "18px",
+          color: SLATE_500,
+          lineHeight: 1.45,
+        }}
+      >
+        Instant public scan on the home page · Private workspaces on paid plans ·
+        Automation is sampling, not legal conformance
+      </div>
+    </div>,
+    {
+      width: SITE_OG_IMAGE_SIZE.width,
+      height: SITE_OG_IMAGE_SIZE.height,
+    },
+  );
+}
+
 /**
- * GET /api/og?domain=example.com
- * Open Graph image for public scan share cards. Renders only from current,
- * non-expired completed public scan data — query-string scores are ignored
- * so social previews cannot overstate evidence we do not hold.
+ * GET /api/og?kind=site — default marketing share card (truthful, no scores).
+ * GET /api/og?domain=example.com — public scan evidence card (data-backed only).
  */
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = request.nextUrl;
+    const kind = searchParams.get("kind")?.trim().toLowerCase();
+
+    if (kind === "site") {
+      return siteOgImageResponse();
+    }
+
     const rawDomain = searchParams.get("domain")?.trim();
 
     if (!rawDomain) {
-      return new Response("Missing domain parameter", { status: 400 });
+      return new Response("Missing domain parameter or kind=site", {
+        status: 400,
+      });
     }
 
     let displayDomain = rawDomain;
@@ -209,8 +328,8 @@ export async function GET(request: NextRequest) {
         </div>
       </div>,
       {
-        width: 1200,
-        height: 630,
+        width: SITE_OG_IMAGE_SIZE.width,
+        height: SITE_OG_IMAGE_SIZE.height,
       },
     );
   } catch {

--- a/apps/web/src/app/docs/api/page.tsx
+++ b/apps/web/src/app/docs/api/page.tsx
@@ -1,20 +1,14 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
-import { pageTitle, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
-import { getAppBaseUrl } from "@/lib/site-url";
+import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: pageTitle("API & integrations"),
-  description: `How to integrate ${PRODUCT_DISPLAY_NAME} today: MCP server, org-scoped API keys, and webhooks. This deployment does not ship a separate public OpenAPI browser.`,
-  alternates: { canonical: "/docs/api" },
-  openGraph: {
-    title: pageTitle("API & integrations"),
-    description: `Integration paths for ${PRODUCT_DISPLAY_NAME}: MCP, API keys, and webhooks.`,
-    url: `${getAppBaseUrl()}/docs/api`,
-    type: "website",
-  },
-};
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "API & integrations",
+  `How to integrate ${PRODUCT_DISPLAY_NAME} today: MCP server, org-scoped API keys, and webhooks. This deployment does not ship a separate public OpenAPI browser.`,
+  "/docs/api",
+);
 
 export default function DocsApiPage() {
   return (

--- a/apps/web/src/app/home-page-client.tsx
+++ b/apps/web/src/app/home-page-client.tsx
@@ -384,7 +384,7 @@ npx @aros/cli scan --site example.com`}</pre>
               return (
                 <article
                   key={feature.title}
-                  className="card border-[rgb(var(--color-border))] transition-shadow hover:shadow-md"
+                  className="card border-[rgb(var(--color-border))] transition-shadow hover:shadow-[var(--shadow-card-hover)]"
                 >
                   <div className="mb-3 text-brand-700" aria-hidden="true">
                     <Icon className="h-8 w-8" strokeWidth={1.75} />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,9 +7,15 @@ import {
   PRODUCT_TAGLINE,
 } from "@/lib/product-brand";
 import { getAppBaseUrl } from "@/lib/site-url";
+import {
+  siteDefaultOpenGraphImages,
+  siteDefaultTwitterImages,
+} from "@/lib/site-metadata";
+
+const appBase = getAppBaseUrl();
 
 export const metadata: Metadata = {
-  metadataBase: new URL(getAppBaseUrl()),
+  metadataBase: new URL(appBase),
   title: {
     default: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
     template: `%s · ${PRODUCT_DISPLAY_NAME}`,
@@ -27,6 +33,21 @@ export const metadata: Metadata = {
   icons: {
     icon: [{ url: "/icons/icon-192.png", sizes: "192x192", type: "image/png" }],
     apple: [{ url: "/icons/icon-192.png", sizes: "192x192" }],
+  },
+  openGraph: {
+    siteName: PRODUCT_DISPLAY_NAME,
+    locale: "en_US",
+    type: "website",
+    url: appBase,
+    title: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
+    description: PRODUCT_DESCRIPTION,
+    images: siteDefaultOpenGraphImages(),
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
+    description: PRODUCT_DESCRIPTION,
+    images: siteDefaultTwitterImages(),
   },
 };
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,6 +7,11 @@ import {
 } from "@/lib/product-brand";
 import { getAppBaseUrl } from "@/lib/site-url";
 import { homeFaqs, productFeatures } from "@/lib/marketing-content";
+import {
+  siteDefaultOpenGraphImages,
+  siteDefaultTwitterImages,
+  siteMarketingJsonLd,
+} from "@/lib/site-metadata";
 
 const baseUrl = getAppBaseUrl();
 
@@ -25,11 +30,13 @@ export const metadata: Metadata = {
     siteName: PRODUCT_DISPLAY_NAME,
     title: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
     description: PRODUCT_DESCRIPTION,
+    images: siteDefaultOpenGraphImages(),
   },
   twitter: {
     card: "summary_large_image",
     title: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
     description: PRODUCT_DESCRIPTION,
+    images: siteDefaultTwitterImages(),
   },
 };
 
@@ -72,8 +79,14 @@ export default function HomePage() {
     description: PRODUCT_DESCRIPTION,
   };
 
+  const webSiteSchema = siteMarketingJsonLd(baseUrl);
+
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteSchema) }}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(orgSchema) }}

--- a/apps/web/src/app/security/page.tsx
+++ b/apps/web/src/app/security/page.tsx
@@ -1,20 +1,14 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
-import { pageTitle, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
-import { getAppBaseUrl } from "@/lib/site-url";
+import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: pageTitle("Security & privacy"),
-  description: `Security and privacy posture for ${PRODUCT_DISPLAY_NAME}: accounts, org boundaries, and what this page is not (a legal contract).`,
-  alternates: { canonical: "/security" },
-  openGraph: {
-    title: pageTitle("Security & privacy"),
-    description: `Security and privacy posture for ${PRODUCT_DISPLAY_NAME}.`,
-    url: `${getAppBaseUrl()}/security`,
-    type: "website",
-  },
-};
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Security & privacy",
+  `Security and privacy posture for ${PRODUCT_DISPLAY_NAME}: accounts, org boundaries, and what this page is not (a legal contract).`,
+  "/security",
+);
 
 export default function SecurityPage() {
   return (

--- a/apps/web/src/app/trust/page.tsx
+++ b/apps/web/src/app/trust/page.tsx
@@ -1,20 +1,14 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
-import { pageTitle, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
-import { getAppBaseUrl } from "@/lib/site-url";
+import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: pageTitle("Trust"),
-  description: `How ${PRODUCT_DISPLAY_NAME} handles evidence, automation limits, and buyer expectations—without fake compliance promises.`,
-  alternates: { canonical: "/trust" },
-  openGraph: {
-    title: pageTitle("Trust"),
-    description: `How ${PRODUCT_DISPLAY_NAME} handles evidence, automation limits, and buyer expectations.`,
-    url: `${getAppBaseUrl()}/trust`,
-    type: "website",
-  },
-};
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Trust",
+  `How ${PRODUCT_DISPLAY_NAME} handles evidence, automation limits, and buyer expectations—without fake compliance promises.`,
+  "/trust",
+);
 
 export default function TrustPage() {
   return (

--- a/apps/web/src/components/layout/mobile-dashboard-nav.tsx
+++ b/apps/web/src/components/layout/mobile-dashboard-nav.tsx
@@ -84,9 +84,9 @@ export function MobileDashboardNav({
       />
       <aside
         ref={panelRef}
-        className="absolute left-0 top-0 flex h-full w-[min(20rem,88vw)] flex-col border-r border-slate-200 bg-white shadow-xl pt-[env(safe-area-inset-top)]"
+        className="absolute left-0 top-0 flex h-full w-[min(20rem,88vw)] flex-col border-r border-[rgb(var(--color-border))] bg-[rgb(var(--color-app-elevated))] shadow-xl pt-[env(safe-area-inset-top)]"
       >
-        <div className="flex h-14 shrink-0 items-center justify-between border-b border-slate-200 px-4">
+        <div className="flex h-14 shrink-0 items-center justify-between border-b border-[rgb(var(--color-border))] px-4">
           <Link
             href="/dashboard"
             className="text-lg font-semibold tracking-tight text-brand-800"
@@ -105,7 +105,7 @@ export function MobileDashboardNav({
           </button>
         </div>
 
-        <div className="border-b border-slate-200 p-3">
+        <div className="border-b border-[rgb(var(--color-border))] p-3">
           <label htmlFor="org-select-mobile" className="sr-only">
             Select organization
           </label>
@@ -201,7 +201,7 @@ export function MobileDashboardNav({
           )}
         </nav>
 
-        <div className="border-t border-slate-200 p-3">
+        <div className="border-t border-[rgb(var(--color-border))] p-3">
           <div className="flex items-center gap-3 rounded-lg px-3 py-2">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-100 text-sm font-medium text-brand-700">
               {(user.name ?? user.email).charAt(0).toUpperCase()}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -41,11 +41,11 @@ export function Sidebar({
 
   return (
     <aside
-      className="hidden w-64 shrink-0 flex-col border-r border-slate-200 bg-white md:flex"
+      className="hidden w-64 shrink-0 flex-col border-r border-[rgb(var(--color-border))] bg-[rgb(var(--color-app-elevated))] md:flex"
       role="navigation"
       aria-label="Main navigation"
     >
-      <div className="flex h-14 items-center border-b border-slate-200 px-4">
+      <div className="flex h-14 items-center border-b border-[rgb(var(--color-border))] px-4">
         <Link
           href="/dashboard"
           className="flex flex-col leading-tight focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 rounded"
@@ -59,7 +59,7 @@ export function Sidebar({
         </Link>
       </div>
 
-      <div className="border-b border-slate-200 p-3">
+      <div className="border-b border-[rgb(var(--color-border))] p-3">
         <label htmlFor="org-select" className="sr-only">
           Select organization
         </label>

--- a/apps/web/src/components/layout/top-bar.tsx
+++ b/apps/web/src/components/layout/top-bar.tsx
@@ -21,7 +21,7 @@ export function TopBar({ user, platformTruth, canViewSystem = false }: TopBarPro
 
   return (
     <header
-      className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 md:px-6"
+      className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-[rgb(var(--color-border))] bg-[rgb(var(--color-app-elevated))] px-4 md:px-6"
       style={{ paddingTop: 'max(0px, env(safe-area-inset-top))' }}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/apps/web/src/components/marketing/marketing-site-chrome.tsx
+++ b/apps/web/src/components/marketing/marketing-site-chrome.tsx
@@ -34,7 +34,10 @@ export function MarketingSiteChrome({ children }: { children: ReactNode }) {
           </Link>
           <div className="flex flex-wrap items-center gap-6 text-sm font-medium text-slate-600">
             <Link href="/#proof" className="hover:text-slate-900">
-              Product
+              Proof &amp; workflow
+            </Link>
+            <Link href="/#pricing" className="hover:text-slate-900">
+              Plans
             </Link>
             <Link href="/trust" className="hover:text-slate-900">
               Trust

--- a/apps/web/src/lib/site-metadata.ts
+++ b/apps/web/src/lib/site-metadata.ts
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import {
+  pageTitle,
+  PRODUCT_DESCRIPTION,
+  PRODUCT_DISPLAY_NAME,
+  PRODUCT_TAGLINE,
+} from "@/lib/product-brand";
+import { getAppBaseUrl } from "@/lib/site-url";
+
+/** Canonical dimensions for dynamic OG images from `/api/og`. */
+export const SITE_OG_IMAGE_SIZE = { width: 1200, height: 630 } as const;
+
+/**
+ * Default marketing share image (no domain-specific claims).
+ * Public scan pages continue to use `/api/og?domain=…` for evidence-backed previews.
+ */
+export const SITE_DEFAULT_OG_IMAGE_PATH = "/api/og?kind=site" as const;
+
+export function siteDefaultOpenGraphImages(): NonNullable<
+  NonNullable<Metadata["openGraph"]>["images"]
+> {
+  return [
+    {
+      url: SITE_DEFAULT_OG_IMAGE_PATH,
+      width: SITE_OG_IMAGE_SIZE.width,
+      height: SITE_OG_IMAGE_SIZE.height,
+      alt: `${PRODUCT_DISPLAY_NAME} — ${PRODUCT_TAGLINE}`,
+    },
+  ];
+}
+
+export function siteDefaultTwitterImages(): string[] {
+  return [SITE_DEFAULT_OG_IMAGE_PATH];
+}
+
+/** Short lines for OG card body — grounded, non-compliance claims. */
+export const SITE_OG_BULLET_LINES = [
+  "Browser-accurate scans and clustered root causes",
+  "Review queues, exports, and org-scoped API keys",
+  "Bounded draft assist where enabled — human review gates",
+] as const;
+
+export function siteMarketingJsonLd(baseUrl: string) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: PRODUCT_DISPLAY_NAME,
+    url: baseUrl,
+    description: PRODUCT_DESCRIPTION,
+  };
+}
+
+/** Consistent OG/Twitter for static marketing routes under MarketingSiteChrome. */
+export function marketingSurfaceMetadata(
+  segment: string,
+  description: string,
+  path: `/${string}`,
+): Metadata {
+  const base = getAppBaseUrl();
+  const url = `${base}${path}`;
+  return {
+    title: pageTitle(segment),
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      title: pageTitle(segment),
+      description,
+      url,
+      type: "website",
+      siteName: PRODUCT_DISPLAY_NAME,
+      locale: "en_US",
+      images: siteDefaultOpenGraphImages(),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: pageTitle(segment),
+      description,
+      images: siteDefaultTwitterImages(),
+    },
+  };
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -12,6 +12,16 @@
     --color-surface-elevated: 255 255 255;
     --color-accent: 13 148 136;
     --color-canvas: 248 250 252;
+    /* Layout chrome (dashboard): align with marketing surface tokens */
+    --color-app-canvas: 248 250 252;
+    --color-app-elevated: 255 255 255;
+    --radius-sm: 0.375rem;
+    --radius-md: 0.5rem;
+    --radius-lg: 0.75rem;
+    --radius-xl: 1rem;
+    --shadow-card: 0 1px 2px 0 rgb(15 23 42 / 0.05);
+    --shadow-card-hover: 0 4px 6px -1px rgb(15 23 42 / 0.08),
+      0 2px 4px -2px rgb(15 23 42 / 0.06);
   }
 
   html {
@@ -65,7 +75,9 @@
   }
 
   .card {
-    @apply rounded-xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-card))] p-6 shadow-sm;
+    @apply border border-[rgb(var(--color-border))] bg-[rgb(var(--color-card))] p-6;
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-card);
   }
 
   .badge {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This pass closes several **share/SEO and visual-coherence seams** without adding marketing theatre.

- **Default Open Graph / Twitter images**: New `GET /api/og?kind=site` renders a light, brand-aligned card with the product name, tagline, and three grounded capability lines—no scores or compliance claims. Root layout and static marketing routes use shared helpers so previews are consistent.
- **Canonical metadata**: `site-metadata.ts` owns default image paths, dimensions, `marketingSurfaceMetadata()` for Trust, Security, and API docs, and `WebSite` JSON-LD on the home page (alongside existing Organization / SoftwareApplication / FAQPage).
- **Public scan OG**: `openGraph.url` is now an **absolute** URL so crawlers and share debuggers resolve the page correctly.
- **Design system / app chrome**: CSS variables for app canvas, elevated surfaces, radius steps, and card shadows; dashboard layout, sidebar, top bar, and mobile drawer use the same border/surface tokens as marketing. Home feature cards use the shared hover shadow token.
- **CRO / IA (small)**: Marketing chrome nav labels align with the home page (Proof & workflow, Plans).

## Verification

`npm run db:generate && npm run verify:core` — pass. ESLint tenant-boundary warnings in unrelated action files are pre-existing.

## Deferred / not in this PR

- Broader dashboard route metadata audit (many pages still use short titles).
- Dedicated static `opengraph-image` assets (dynamic route chosen for single pipeline).
- Marketing hero or copy overhaul beyond nav alignment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-184bb038-f4bf-4947-a522-68631426dfbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-184bb038-f4bf-4947-a522-68631426dfbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

