### PR TITLE
docs: production AI and accessibility operating rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 .next/
 out/
 build/
+.turbo/
 
 # Environment
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 This is an npm **workspaces** monorepo (not pnpm). Core apps and packages live under `apps/` and `packages/`.
 
+### AI and accessibility governance
+
+Before changing AI-assisted remediation, recommendations, or compliance-facing copy, read [`docs/AI_ACCESSIBILITY_OPERATING_RULES.md`](docs/AI_ACCESSIBILITY_OPERATING_RULES.md). Evidence-backed workflow wins over impressive model output; raw LLM output must not reach users without schema validation and traceability.
+
 ### Prerequisites
 
 - Node.js >= 20

--- a/apps/web/src/app/(auth)/login/actions.ts
+++ b/apps/web/src/app/(auth)/login/actions.ts
@@ -6,7 +6,6 @@ import { prisma } from "@/lib/db";
 import { createSession } from "@/lib/session";
 import { abuseRateLimit, verifyPassword } from "@aros/shared";
 import { getClientIpFromHeaders } from "@/lib/client-ip";
-import { timingSafeEqual } from "crypto";
 
 interface LoginState {
   error: string | null;
@@ -47,6 +46,8 @@ export async function loginAction(
   if (!email || !password) {
     return { error: "Email and password are required" };
   }
+
+  const emailNorm = email.trim().toLowerCase();
 
   const h = await headers();
   const ip = getClientIpFromHeaders(h);

--- a/apps/web/src/app/(auth)/signup/actions.ts
+++ b/apps/web/src/app/(auth)/signup/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { createHash } from "node:crypto";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { prisma } from "@/lib/db";
@@ -12,6 +13,7 @@ import { getClientIpFromHeaders } from "@/lib/client-ip";
 import { issueSecurityToken, EMAIL_VERIFICATION_TTL_MS } from "@/lib/auth-tokens";
 import { sendTransactionalMail } from "@/lib/mail";
 import { getAppBaseUrl } from "@/lib/site-url";
+import { rateLimitSafe } from "@/lib/rate-limit";
 
 interface SignupState {
   error: string | null;
@@ -37,15 +39,13 @@ export async function signupAction(
     return { error: "Password must be at least 8 characters" };
   }
 
-  const h = await headers();
-  const ip = getClientIpFromHeaders(h);
+  const headerList = await headers();
+  const ip = getClientIpFromHeaders(headerList);
   const rl = await abuseRateLimit(`signup:${ip}`, SIGNUP_MAX_PER_WINDOW, SIGNUP_WINDOW_MS);
   if (!rl.allowed) {
     return { error: "Too many signup attempts from this network. Try again later." };
   }
 
-  const headerList = await headers();
-  const ip = getClientIpFromHeaders(headerList);
   const rlKeyIp = `auth:signup:ip:${createHash('sha256').update(ip).digest('hex').slice(0, 32)}`;
   const rlIp = await rateLimitSafe(rlKeyIp, 10, 60 * 60 * 1000);
   if (!rlIp.success) {

--- a/docs/AI_ACCESSIBILITY_OPERATING_RULES.md
+++ b/docs/AI_ACCESSIBILITY_OPERATING_RULES.md
@@ -1,0 +1,41 @@
+# Production AI / accessibility operating rules
+
+**Product:** AccessibleMadeFlexible (AROS engine)  
+**Intent:** Treat the product as an **accessibility intelligence and remediation operating system**, not as an AI demo.
+
+## Non-negotiables
+
+- **Deterministic accessibility evidence is the source of truth.**
+- **AI must never invent** findings, severity, WCAG mapping, proof, or compliance claims.
+- AI may **explain, cluster, prioritize, draft fixes, summarize patterns, and assist workflow** only when grounded in **stored evidence**.
+- **Every recommendation** must reference concrete **issue IDs**, **evidence IDs**, **WCAG refs**, **affected surfaces**, and **confidence / review state**.
+- **Raw model output must never** be returned directly to users or downstream systems. Convert all outputs to **validated structured schemas**.
+- **Separate** detection, evidence, recommendation, workflow, and integration concerns. Do not tightly couple model logic to product logic.
+- **All recommendation calls must be observable:** model version, latency, token cost, inputs used, outputs produced, tool calls, acceptance / rejection outcome.
+- **Use cost discipline by default:** deterministic scan first; AI only for changed / new / high-value issues; cheaper models for routine explanation; stronger models only for complex remediation.
+- **Never present AI suggestions as compliance truth.** Present them as **guided remediation proposals** unless verified.
+- **Prefer component-level and system-level remediation** over page-by-page patching.
+- **Preserve full audit history:** findings, suppressions, review notes, regressions, accepted fixes, verification results, and proofpack lineage.
+- **Optimize for workflow lock-in** through issue memory, recurring-pattern learning, component fingerprints, verification loops, and integrations.
+- **Product goal:** make accessibility work faster, clearer, more provable, more collaborative, and harder to regress.
+
+## Required system capabilities
+
+- Canonical queue of actionable issues
+- Evidence-backed issue detail with reproduction and impact
+- Structured recommendation objects
+- Verification / recheck workflow
+- Historical diffing and recurring-issue memory
+- CI, ticketing, repo, and design-system integrations
+- Exportable proofpacks and machine-readable APIs
+- Graceful degraded states when AI is unavailable
+
+## Default decision rule
+
+If there is a conflict between **impressive AI behavior** and **trustworthy audit/remediation workflow**, choose **trustworthy workflow**.
+
+## Related docs
+
+- [Accessibility evidence model](./ACCESSIBILITY_EVIDENCE_MODEL.md) — what is stored today
+- [Findings and reporting truth](./FINDINGS_AND_REPORTING_TRUTH.md) — what the product claims in summaries and exports
+- [Platform degradation model](./PLATFORM_DEGRADATION_MODEL.md) — degraded / blocked behavior

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "prettier": "^3.4.0",
         "redis-errors": "^1.2.0",
         "standard-as-callback": "^2.1.0",
+        "turbo": "^2.7.4",
         "typescript": "^5.7.0"
       },
       "engines": {
@@ -35,7 +36,6 @@
         "@aros/db": "*",
         "@aros/shared": "*",
         "@aros/stakeholders": "*",
-        "@aros/ui": "*",
         "autoprefixer": "^10.4.0",
         "bullmq": "^5.31.0",
         "clsx": "^2.1.0",
@@ -6900,6 +6900,90 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.4.tgz",
+      "integrity": "sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/darwin-arm64": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.4.tgz",
+      "integrity": "sha512-9cjTWe4OiNlFMSRggPNh+TJlRs7MS5FWrHc96MOzft5vESWjjpvaadYPv5ykDW7b45mVHOF2U/W+48LoX9USWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.4.tgz",
+      "integrity": "sha512-Cl1GjxqBXQ+r9KKowmXG+lhD1gclLp48/SE7NxL//66iaMytRw0uiphWGOkccD92iPiRjHLRUaA9lOTtgr5OCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.4.tgz",
+      "integrity": "sha512-j2hPAKVmGNN2EsKigEWD+43y9m7zaPhNAs6ptsyfq0u7evHHBAXAwOfv86OEMg/gvC+pwGip0i1CIm1bR1vYug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.4.tgz",
+      "integrity": "sha512-1jWPjCe9ZRmsDTXE7uzqfySNQspnUx0g6caqvwps+k/sc+fm9hC/4zRQKlXZLbVmP3Xxp601Ju71boegHdnYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.4.tgz",
+      "integrity": "sha512-dlko15TQVu/BFYmIY018Y3covWMRQlUgAkD+OOk+Rokcfj6VY02Vv4mCfT/Zns6B4q8jGbOd6IZhnCFYsE8Viw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -16108,6 +16192,24 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/turbo": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.4.tgz",
+      "integrity": "sha512-wZ/kMcZCuK5oEp7sXSSo/5fzKjP9I2EhoiarZjyCm2Ixk0WxFrC/h0gF3686eHHINoFQOOSWgB/pGfvkR8rkgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "@turbo/darwin-64": "2.9.4",
+        "@turbo/darwin-arm64": "2.9.4",
+        "@turbo/linux-64": "2.9.4",
+        "@turbo/linux-arm64": "2.9.4",
+        "@turbo/windows-64": "2.9.4",
+        "@turbo/windows-arm64": "2.9.4"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "accessibility-remediation-os",
   "private": true,
+  "packageManager": "npm@10.9.4",
   "workspaces": [
     "apps/*",
     "packages/*"
   ],
   "scripts": {
-    "postinstall": "node scripts/workspace-symlinks.js",
+    "postinstall": "node scripts/workspace-symlinks.js && npm run db:generate",
     "dev": "npm run dev --workspace=apps/web",
     "dev:worker": "npm run dev --workspace=apps/worker",
     "build": "npm run build --workspace=apps/web",
@@ -34,6 +35,7 @@
     "test:launch-critical": "npm run test:launch-critical --workspace=apps/web"
   },
   "devDependencies": {
+    "turbo": "^2.7.4",
     "@axe-core/playwright": "^4.11.1",
     "@ioredis/commands": "^1.5.1",
     "@playwright/experimental-ct-react": "^1.58.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds production AI/accessibility operating rules documentation and fixes the Vercel + Turborepo build path so `apps/web` compiles on Next.js 15.

## Changes

### Docs / agent guidance
- **`docs/AI_ACCESSIBILITY_OPERATING_RULES.md`** — Evidence-first AI governance, required capabilities, default decision rule, links to existing truth docs.
- **`AGENTS.md`** — Link to the operating rules for anyone changing AI or compliance-facing behavior.

### Vercel / monorepo build
- **`package.json`** — `packageManager: "npm@10.9.4"` (Turbo requires this to resolve npm workspaces), `turbo` as a devDependency, and **`postinstall`** runs `db:generate` after workspace symlinks so Prisma client (including `SecurityTokenKind`) is always generated on install (CI/Vercel).
- **`package-lock.json`** — Lockfile updated for turbo.

### Next.js compile fixes
- **`apps/web/src/app/(auth)/signup/actions.ts`** — Remove duplicate `ip` / `headers()` usage; add `createHash` + `rateLimitSafe` imports.
- **`apps/web/src/app/(auth)/login/actions.ts`** — Define `emailNorm`; remove unused `timingSafeEqual` import.

### Hygiene
- **`.gitignore`** — Ignore `.turbo/`.

## Verification

Local: `npx turbo run build --filter=@aros/web` completes (static pages prerender; ESLint tenant-boundary warnings only).

## Notes

Vercel project should use **root directory = repo root** (or equivalent) so `npm install` runs the root `postinstall`. If the project root were only `apps/web`, adjust to monorepo root or add an explicit build-time `prisma generate` there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b65288b0-a3bf-4c7d-91f0-05110259bda4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b65288b0-a3bf-4c7d-91f0-05110259bda4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

