### PR TITLE
Go-live closure: truthful packaging, legal shell, seat + auth hardening

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,6 @@
     "@aros/ui": "*",
     "@aros/shared": "*",
     "@aros/stakeholders": "*",
-    "@aros/ui": "*",
     "autoprefixer": "^10.4.0",
     "bullmq": "^5.31.0",
     "clsx": "^2.1.0",

--- a/apps/web/src/app/(auth)/login/actions.ts
+++ b/apps/web/src/app/(auth)/login/actions.ts
@@ -1,10 +1,13 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
+import { createHash } from "crypto";
 import { prisma } from "@/lib/db";
 import { createSession } from "@/lib/session";
 import { verifyPassword } from "@aros/shared";
-import { timingSafeEqual } from "crypto";
+import { rateLimitSafe } from "@/lib/rate-limit";
+import { getClientIpFromHeaders } from "@/lib/request-ip";
 
 interface LoginState {
   error: string | null;
@@ -43,8 +46,20 @@ export async function loginAction(
     return { error: "Email and password are required" };
   }
 
+  const headerList = await headers();
+  const ip = getClientIpFromHeaders(headerList);
+  const emailNorm = email.toLowerCase().trim();
+  const rlKey = `auth:login:${createHash("sha256").update(`${ip}:${emailNorm}`).digest("hex").slice(0, 32)}`;
+  const rl = await rateLimitSafe(rlKey, 20, 15 * 60 * 1000);
+  if (!rl.success) {
+    return {
+      error:
+        "Too many sign-in attempts. Please wait a few minutes and try again.",
+    };
+  }
+
   const user = await prisma.user.findUnique({
-    where: { email: email.toLowerCase() },
+    where: { email: emailNorm },
   });
   if (!user) {
     // Perform a dummy hash verification to prevent user enumeration via timing

--- a/apps/web/src/app/(auth)/signup/actions.ts
+++ b/apps/web/src/app/(auth)/signup/actions.ts
@@ -1,10 +1,14 @@
 'use server';
 
 import { redirect } from 'next/navigation';
+import { headers } from 'next/headers';
+import { createHash } from 'crypto';
 import { prisma } from '@/lib/db';
 import type { Prisma } from '@aros/db';
 import { createSession } from '@/lib/session';
 import { hashPassword, slugify } from '@aros/shared';
+import { rateLimitSafe } from '@/lib/rate-limit';
+import { getClientIpFromHeaders } from '@/lib/request-ip';
 
 interface SignupState {
   error: string | null;
@@ -25,6 +29,26 @@ export async function signupAction(
 
   if (password.length < 8) {
     return { error: 'Password must be at least 8 characters' };
+  }
+
+  const headerList = await headers();
+  const ip = getClientIpFromHeaders(headerList);
+  const rlKeyIp = `auth:signup:ip:${createHash('sha256').update(ip).digest('hex').slice(0, 32)}`;
+  const rlIp = await rateLimitSafe(rlKeyIp, 10, 60 * 60 * 1000);
+  if (!rlIp.success) {
+    return {
+      error:
+        'Too many sign-up attempts from this network. Please try again later.',
+    };
+  }
+
+  const rlKeyEmail = `auth:signup:email:${createHash('sha256').update(email).digest('hex').slice(0, 32)}`;
+  const rlEmail = await rateLimitSafe(rlKeyEmail, 5, 24 * 60 * 60 * 1000);
+  if (!rlEmail.success) {
+    return {
+      error:
+        'Too many sign-up attempts for this email. Please try again tomorrow or contact support.',
+    };
   }
 
   const existing = await prisma.user.findUnique({ where: { email } });

--- a/apps/web/src/app/(dashboard)/settings/members/actions.test.ts
+++ b/apps/web/src/app/(dashboard)/settings/members/actions.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/lib/db", () => ({
     },
     auditLog: {
       create: vi.fn(),
+      count: vi.fn(),
     },
   },
 }));
@@ -46,6 +47,7 @@ import { requireOrgAccess } from "@/lib/auth-guard";
 describe("inviteMemberAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.auditLog.count).mockResolvedValue(0);
   });
 
   it("invites existing user successfully", async () => {
@@ -181,6 +183,37 @@ describe("inviteMemberAction", () => {
       maxSeats: 3,
     } as any);
     vi.mocked(prisma.membership.count).mockResolvedValue(3);
+
+    const formData = new FormData();
+    formData.set("organizationId", "org_123");
+    formData.set("email", "new@example.com");
+    formData.set("role", "DEVELOPER");
+
+    const result = await inviteMemberAction(
+      { success: false, error: null },
+      formData,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "Seat limit reached. Upgrade your plan to add more members.",
+    );
+  });
+
+  it("counts pending invites toward seat limit", async () => {
+    vi.mocked(requireOrgAccess).mockResolvedValue({
+      user: { id: "user_admin", email: "admin@example.com", name: "Admin" },
+      organizationId: "org_123",
+      role: "ADMIN",
+      subscription: null,
+      entitlement: { hasPaidAccess: false, reason: "free_plan" },
+    });
+
+    vi.mocked(prisma.subscription.findUnique).mockResolvedValue({
+      maxSeats: 3,
+    } as any);
+    vi.mocked(prisma.membership.count).mockResolvedValue(2);
+    vi.mocked(prisma.auditLog.count).mockResolvedValue(1);
 
     const formData = new FormData();
     formData.set("organizationId", "org_123");

--- a/apps/web/src/app/(dashboard)/settings/members/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/members/actions.ts
@@ -117,9 +117,24 @@ export async function inviteMemberAction(
     return { success: false, error: "Unable to validate current membership" };
   }
 
+  const pendingInviteCountResult = await runOrgScopedQuery(ctx, async (orgId) =>
+    prisma.auditLog.count({
+      where: {
+        organizationId: orgId,
+        action: "member:invite_pending",
+      },
+    }),
+  );
+  if (!pendingInviteCountResult.ok) {
+    return { success: false, error: "Unable to validate pending invitations" };
+  }
+
+  const seatsInUse =
+    memberCountResult.data + pendingInviteCountResult.data;
+
   if (
     subscriptionResult.data &&
-    memberCountResult.data >= subscriptionResult.data.maxSeats
+    seatsInUse >= subscriptionResult.data.maxSeats
   ) {
     return {
       success: false,
@@ -225,7 +240,7 @@ export async function inviteMemberAction(
     return {
       success: true,
       error: null,
-      info: "Invitation recorded. User will need to sign up to join.",
+      info: "Invite recorded. Ask them to sign up with this email, then add them from Members once their account exists.",
     } as InviteMemberState & { info?: string };
   } catch (error) {
     console.error("[members] invite error:", error);

--- a/apps/web/src/app/(dashboard)/settings/members/invite-form.tsx
+++ b/apps/web/src/app/(dashboard)/settings/members/invite-form.tsx
@@ -103,7 +103,7 @@ export function InviteForm({
         className="btn-primary"
       >
         <UserPlus className="h-4 w-4 mr-2" />
-        Invite Member
+        Add member
       </button>
     );
   }
@@ -111,7 +111,7 @@ export function InviteForm({
   return (
     <div className="card border-brand-200">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-slate-900">Invite Member</h3>
+        <h3 className="text-lg font-semibold text-slate-900">Add member</h3>
         <button
           type="button"
           onClick={() => {
@@ -145,7 +145,10 @@ export function InviteForm({
             disabled={isPending}
           />
           <p className="mt-1 text-xs text-slate-500">
-            They will receive an invitation to join this organization.
+            If they already have an account, they are added immediately. If not,
+            we record the invite here—ask them to sign up with this email so you
+            can add them once they appear in your directory (no outbound email
+            is sent from this deployment yet).
           </p>
         </div>
 
@@ -190,7 +193,7 @@ export function InviteForm({
         {inviteState.success && (
           <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-700 flex items-center gap-2">
             <Check className="h-4 w-4" />
-            {inviteState.info || "Invitation sent successfully!"}
+            {inviteState.info || "Member added or invite recorded."}
           </div>
         )}
 
@@ -201,9 +204,9 @@ export function InviteForm({
             disabled={isPending || !email}
           >
             {isPending ? (
-              <LoadingSpinner size="sm" label="Sending..." />
+              <LoadingSpinner size="sm" label="Working…" />
             ) : (
-              "Send Invitation"
+              "Add or record invite"
             )}
           </button>
           <button

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
@@ -9,7 +9,13 @@ import {
   runOrgScopedQuery,
 } from "@/lib/route-data-boundary";
 import { RouteReliabilityNotice } from "@/components/reliability/route-reliability-notice";
-import { StatusBadge, EmptyState, SeverityChip, type SeverityLevel } from "@aros/ui";
+import {
+  StatusBadge,
+  EmptyState,
+  SeverityChip,
+  ProcessBadge,
+  type SeverityLevel,
+} from "@aros/ui";
 import { ScanNowButton } from "./scan-now-button";
 import { ScanSiteActionState, scanSiteInitialState } from "./scan-action-state";
 import { getAutomationEvidenceFreshnessDescriptor } from "@/lib/findings/evidence-freshness";

--- a/apps/web/src/app/accessibility/page.tsx
+++ b/apps/web/src/app/accessibility/page.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { PRODUCT_CONTACT_EMAIL, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Accessibility statement",
+  `Accessibility posture for the ${PRODUCT_DISPLAY_NAME} web app: intent, limits of automated testing, and how to report issues.`,
+  "/accessibility",
+);
+
+export default function AccessibilityStatementPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Accessibility</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          Accessibility statement
+        </h1>
+        <p className="mt-4 text-slate-600">
+          {PRODUCT_DISPLAY_NAME} exists to help teams ship more accessible
+          products. This statement covers the product UI itself—not the
+          third-party sites customers scan.
+        </p>
+
+        <ul className="mt-10 space-y-8 text-slate-700">
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              What we optimize for
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Keyboard paths, visible focus, semantic structure, and clear error
+              states in core flows (marketing, auth, dashboard navigation). We
+              treat accessibility as ongoing work, not a one-time checkbox.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Limits of automation in the product
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              The same honesty we apply to customer scans applies here: automated
+              checks do not prove full WCAG conformance. Manual testing with
+              assistive technologies remains important.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Feedback
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              If you hit a barrier in the app, email{" "}
+              <a
+                href={`mailto:${PRODUCT_CONTACT_EMAIL}`}
+                className="font-medium text-brand-700 hover:underline"
+              >
+                {PRODUCT_CONTACT_EMAIL}
+              </a>{" "}
+              with the page URL, browser, and assistive technology if relevant.
+            </p>
+          </li>
+        </ul>
+
+        <p className="mt-12 text-sm text-slate-500">
+          Methodology for scans:{" "}
+          <Link href="/trust" className="font-medium text-brand-700 hover:underline">
+            Trust overview
+          </Link>
+          .
+        </p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/legal/subprocessors/page.tsx
+++ b/apps/web/src/app/legal/subprocessors/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Subprocessors",
+  `Infrastructure and service subprocessors commonly used with ${PRODUCT_DISPLAY_NAME} when operators enable them.`,
+  "/legal/subprocessors",
+);
+
+export default function SubprocessorsPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Legal</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          Subprocessors
+        </h1>
+        <p className="mt-4 text-slate-600">
+          This list describes categories of vendors your operator may configure
+          when running {PRODUCT_DISPLAY_NAME}. It is not exhaustive for every
+          deployment—your DPA should name the subprocessors actually in use.
+        </p>
+
+        <div className="mt-10 overflow-x-auto rounded-lg border border-[rgb(var(--color-border))]">
+          <table className="w-full text-left text-sm text-slate-700">
+            <thead className="bg-[rgb(var(--color-surface-elevated))] text-slate-900">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Category</th>
+                <th className="px-4 py-3 font-semibold">Typical purpose</th>
+                <th className="px-4 py-3 font-semibold">When it applies</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-t border-[rgb(var(--color-border))]">
+                <td className="px-4 py-3">Hosting / edge</td>
+                <td className="px-4 py-3">Serve the web app and APIs</td>
+                <td className="px-4 py-3">Always for SaaS-style hosting</td>
+              </tr>
+              <tr className="border-t border-[rgb(var(--color-border))]">
+                <td className="px-4 py-3">PostgreSQL</td>
+                <td className="px-4 py-3">Primary application data</td>
+                <td className="px-4 py-3">Always</td>
+              </tr>
+              <tr className="border-t border-[rgb(var(--color-border))]">
+                <td className="px-4 py-3">Redis</td>
+                <td className="px-4 py-3">Queues, caches, rate limits</td>
+                <td className="px-4 py-3">When workers / jobs enabled</td>
+              </tr>
+              <tr className="border-t border-[rgb(var(--color-border))]">
+                <td className="px-4 py-3">Stripe</td>
+                <td className="px-4 py-3">Payments and subscription state</td>
+                <td className="px-4 py-3">When billing is configured</td>
+              </tr>
+              <tr className="border-t border-[rgb(var(--color-border))]">
+                <td className="px-4 py-3">Object storage (e.g. S3)</td>
+                <td className="px-4 py-3">Large artifacts and screenshots</td>
+                <td className="px-4 py-3">When S3 env vars are set</td>
+              </tr>
+              <tr className="border-t border-[rgb(var(--color-border))]">
+                <td className="px-4 py-3">Model providers</td>
+                <td className="px-4 py-3">Optional draft assist</td>
+                <td className="px-4 py-3">When API keys are configured</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p className="mt-10 text-sm text-slate-500">
+          <Link href="/privacy" className="font-medium text-brand-700 hover:underline">
+            Privacy overview
+          </Link>
+          ·{" "}
+          <Link href="/security" className="font-medium text-brand-700 hover:underline">
+            Security &amp; privacy
+          </Link>
+        </p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/legal/terms/page.tsx
+++ b/apps/web/src/app/legal/terms/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { PRODUCT_CONTACT_EMAIL, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Terms of service",
+  `Terms of use for ${PRODUCT_DISPLAY_NAME}: no legal conformance warranty, bounded automation, and operator-specific commercial terms.`,
+  "/legal/terms",
+);
+
+export default function TermsPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Legal</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          Terms of service (summary)
+        </h1>
+        <p className="mt-4 text-slate-600">
+          This is a plain-language summary of how the product is intended to be
+          used. Your organization may require a separate order form, MSA, or
+          vendor paper—this page does not replace those instruments.
+        </p>
+
+        <ul className="mt-10 space-y-8 text-slate-700">
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Service scope
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              {PRODUCT_DISPLAY_NAME} provides accessibility operations tooling:
+              crawling, scanning, findings, workflows, exports, and integrations.
+              It does not provide legal advice or a guarantee of WCAG or
+              regulatory compliance. Automated checks are incomplete by nature.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Acceptable use
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              You may not use the product to attack third-party systems, exceed
+              fair-use limits, circumvent technical controls, or scrape at a
+              scale that harms targets. Public instant scans are intentionally
+              rate-limited and shallow.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Accounts and billing
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Paid access is billed through Stripe where enabled. Plan limits and
+              entitlements are enforced server-side; attempting to bypass them
+              violates these terms.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Warranty disclaimer
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              The service is provided &quot;as is&quot; to the extent permitted
+              by law. To the extent your jurisdiction does not allow certain
+              disclaimers, those disclaimers apply only as far as allowed.
+            </p>
+          </li>
+        </ul>
+
+        <p className="mt-12 text-sm text-slate-500">
+          Commercial and procurement terms:{" "}
+          <a
+            href={`mailto:${PRODUCT_CONTACT_EMAIL}`}
+            className="font-medium text-brand-700 hover:underline"
+          >
+            {PRODUCT_CONTACT_EMAIL}
+          </a>
+          .{" "}
+          <Link href="/privacy" className="font-medium text-brand-700 hover:underline">
+            Privacy overview
+          </Link>
+          .
+        </p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { PRODUCT_CONTACT_EMAIL, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Privacy",
+  `How ${PRODUCT_DISPLAY_NAME} treats account data, scan content, and retention at a high level—not a substitute for a signed DPA.`,
+  "/privacy",
+);
+
+export default function PrivacyPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Privacy</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          Privacy overview
+        </h1>
+        <p className="mt-4 text-slate-600">
+          This page describes how the product is designed to handle data in a
+          typical self-hosted or operator-run deployment. It is not legal advice
+          and does not replace a data processing agreement your counsel reviews.
+        </p>
+
+        <ul className="mt-10 space-y-8 text-slate-700">
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              What we process
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Accounts (email, name, password hash), organization and membership
+              records, scan configuration, crawl and scan results, findings,
+              evidence artifacts, billing identifiers synced from Stripe, and
+              audit-style logs for operator accountability. Exact fields live
+              in the application database schema for this deployment.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Crawl and scan content
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              The engine fetches URLs you authorize (or submit for instant
+              scans). That can include page HTML, assets needed for analysis, and
+              derived artifacts (for example screenshots where configured).
+              Retention follows this deployment&apos;s settings and operator
+              practice—not a promise of indefinite storage.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              AI and model providers
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Where draft assist is enabled, bounded context may be sent to the
+              model provider configured in your environment. That provider is a
+              subprocessor for those flows; see{" "}
+              <Link
+                href="/legal/subprocessors"
+                className="font-medium text-brand-700 hover:underline"
+              >
+                Subprocessors
+              </Link>
+              .
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Your controls
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Organization owners and admins can manage members, API keys, and
+              many product settings inside the app. For export, deletion, or
+              DPA-level requests, contact your deployment operator.
+            </p>
+          </li>
+        </ul>
+
+        <p className="mt-12 text-sm text-slate-500">
+          Questions:{" "}
+          <a
+            href={`mailto:${PRODUCT_CONTACT_EMAIL}`}
+            className="font-medium text-brand-700 hover:underline"
+          >
+            {PRODUCT_CONTACT_EMAIL}
+          </a>
+          . Also see{" "}
+          <Link href="/security" className="font-medium text-brand-700 hover:underline">
+            Security &amp; privacy
+          </Link>{" "}
+          and{" "}
+          <Link href="/legal/terms" className="font-medium text-brand-700 hover:underline">
+            Terms of service
+          </Link>
+          .
+        </p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/security/page.tsx
+++ b/apps/web/src/app/security/page.tsx
@@ -74,6 +74,14 @@ export default function SecurityPage() {
             Trust overview
           </Link>
           ·{" "}
+          <Link href="/privacy" className="font-medium text-brand-700 hover:underline">
+            Privacy
+          </Link>
+          ·{" "}
+          <Link href="/legal/terms" className="font-medium text-brand-700 hover:underline">
+            Terms
+          </Link>
+          ·{" "}
           <Link href="/" className="font-medium text-brand-700 hover:underline">
             Home
           </Link>

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -12,6 +12,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/signup",
     "/trust",
     "/security",
+    "/privacy",
+    "/support",
+    "/accessibility",
+    "/legal/terms",
+    "/legal/subprocessors",
   ] as const;
 
   return paths.map((path) => ({

--- a/apps/web/src/app/support/page.tsx
+++ b/apps/web/src/app/support/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { PRODUCT_CONTACT_EMAIL, PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Support & contact",
+  `How to reach the operator of this ${PRODUCT_DISPLAY_NAME} deployment for support, procurement, and incident reports.`,
+  "/support",
+);
+
+export default function SupportPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Support</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          Contact &amp; support
+        </h1>
+        <p className="mt-4 text-slate-600">
+          This deployment is operated by a human team (or solo operator). There
+          is no implied 24/7 global support desk unless your contract says
+          otherwise.
+        </p>
+
+        <ul className="mt-10 space-y-8 text-slate-700">
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Product and billing questions
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Email{" "}
+              <a
+                href={`mailto:${PRODUCT_CONTACT_EMAIL}`}
+                className="font-medium text-brand-700 hover:underline"
+              >
+                {PRODUCT_CONTACT_EMAIL}
+              </a>
+              . Include your organization name, approximate timezone, and what you
+              were trying to do—we respond as capacity allows.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Security reports
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Use the same channel and mark the subject line with
+              &quot;Security&quot;. We do not publish a public bug bounty or
+              pentest summary here; scope is agreed per deployment.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Status and incidents
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Health for this instance is exposed at{" "}
+              <Link href="/api/health" className="font-medium text-brand-700 hover:underline">
+                /api/health
+              </Link>{" "}
+              where enabled. There is no separate status page unless your
+              operator configures one.
+            </p>
+          </li>
+        </ul>
+
+        <p className="mt-12 text-sm text-slate-500">
+          <Link href="/trust" className="font-medium text-brand-700 hover:underline">
+            Trust overview
+          </Link>
+          ·{" "}
+          <Link href="/accessibility" className="font-medium text-brand-700 hover:underline">
+            Product accessibility statement
+          </Link>
+        </p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/trust/page.tsx
+++ b/apps/web/src/app/trust/page.tsx
@@ -73,9 +73,21 @@ export default function TrustPage() {
           <Link href="/security" className="font-medium text-brand-700 hover:underline">
             Security &amp; privacy
           </Link>
+          ,{" "}
+          <Link href="/privacy" className="font-medium text-brand-700 hover:underline">
+            Privacy overview
+          </Link>
+          , and{" "}
+          <Link href="/legal/subprocessors" className="font-medium text-brand-700 hover:underline">
+            Subprocessors
+          </Link>
           . For integration paths, see{" "}
           <Link href="/docs/api" className="font-medium text-brand-700 hover:underline">
             API &amp; integrations
+          </Link>
+          . For contact, see{" "}
+          <Link href="/support" className="font-medium text-brand-700 hover:underline">
+            Support
           </Link>
           .
         </p>

--- a/apps/web/src/components/marketing/marketing-site-chrome.tsx
+++ b/apps/web/src/components/marketing/marketing-site-chrome.tsx
@@ -48,8 +48,17 @@ export function MarketingSiteChrome({ children }: { children: ReactNode }) {
             <Link href="/security" className="hover:text-slate-800">
               Security
             </Link>
+            <Link href="/privacy" className="hover:text-slate-800">
+              Privacy
+            </Link>
+            <Link href="/support" className="hover:text-slate-800">
+              Support
+            </Link>
             <Link href="/docs/api" className="hover:text-slate-800">
               Docs
+            </Link>
+            <Link href="/legal/terms" className="hover:text-slate-800">
+              Terms
             </Link>
           </div>
         </div>

--- a/apps/web/src/components/marketing/marketing-site-header.tsx
+++ b/apps/web/src/components/marketing/marketing-site-header.tsx
@@ -12,6 +12,7 @@ const NAV_LINKS = [
   { href: "/#pricing", label: "Plans" },
   { href: "/trust", label: "Trust" },
   { href: "/docs/api", label: "Integrations" },
+  { href: "/support", label: "Support" },
   { href: "/login", label: "Sign in" },
 ] as const;
 

--- a/apps/web/src/lib/marketing-content.ts
+++ b/apps/web/src/lib/marketing-content.ts
@@ -5,7 +5,7 @@
 import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
 
 export const developerFeatures = [
-  "MCP server with 20+ tools for IDE-native workflows",
+  "MCP server with a broad IDE tool surface (see package README for the current tool list)",
   "Scoped API keys with organization boundaries enforced server-side",
   "CLI for CI gates and diff-friendly scan output",
   "Webhooks when crawls complete—wire into your own runbooks",

--- a/apps/web/src/lib/rate-limit.test.ts
+++ b/apps/web/src/lib/rate-limit.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@aros/shared", () => ({
+  getRedisClient: vi.fn(),
+}));
+
+import { getRedisClient } from "@aros/shared";
+import { rateLimitSafe } from "./rate-limit";
+
+describe("rateLimitSafe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows traffic when Redis throws (degraded)", async () => {
+    vi.mocked(getRedisClient).mockImplementation(() => {
+      throw new Error("redis down");
+    });
+
+    const result = await rateLimitSafe("test-key", 5, 60_000);
+    expect(result.success).toBe(true);
+    expect(result.remaining).toBe(5);
+  });
+});

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -45,3 +45,22 @@ export async function rateLimit(
     reset,
   };
 }
+
+/**
+ * Same as {@link rateLimit}, but never throws. On Redis errors we allow the
+ * request (degraded: limits not enforced) and log loudly—operators should
+ * treat Redis health as part of abuse posture.
+ */
+export async function rateLimitSafe(
+  key: string,
+  limit: number,
+  windowMs: number,
+): Promise<RateLimitResult> {
+  try {
+    return await rateLimit(key, limit, windowMs);
+  } catch (e) {
+    console.error('[rate-limit] Redis failure; limiter degraded (request allowed)', e);
+    const reset = Date.now() + windowMs;
+    return { success: true, limit, remaining: limit, reset };
+  }
+}

--- a/apps/web/src/lib/request-ip.ts
+++ b/apps/web/src/lib/request-ip.ts
@@ -1,0 +1,13 @@
+/**
+ * Best-effort client IP for rate limiting (trusts X-Forwarded-For when present).
+ */
+export function getClientIpFromHeaders(headersList: {
+  get(name: string): string | null;
+}): string {
+  const forwarded = headersList.get("x-forwarded-for");
+  const ip =
+    forwarded?.split(",")[0]?.trim() ??
+    headersList.get("x-real-ip") ??
+    "unknown";
+  return ip || "unknown";
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -38,7 +38,11 @@ function isPublicMarketingPath(pathname: string) {
     pathname === "/" ||
     pathname === "/login" ||
     pathname === "/signup" ||
-    pathname === "/offline"
+    pathname === "/offline" ||
+    pathname === "/privacy" ||
+    pathname === "/support" ||
+    pathname === "/accessibility" ||
+    pathname.startsWith("/legal/")
   );
 }
 

--- a/packages/config/src/plans.ts
+++ b/packages/config/src/plans.ts
@@ -75,7 +75,7 @@ export const PLANS: Record<PlanTier, PlanConfig> = {
       "Higher limits + procurement-friendly terms",
       "Custom integrations & migration support",
       "Managed accessibility operations (optional)",
-      "SLA and onboarding packages (scoped per contract)",
+      "Response-time and onboarding commitments only where agreed in writing",
     ],
     priceMonthly: 499,
     aiEnabled: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This pass tightens **public claim discipline**, adds a **minimal buyer/legal shell**, **closes a seat-cap gap** for pending invites, wires **Redis-backed rate limits** onto login/signup (with explicit degraded behavior when Redis fails), and fixes a **pre-existing build break** (`ProcessBadge` import).

**Update:** Merged latest `origin/main` (import conflict on site detail page was cosmetic). Follow-up TS fixes were needed for strict typing after main’s dashboard/findings changes (`aiUsage` widening, Prisma `GetPayload` for finding queries, stakeholders `BiasAuditResult` / gap analysis typing, API key rotate test mock).

## Key changes

- **Enterprise plan copy**: Replace implied packaged SLA with contract-scoped response/onboarding language (`packages/config/src/plans.ts`).
- **Marketing**: MCP bullet no longer claims “20+ tools”; points to README for current tool surface (`apps/web/src/lib/marketing-content.ts`).
- **Seats**: `inviteMemberAction` counts `auditLog` rows with `member:invite_pending` toward `maxSeats`; invite UI copy matches reality (no outbound email yet); new unit test.
- **Auth abuse**: `rateLimitSafe` + IP/email keyed limits on login and signup; logs when Redis errors (limiter degraded = traffic allowed).
- **Trust shell**: New `/privacy`, `/legal/terms`, `/legal/subprocessors`, `/support`, `/accessibility`; footer/header/sitemap/middleware updates; cross-links from trust/security.
- **Build**: Import `ProcessBadge` from `@aros/ui` on site detail page; remove duplicate `@aros/ui` dependency key in `apps/web/package.json`.

## Verification

- `npm install`, `npm run db:generate`
- `npm run lint` (0 errors; existing tenant-boundary warnings remain)
- `npm run typecheck`
- `npm run test`
- `npm run build --workspace=@aros/web`

## Operator note

If Redis is unhealthy, auth rate limits **do not enforce** (logged as degraded). Treat Redis as part of abuse posture for production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3027362-410f-442e-833a-b786585edc35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3027362-410f-442e-833a-b786585edc35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

