### PR TITLE
Commercial truth: TRIALING access, plan gates, Stripe preservation, operator audit events

### DIFF
--- a/apps/web/e2e/paywall.spec.ts
+++ b/apps/web/e2e/paywall.spec.ts
@@ -201,6 +201,17 @@ test.describe("Paywall – authenticated billing flow (demo user)", () => {
   });
 });
 
+test.describe("Paywall – plan minimum on deploy webhook listing", () => {
+  test("GET /api/deploy-webhook without session returns 401/403", async ({
+    page,
+  }) => {
+    const response = await page.request.get(
+      "/api/deploy-webhook?organizationId=test-org",
+    );
+    expect([401, 403]).toContain(response.status());
+  });
+});
+
 test.describe("Paywall – subscription validation in POST endpoints", () => {
   test("AI copilot rejects requests with missing required fields", async ({
     page,

--- a/apps/web/src/app/(auth)/signup/actions.ts
+++ b/apps/web/src/app/(auth)/signup/actions.ts
@@ -14,6 +14,7 @@ import { issueSecurityToken, EMAIL_VERIFICATION_TTL_MS } from "@/lib/auth-tokens
 import { sendTransactionalMail } from "@/lib/mail";
 import { getAppBaseUrl } from "@/lib/site-url";
 import { rateLimitSafe } from "@/lib/rate-limit";
+import { logProductEvent, PRODUCT_EVENT_ACTIONS } from "@/lib/product-events";
 
 interface SignupState {
   error: string | null;
@@ -127,6 +128,13 @@ export async function signupAction(
     });
 
     return { user, organizationId: org.id };
+  });
+
+  await logProductEvent({
+    organizationId: result.organizationId,
+    userId: result.user.id,
+    action: PRODUCT_EVENT_ACTIONS.signup_completed,
+    metadata: { emailVerified: skipVerificationInDev },
   });
 
   async function rollbackSignup() {

--- a/apps/web/src/app/(dashboard)/settings/api-keys/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/actions.ts
@@ -9,6 +9,7 @@ import { requireOrgAccess } from "@/lib/auth-guard";
 import { ApiError } from "@aros/shared";
 import { hasPermission } from "@aros/config";
 import crypto from "node:crypto";
+import { logProductEvent, PRODUCT_EVENT_ACTIONS } from "@/lib/product-events";
 
 const API_KEY_PREFIX = "arsk_live_";
 const KEY_BYTES = 32; // 64 hex chars
@@ -168,6 +169,13 @@ export async function createApiKeyAction(
     });
 
     revalidatePath("/settings/api-keys");
+
+    await logProductEvent({
+      organizationId,
+      userId: user.id,
+      action: PRODUCT_EVENT_ACTIONS.api_key_created,
+      metadata: { keyId: apiKey.id, name: apiKey.name },
+    });
 
     return {
       success: true,

--- a/apps/web/src/app/(dashboard)/settings/billing/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/billing/actions.ts
@@ -9,6 +9,7 @@ import {
   getOrCreateBillingCustomer,
 } from "@/lib/billing/org-scoped-queries";
 import type { PlanTier } from "@aros/db";
+import { logProductEvent, PRODUCT_EVENT_ACTIONS } from "@/lib/product-events";
 
 function redirectWithError(message: string) {
   redirect(`/settings/billing?error=${encodeURIComponent(message)}`);
@@ -90,6 +91,13 @@ export async function startSubscriptionCheckoutAction(formData: FormData) {
   if (!session.url) {
     redirectWithError("Stripe did not return a checkout URL.");
   }
+
+  await logProductEvent({
+    organizationId: ctx.organizationId,
+    userId: user.id,
+    action: PRODUCT_EVENT_ACTIONS.checkout_started,
+    metadata: { plan: requestedPlan },
+  });
 
   redirect(session.url);
 }

--- a/apps/web/src/app/(dashboard)/settings/billing/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/billing/page.tsx
@@ -146,7 +146,8 @@ export default async function BillingPage({ searchParams }: PageProps) {
           0,
         ),
       );
-      const [membership, customer, scansUsedThisMonth] = await Promise.all([
+      const [membership, customer, scansUsedThisMonth, memberCount, pendingInviteCount] =
+        await Promise.all([
         prisma.membership.findUnique({
           where: {
             userId_organizationId: {
@@ -176,12 +177,18 @@ export default async function BillingPage({ searchParams }: PageProps) {
             },
           },
         }),
+        prisma.membership.count({ where: { organizationId } }),
+        prisma.auditLog.count({
+          where: { organizationId, action: "member:invite_pending" },
+        }),
       ]);
 
       return {
         membership,
         customer,
         scansUsedThisMonth,
+        memberCount,
+        pendingInviteCount,
       };
     },
   );
@@ -212,6 +219,10 @@ export default async function BillingPage({ searchParams }: PageProps) {
   const canManageBilling = hasPermission(membership.role, "org:billing");
   const plans = getBillingPlanCards();
   const scansUsedThisMonth = billingResult.data.scansUsedThisMonth;
+  const memberCount = billingResult.data.memberCount;
+  const pendingInviteCount = billingResult.data.pendingInviteCount;
+  const seatLimit = subscription?.maxSeats ?? 1;
+  const seatsReserved = memberCount + pendingInviteCount;
   const scanLimit = subscription?.maxScansPerMonth ?? 3;
   const scansRemaining = Math.max(scanLimit - scansUsedThisMonth, 0);
   const usagePercent = Math.min(
@@ -306,9 +317,33 @@ export default async function BillingPage({ searchParams }: PageProps) {
               value={String(subscription?.maxDomains ?? 1)}
             />
             <Stat
+              label="Pages / crawl"
+              value={String(subscription?.maxPagesPerCrawl ?? 50)}
+            />
+            <Stat
               label="AI access"
               value={subscription?.aiEnabled ? "Included" : "Locked"}
             />
+          </div>
+
+          <div
+            className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600"
+            role="status"
+          >
+            <p className="font-medium text-slate-900">Seats</p>
+            <p className="mt-1">
+              {memberCount} member{memberCount === 1 ? "" : "s"}
+              {pendingInviteCount > 0
+                ? `, ${pendingInviteCount} pending invite${pendingInviteCount === 1 ? "" : "s"}`
+                : ""}{" "}
+              · cap {seatLimit}
+              {seatsReserved >= seatLimit ? (
+                <span className="text-amber-800">
+                  {" "}
+                  (at seat cap — upgrade or remove pending invites to add people)
+                </span>
+              ) : null}
+            </p>
           </div>
 
           <div
@@ -336,6 +371,22 @@ export default async function BillingPage({ searchParams }: PageProps) {
                 This subscription is set to cancel at period end.
               </p>
             )}
+            {entitlement.reason === "past_due" && (
+              <p className="mt-2 text-amber-900">
+                Past due: private dashboard routes stay locked until billing is current. You can still use this billing
+                page and the public scan.
+              </p>
+            )}
+            {entitlement.reason === "cancelled" && (
+              <p className="mt-2 text-amber-900">
+                Cancelled: you keep read access to billing here; private product data stays locked until you subscribe
+                again.
+              </p>
+            )}
+            <p className="mt-3 text-xs text-slate-500">
+              Downgrade to Free (via Stripe or support) resets limits to the Free tier and removes paid automation such
+              as deploy webhooks (Professional+) and AI draft assist (Professional+ with AI enabled).
+            </p>
           </div>
 
           <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-4">

--- a/apps/web/src/app/(dashboard)/settings/members/actions.test.ts
+++ b/apps/web/src/app/(dashboard)/settings/members/actions.test.ts
@@ -202,7 +202,7 @@ describe("inviteMemberAction", () => {
 
   it("counts pending invites toward seat limit", async () => {
     vi.mocked(requireOrgAccess).mockResolvedValue({
-      user: { id: "user_admin", email: "admin@example.com", name: "Admin" },
+      user: { id: "user_admin", email: "admin@example.com", name: "Admin", emailVerified: true },
       organizationId: "org_123",
       role: "ADMIN",
       subscription: null,

--- a/apps/web/src/app/(dashboard)/settings/members/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/members/actions.ts
@@ -6,6 +6,7 @@ import { requireOrgAccess } from "@/lib/auth-guard";
 import { runOrgScopedQuery } from "@/lib/route-data-boundary";
 import { hasPermission } from "@aros/config";
 import type { MemberRole } from "@aros/db";
+import { logProductEvent, PRODUCT_EVENT_ACTIONS } from "@/lib/product-events";
 
 const INVITABLE_ROLES: MemberRole[] = [
   "DEVELOPER",
@@ -198,6 +199,13 @@ export async function inviteMemberAction(
             metadata: { invitedEmail: email, role },
           },
         });
+
+        await logProductEvent({
+          organizationId: orgId,
+          userId: ctx.user.id,
+          action: PRODUCT_EVENT_ACTIONS.invite_sent,
+          metadata: { role, path: "existing_user" },
+        });
       });
       if (!inviteResult.ok) {
         return {
@@ -218,8 +226,8 @@ export async function inviteMemberAction(
   }
 
   try {
-    const pendingInviteResult = await runOrgScopedQuery(ctx, async (orgId) =>
-      prisma.auditLog.create({
+    const pendingInviteResult = await runOrgScopedQuery(ctx, async (orgId) => {
+      await prisma.auditLog.create({
         data: {
           organizationId: orgId,
           userId: ctx.user.id,
@@ -227,8 +235,14 @@ export async function inviteMemberAction(
           entityType: "user",
           metadata: { invitedEmail: email, role },
         },
-      }),
-    );
+      });
+      await logProductEvent({
+        organizationId: orgId,
+        userId: ctx.user.id,
+        action: PRODUCT_EVENT_ACTIONS.invite_sent,
+        metadata: { role, path: "pending_signup" },
+      });
+    });
     if (!pendingInviteResult.ok) {
       return {
         success: false,

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
@@ -8,6 +8,7 @@ import {
 import { ApiError } from '@aros/shared';
 import { prisma } from '@/lib/db';
 import { requireSiteAccess } from '@/lib/auth-guard';
+import { logProductEvent, PRODUCT_EVENT_ACTIONS } from '@/lib/product-events';
 import type { ScanSiteActionState } from './scan-action-state';
 
 export async function startSiteScanAction(
@@ -37,6 +38,17 @@ export async function startSiteScanAction(
 
     if (result.ok) {
       if (result.kind === 'queued') {
+        const priorCount = await prisma.scanRun.count({
+          where: { site: { workspace: { organizationId: ctx.organizationId } } },
+        });
+        if (priorCount <= 1) {
+          await logProductEvent({
+            organizationId: ctx.organizationId,
+            userId: ctx.user.id,
+            action: PRODUCT_EVENT_ACTIONS.first_private_scan_queued,
+            metadata: { siteId: ctx.siteId, scanRunId: result.scanRunId },
+          });
+        }
         return {
           status: 'queued',
           message: 'Queued for verification. Evidence refreshes when the worker finishes this scan.',

--- a/apps/web/src/app/(dashboard)/system/page.tsx
+++ b/apps/web/src/app/(dashboard)/system/page.tsx
@@ -13,6 +13,8 @@ import {
 } from '@/components/system/operator-control-plane-client';
 import { type PlatformDiagnosticIssue } from '@aros/core-services';
 import { getQueueDiagnostics } from '@/lib/queue-diagnostics';
+import { getEntitlementState } from '@/lib/auth-guard';
+import { PRODUCT_EVENT_ACTIONS } from '@/lib/product-events';
 
 
 export const metadata = { title: 'System & services' };
@@ -85,7 +87,50 @@ export default async function SystemPage() {
     console.error('[system] platform health failed', e);
   }
 
-  const queueStats = await getQueueDiagnostics().catch(() => []);
+  const productDecisionActions = Object.values(PRODUCT_EVENT_ACTIONS);
+
+  const [queueStats, orgCommercialBrief, apiKeyCount, pendingInviteCount, recentProductEvents] =
+    await Promise.all([
+      getQueueDiagnostics().catch(() => []),
+      prisma.organization
+        .findUnique({
+          where: { id: orgId },
+          select: {
+            subscription: {
+              select: {
+                plan: true,
+                status: true,
+                maxDomains: true,
+                maxPagesPerCrawl: true,
+                maxScansPerMonth: true,
+                maxSeats: true,
+                aiEnabled: true,
+                aiTokenLimit: true,
+                currentPeriodEnd: true,
+                cancelAtPeriodEnd: true,
+              },
+            },
+            _count: { select: { memberships: true, workspaces: true } },
+          },
+        })
+        .catch(() => null),
+      prisma.apiKey
+        .count({ where: { organizationId: orgId, isActive: true } })
+        .catch(() => 0),
+      prisma.auditLog
+        .count({
+          where: { organizationId: orgId, action: 'member:invite_pending' },
+        })
+        .catch(() => 0),
+      prisma.auditLog
+        .findMany({
+          where: { organizationId: orgId, action: { in: productDecisionActions } },
+          orderBy: { createdAt: 'desc' },
+          take: 15,
+          select: { id: true, action: true, createdAt: true, userId: true },
+        })
+        .catch(() => []),
+    ]);
 
 
   const summary = payload?.diagnostics.summary ?? null;
@@ -95,6 +140,11 @@ export default async function SystemPage() {
   const optionalIssueCount = summary?.optionalUnavailable.length ?? 0;
   const unhealthyServiceCount =
     payload?.report.services.filter((svc) => !['running', 'ready', 'disabled'].includes(svc.healthState)).length ?? 0;
+
+  const commercialEntitlement = getEntitlementState(orgCommercialBrief?.subscription ?? null);
+  const seatsInUse = orgCommercialBrief?._count.memberships ?? 0;
+  const seatCap = orgCommercialBrief?.subscription?.maxSeats ?? 1;
+  const seatsAtCap = seatsInUse + pendingInviteCount >= seatCap;
 
   return (
     <div className="space-y-8">
@@ -121,6 +171,87 @@ export default async function SystemPage() {
           </p>
         </RouteReliabilityNotice>
       )}
+
+      <section className="card space-y-4" aria-labelledby="commercial-readiness-heading">
+        <div>
+          <h2 id="commercial-readiness-heading" className="text-lg font-semibold text-slate-900">
+            Customer org commercial readiness
+          </h2>
+          <p className="mt-1 text-sm text-slate-600">
+            Snapshot for operator triage: billing posture, seat pressure, and recent product-decision audit events (not a
+            CRM). Self-serve limits apply unless a written contract explicitly overrides them.
+          </p>
+        </div>
+        {orgCommercialBrief ? (
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+              <p className="font-medium text-slate-900">Entitlement</p>
+              <ul className="mt-2 space-y-1">
+                <li>
+                  Plan:{' '}
+                  <span className="font-mono text-xs">{orgCommercialBrief.subscription?.plan ?? 'FREE'}</span>
+                </li>
+                <li>
+                  Status:{' '}
+                  <span className="font-mono text-xs">
+                    {orgCommercialBrief.subscription?.status ?? 'UNKNOWN'}
+                  </span>
+                </li>
+                <li>
+                  Paid access (server model):{' '}
+                  <span className="font-medium">{commercialEntitlement.hasPaidAccess ? 'Yes' : 'No'}</span>
+                  {commercialEntitlement.reason !== 'active_paid' && (
+                    <span className="text-slate-500"> ({commercialEntitlement.reason})</span>
+                  )}
+                </li>
+                {orgCommercialBrief.subscription?.cancelAtPeriodEnd && (
+                  <li className="text-amber-800">Cancellation scheduled at period end.</li>
+                )}
+              </ul>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+              <p className="font-medium text-slate-900">Capacity</p>
+              <ul className="mt-2 space-y-1">
+                <li>
+                  Workspaces: {orgCommercialBrief._count.workspaces}
+                </li>
+                <li>
+                  Seats: {seatsInUse} members + {pendingInviteCount} pending invites / cap {seatCap}
+                  {seatsAtCap ? (
+                    <span className="ml-1 text-amber-800">(at or over seat cap)</span>
+                  ) : null}
+                </li>
+                <li>Active API keys: {apiKeyCount}</li>
+                <li>
+                  Monthly scan limit (plan): {orgCommercialBrief.subscription?.maxScansPerMonth ?? '—'}
+                </li>
+              </ul>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-slate-500">Commercial snapshot unavailable (database error).</p>
+        )}
+        <div>
+          <p className="text-sm font-medium text-slate-900">Recent product decision events</p>
+          <p className="text-xs text-slate-500 mt-1">
+            Logged to audit with actions {productDecisionActions.join(', ')}.
+          </p>
+          {recentProductEvents.length === 0 ? (
+            <p className="mt-2 text-sm text-slate-500">No product decision events recorded yet.</p>
+          ) : (
+            <ul className="mt-2 divide-y divide-slate-100 text-sm">
+              {recentProductEvents.map((row) => (
+                <li key={row.id} className="flex flex-wrap justify-between gap-2 py-2">
+                  <span className="font-mono text-xs text-slate-800">{row.action}</span>
+                  <time className="text-xs text-slate-500" dateTime={row.createdAt.toISOString()}>
+                    {formatIsoDateTime(row.createdAt.toISOString())}
+                  </time>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
 
       {loadError && (
         <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900" role="alert">

--- a/apps/web/src/app/api/ai-copilot/route.test.ts
+++ b/apps/web/src/app/api/ai-copilot/route.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import { POST } from "./route";
 import { ApiError } from "@aros/shared";
 
-vi.mock("@/lib/auth-guard", () => ({
-  requireOrgAccess: vi.fn(),
-}));
+vi.mock("@/lib/server-org-boundary", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/server-org-boundary")>();
+  return {
+    ...actual,
+    requireCanonicalOrgAccess: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/session", () => ({
   requireSession: vi.fn(),
@@ -36,14 +40,23 @@ vi.mock("fetch", () => ({
   default: vi.fn(),
 }));
 
-import { requireOrgAccess } from "@/lib/auth-guard";
+import { requireCanonicalOrgAccess } from "@/lib/server-org-boundary";
 import { requireSession } from "@/lib/session";
 import { prisma } from "@/lib/db";
 
 describe("AI Copilot API", () => {
+  beforeEach(() => {
+    vi.mocked(requireSession).mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+      name: "Test User",
+      emailVerified: true,
+    });
+  });
+
   it("should reject unauthorized users", async () => {
-    const mockRequireOrgAccess = vi.mocked(requireOrgAccess);
-    mockRequireOrgAccess.mockRejectedValueOnce(
+    const mockRequire = vi.mocked(requireCanonicalOrgAccess);
+    mockRequire.mockRejectedValueOnce(
       ApiError.forbidden("Missing permission: finding:manage"),
     );
 
@@ -65,14 +78,11 @@ describe("AI Copilot API", () => {
   });
 
   it("should reject when finding not found or not in org", async () => {
-    const mockRequireOrgAccess = vi.mocked(requireOrgAccess);
-    mockRequireOrgAccess.mockResolvedValueOnce({
-      user: { id: "user-1", email: "user@example.com", name: "Test User" },
+    const mockRequire = vi.mocked(requireCanonicalOrgAccess);
+    mockRequire.mockResolvedValueOnce({
       organizationId: "org-1",
       role: "OWNER",
-      subscription: null,
-      entitlement: { hasPaidAccess: true, reason: "active_paid" },
-    } as any);
+    });
 
     const mockFindFirst = vi.mocked(prisma.canonicalFinding.findFirst);
     mockFindFirst.mockResolvedValueOnce(null);
@@ -95,25 +105,11 @@ describe("AI Copilot API", () => {
   });
 
   it("should reject when AI not enabled", async () => {
-    const mockRequireOrgAccess = vi.mocked(requireOrgAccess);
-    mockRequireOrgAccess.mockResolvedValueOnce({
-      user: { id: "user-1", email: "user@example.com", name: "Test User" },
+    const mockRequire = vi.mocked(requireCanonicalOrgAccess);
+    mockRequire.mockResolvedValueOnce({
       organizationId: "org-1",
       role: "OWNER",
-      subscription: {
-        plan: "STARTER",
-        status: "ACTIVE",
-        maxDomains: 5,
-        maxPagesPerCrawl: 100,
-        maxScansPerMonth: 10,
-        maxSeats: 5,
-        aiEnabled: false,
-        aiTokenLimit: 0,
-        currentPeriodEnd: null,
-        cancelAtPeriodEnd: false,
-      },
-      entitlement: { hasPaidAccess: true, reason: "active_paid" },
-    } as any);
+    });
 
     const mockFindFirst = vi.mocked(prisma.canonicalFinding.findFirst);
     mockFindFirst.mockResolvedValueOnce({

--- a/apps/web/src/app/api/ai-copilot/route.ts
+++ b/apps/web/src/app/api/ai-copilot/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
     const ctx = await requireCanonicalOrgAccess(
       parsed.organizationId,
       "finding:manage",
-      { requirePaid: true },
+      { requirePaid: true, planMinimum: "PROFESSIONAL" },
     );
 
     // Load finding context for RAG
@@ -68,7 +68,8 @@ ${parsed.message}`;
           success: false,
           error: {
             code: "AI_NOT_ENABLED",
-            message: "AI features require a Starter plan or higher.",
+            message:
+              "AI draft assist requires Professional or Enterprise (AI-enabled plans on this product).",
           },
         },
         { status: 403 },

--- a/apps/web/src/app/api/deploy-webhook/route.ts
+++ b/apps/web/src/app/api/deploy-webhook/route.ts
@@ -4,6 +4,7 @@ import { apiSuccess, apiError } from "@/lib/api-utils";
 import { ApiError } from "@aros/shared";
 import { createHmac, timingSafeEqual } from "crypto";
 import { createPendingScanRun, findActiveDeployWebhookByDomain, listDeployWebhooks } from "@/lib/integrations/org-scoped-queries";
+import { deployWebhookSubscriptionAllowed } from "@/lib/deploy-webhook-plan-gate";
 
 export const runtime = "nodejs";
 
@@ -156,15 +157,16 @@ export async function POST(request: Request) {
       });
     }
 
-    // Additional security: Verify organization has active subscription for webhooks
+    // Deploy-triggered scans are a Professional+ automation; require paid access in good standing.
     const subscription = deployWebhook.site.workspace.organization.subscription;
-    if (!subscription || subscription.status !== "ACTIVE") {
+    if (!deployWebhookSubscriptionAllowed(subscription)) {
       return NextResponse.json(
         {
           success: false,
           error: {
-            code: "SUBSCRIPTION_INACTIVE",
-            message: "Deploy webhooks require active subscription",
+            code: "PLAN_UPGRADE_REQUIRED",
+            message:
+              "Deploy webhooks require Professional (or Enterprise) with an active or trialing subscription.",
           },
         },
         { status: 403 },
@@ -226,6 +228,7 @@ export async function GET(request: Request) {
 
     const ctx = await requireCanonicalOrgAccess(organizationId, "integrations:view", {
       requirePaid: true,
+      planMinimum: "PROFESSIONAL",
     });
 
     const webhooks = await listDeployWebhooks(ctx);

--- a/apps/web/src/app/support/page.tsx
+++ b/apps/web/src/app/support/page.tsx
@@ -40,6 +40,17 @@ export default function SupportPage() {
               . Include your organization name, approximate timezone, and what you
               were trying to do—we respond as capacity allows.
             </p>
+            <p className="mt-3 text-sm leading-relaxed text-slate-600">
+              Self-serve plans use the in-app billing page for upgrades, downgrades, and
+              payment updates. If private routes are locked, check billing status there
+              first (past due or cancelled subscriptions block paid surfaces even when
+              marketing pages still load).
+            </p>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">
+              Enterprise or managed accessibility operations are contract-shaped: scope,
+              response expectations, and onboarding commitments apply only where agreed in
+              writing—not from marketing copy alone.
+            </p>
           </li>
           <li>
             <h2 className="text-lg font-semibold text-slate-900">

--- a/apps/web/src/lib/__tests__/auth-guard.test.ts
+++ b/apps/web/src/lib/__tests__/auth-guard.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { getEntitlementState } from '../auth-guard';
+
+describe('getEntitlementState', () => {
+  const base = {
+    maxDomains: 3,
+    maxPagesPerCrawl: 200,
+    maxScansPerMonth: 10,
+    maxSeats: 3,
+    aiEnabled: false,
+    aiTokenLimit: 0,
+    currentPeriodEnd: null,
+    cancelAtPeriodEnd: false,
+  };
+
+  it('treats TRIALING as paid access', () => {
+    const s = getEntitlementState({
+      ...base,
+      plan: 'STARTER',
+      status: 'TRIALING',
+    });
+    expect(s.hasPaidAccess).toBe(true);
+    expect(s.reason).toBe('active_paid');
+  });
+
+  it('denies PAST_DUE even on a paid plan tier', () => {
+    const s = getEntitlementState({
+      ...base,
+      plan: 'PROFESSIONAL',
+      status: 'PAST_DUE',
+    });
+    expect(s.hasPaidAccess).toBe(false);
+    expect(s.reason).toBe('past_due');
+  });
+});

--- a/apps/web/src/lib/__tests__/deploy-webhook-plan-gate.test.ts
+++ b/apps/web/src/lib/__tests__/deploy-webhook-plan-gate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { deployWebhookSubscriptionAllowed } from '../deploy-webhook-plan-gate';
+
+describe('deployWebhookSubscriptionAllowed', () => {
+  it('allows Professional active', () => {
+    expect(
+      deployWebhookSubscriptionAllowed({ plan: 'PROFESSIONAL', status: 'ACTIVE' }),
+    ).toBe(true);
+  });
+
+  it('allows Professional trialing', () => {
+    expect(
+      deployWebhookSubscriptionAllowed({ plan: 'PROFESSIONAL', status: 'TRIALING' }),
+    ).toBe(true);
+  });
+
+  it('denies Starter even when active', () => {
+    expect(
+      deployWebhookSubscriptionAllowed({ plan: 'STARTER', status: 'ACTIVE' }),
+    ).toBe(false);
+  });
+
+  it('denies past due Professional', () => {
+    expect(
+      deployWebhookSubscriptionAllowed({ plan: 'PROFESSIONAL', status: 'PAST_DUE' }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/stripe-webhook.integration.test.ts
+++ b/apps/web/src/lib/__tests__/stripe-webhook.integration.test.ts
@@ -150,7 +150,7 @@ describeDb('Stripe webhook integration', () => {
   });
 
 
-  it('does not silently grant paid entitlements for unknown price ids', async () => {
+  it('does not promote FREE orgs when Stripe sends an unknown price id', async () => {
     const eventId = `evt_test_${Date.now()}_unknown_price`;
     const subId = `sub_test_unknown_${Date.now()}`;
 
@@ -184,6 +184,43 @@ describeDb('Stripe webhook integration', () => {
     expect(sub?.plan).toBe('FREE');
     expect(sub?.maxDomains).toBe(1);
     expect(sub?.aiEnabled).toBe(false);
+  });
+
+  it('preserves an existing paid tier when Stripe sends an unknown price id', async () => {
+    const eventId = `evt_test_${Date.now()}_unknown_preserve`;
+    const subId = `sub_test_preserve_${Date.now()}`;
+
+    await prisma.subscription.update({
+      where: { organizationId: orgId },
+      data: {
+        plan: 'ENTERPRISE',
+        status: 'ACTIVE',
+        maxDomains: 100,
+        maxPagesPerCrawl: 10000,
+        maxScansPerMonth: 500,
+        maxSeats: 100,
+        aiEnabled: true,
+        aiTokenLimit: 1_000_000,
+      },
+    });
+
+    const payload = subscriptionPayload({
+      id: subId,
+      eventId,
+      customerId: stripeCustomerId,
+      priceId: 'price_custom_contract',
+      status: 'active',
+    });
+    const raw = JSON.stringify(payload);
+    const sig = signStripePayload(raw, env.webhookSecret);
+
+    const r = await handleStripeWebhookRequest(raw, sig, env, prisma);
+    expect(r).toEqual({ ok: true, duplicate: false });
+
+    const sub = await prisma.subscription.findUnique({ where: { organizationId: orgId } });
+    expect(sub?.plan).toBe('ENTERPRISE');
+    expect(sub?.maxDomains).toBe(100);
+    expect(sub?.stripeSubscriptionId).toBe(subId);
   });
 
   it('downgrades on customer.subscription.deleted', async () => {

--- a/apps/web/src/lib/auth-guard.ts
+++ b/apps/web/src/lib/auth-guard.ts
@@ -95,6 +95,7 @@ export function getEntitlementState(
     return { hasPaidAccess: false, reason: 'cancelled' };
   }
 
+  // TRIALING and ACTIVE both carry paid plan limits until Stripe moves the subscription.
   return { hasPaidAccess: true, reason: 'active_paid' };
 }
 
@@ -103,9 +104,9 @@ export function entitlementReasonMessage(state: EntitlementState): string {
     case 'free_plan':
       return 'This feature is available on paid plans only.';
     case 'past_due':
-      return 'Your subscription is past due. Update billing to restore access.';
+      return 'Your subscription is past due. Update billing to restore paid access.';
     case 'cancelled':
-      return 'Your subscription has been cancelled. Upgrade to restore access.';
+      return 'Your subscription has ended. Upgrade to restore paid access.';
     case 'missing_subscription':
       return 'No subscription was found for this organization.';
     case 'active_paid':

--- a/apps/web/src/lib/deploy-webhook-plan-gate.ts
+++ b/apps/web/src/lib/deploy-webhook-plan-gate.ts
@@ -1,0 +1,19 @@
+import { planMeetsMinimum } from '@aros/config';
+import type { PlanTier, SubscriptionStatus } from '@aros/db';
+
+export function deployWebhookSubscriptionAllowed(
+  subscription:
+    | {
+        plan: PlanTier;
+        status: SubscriptionStatus;
+      }
+    | null
+    | undefined,
+): boolean {
+  if (!subscription || subscription.plan === 'FREE') {
+    return false;
+  }
+  const statusOk = subscription.status === 'ACTIVE' || subscription.status === 'TRIALING';
+  const tierOk = planMeetsMinimum(subscription.plan, 'PROFESSIONAL');
+  return statusOk && tierOk;
+}

--- a/apps/web/src/lib/product-events.ts
+++ b/apps/web/src/lib/product-events.ts
@@ -1,0 +1,34 @@
+import { prisma } from '@/lib/db';
+import type { Prisma } from '@aros/db';
+
+/** Decision-oriented audit trail (not a third-party analytics pipeline). */
+export const PRODUCT_EVENT_ACTIONS = {
+  signup_completed: 'product:signup_completed',
+  checkout_started: 'product:checkout_started',
+  invite_sent: 'product:invite_sent',
+  api_key_created: 'product:api_key_created',
+  first_private_scan_queued: 'product:first_private_scan_queued',
+} as const;
+
+export type ProductEventAction =
+  (typeof PRODUCT_EVENT_ACTIONS)[keyof typeof PRODUCT_EVENT_ACTIONS];
+
+export async function logProductEvent(input: {
+  organizationId: string;
+  userId: string | null;
+  action: ProductEventAction;
+  metadata?: Prisma.InputJsonValue;
+}): Promise<void> {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        organizationId: input.organizationId,
+        userId: input.userId,
+        action: input.action,
+        metadata: input.metadata ?? undefined,
+      },
+    });
+  } catch (e) {
+    console.error('[product-events] audit log failed', input.action, e);
+  }
+}

--- a/apps/web/src/lib/public-packaging.test.ts
+++ b/apps/web/src/lib/public-packaging.test.ts
@@ -24,4 +24,14 @@ describe('getPublicPlanCards', () => {
       `Bounded AI draft assist: ${PLANS.PROFESSIONAL.aiTokenLimit.toLocaleString()} tokens/mo (review required)`,
     );
   });
+
+  it('surfaces deploy webhook automation only on Professional where the plan config says so', () => {
+    const cards = getPublicPlanCards();
+    const professional = cards.find((c) => c.tier === 'PROFESSIONAL');
+    const starter = cards.find((c) => c.tier === 'STARTER');
+    expect(
+      professional?.bullets.some((b) => /deploy webhook/i.test(b)),
+    ).toBe(true);
+    expect(starter?.bullets.some((b) => /deploy webhook/i.test(b))).toBe(false);
+  });
 });

--- a/apps/web/src/lib/server-org-boundary.ts
+++ b/apps/web/src/lib/server-org-boundary.ts
@@ -1,10 +1,13 @@
 import { ApiError, AppError } from "@aros/shared";
 import { requireOrgAccess } from "@/lib/auth-guard";
 import { runOrgScopedQuery, type OrgMembershipCore } from "@/lib/route-data-boundary";
-import type { Permission } from "@aros/config";
+import type { Permission, PlanTier } from "@aros/config";
+import { planMeetsMinimum } from "@aros/config";
 
 interface OrgBoundaryOptions {
   requirePaid?: boolean;
+  /** Minimum self-serve tier on the plan ladder (FREE < STARTER < PROFESSIONAL < ENTERPRISE). */
+  planMinimum?: PlanTier;
 }
 
 export async function requireCanonicalOrgAccess(
@@ -17,6 +20,18 @@ export async function requireCanonicalOrgAccess(
   }
 
   const ctx = await requireOrgAccess(organizationId, permission, options);
+
+  if (options.planMinimum) {
+    const tier = ctx.subscription?.plan ?? "FREE";
+    if (!planMeetsMinimum(tier, options.planMinimum)) {
+      throw new ApiError(
+        `This capability requires ${options.planMinimum} or higher on this organization.`,
+        "PLAN_UPGRADE_REQUIRED",
+        403,
+      );
+    }
+  }
+
   return { organizationId: ctx.organizationId, role: ctx.role };
 }
 

--- a/apps/web/src/lib/stripe-webhook.ts
+++ b/apps/web/src/lib/stripe-webhook.ts
@@ -150,12 +150,24 @@ async function applySubscriptionUpsert(
 
   const priceId = subscription.items?.data?.[0]?.price?.id;
   const resolvedPlanTier = resolvePlanTierFromPriceId(priceId, env);
-  const planConfig = resolvedPlanTier ? PLANS[resolvedPlanTier] : null;
+
+  const existing = await tx.subscription.findUnique({
+    where: { organizationId: billingCustomer.organizationId },
+    select: { plan: true },
+  });
+
+  /** When Stripe sends an unmapped price id, keep the org on its current paid tier instead of snapping to FREE limits. */
+  const tierToApply: PlanTier =
+    resolvedPlanTier ?? (existing && existing.plan !== 'FREE' ? existing.plan : 'FREE');
+
+  const planConfig =
+    tierToApply !== 'FREE' ? PLANS[tierToApply as Exclude<PlanTier, 'FREE'>] : null;
 
   if (!resolvedPlanTier && priceId) {
     console.warn('[stripe-webhook] unknown price id received; preserving existing entitlement where possible', {
       stripeSubscriptionId: subscription.id,
       priceId,
+      preservedPlan: tierToApply,
     });
   }
 
@@ -164,7 +176,7 @@ async function applySubscriptionUpsert(
     create: {
       organizationId: billingCustomer.organizationId,
       stripeSubscriptionId: subscription.id,
-      plan: planConfig?.tier ?? 'FREE',
+      plan: tierToApply,
       status: subscriptionStatusFromStripe(subscription.status),
       maxDomains: planConfig?.maxDomains ?? PLANS.FREE.maxDomains,
       maxPagesPerCrawl: planConfig?.maxPagesPerCrawl ?? PLANS.FREE.maxPagesPerCrawl,
@@ -178,14 +190,14 @@ async function applySubscriptionUpsert(
     },
     update: {
       stripeSubscriptionId: subscription.id,
-      plan: planConfig?.tier ?? undefined,
+      plan: tierToApply,
       status: subscriptionStatusFromStripe(subscription.status),
-      maxDomains: planConfig?.maxDomains,
-      maxPagesPerCrawl: planConfig?.maxPagesPerCrawl,
-      maxScansPerMonth: planConfig?.maxScansPerMonth,
-      maxSeats: planConfig?.maxSeats,
-      aiEnabled: planConfig?.aiEnabled,
-      aiTokenLimit: planConfig?.aiTokenLimit,
+      maxDomains: planConfig?.maxDomains ?? PLANS.FREE.maxDomains,
+      maxPagesPerCrawl: planConfig?.maxPagesPerCrawl ?? PLANS.FREE.maxPagesPerCrawl,
+      maxScansPerMonth: planConfig?.maxScansPerMonth ?? PLANS.FREE.maxScansPerMonth,
+      maxSeats: planConfig?.maxSeats ?? PLANS.FREE.maxSeats,
+      aiEnabled: planConfig?.aiEnabled ?? PLANS.FREE.aiEnabled,
+      aiTokenLimit: planConfig?.aiTokenLimit ?? PLANS.FREE.aiTokenLimit,
       currentPeriodStart: new Date(subscription.current_period_start * 1000),
       currentPeriodEnd: new Date(subscription.current_period_end * 1000),
       cancelAtPeriodEnd: subscription.cancel_at_period_end ?? false,

--- a/packages/config/src/__tests__/plan-tier-order.test.ts
+++ b/packages/config/src/__tests__/plan-tier-order.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { planMeetsMinimum, planTierRank } from '../plan-tier-order';
+
+describe('planMeetsMinimum', () => {
+  it('ranks tiers in ascending order', () => {
+    expect(planTierRank('FREE')).toBeLessThan(planTierRank('STARTER'));
+    expect(planTierRank('STARTER')).toBeLessThan(planTierRank('PROFESSIONAL'));
+    expect(planTierRank('PROFESSIONAL')).toBeLessThan(planTierRank('ENTERPRISE'));
+  });
+
+  it('requires same or higher tier', () => {
+    expect(planMeetsMinimum('PROFESSIONAL', 'PROFESSIONAL')).toBe(true);
+    expect(planMeetsMinimum('ENTERPRISE', 'PROFESSIONAL')).toBe(true);
+    expect(planMeetsMinimum('STARTER', 'PROFESSIONAL')).toBe(false);
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -8,6 +8,11 @@ export {
   type EnvDiagnostics,
 } from './env';
 export { PLANS, type PlanConfig, type PlanTier } from './plans';
+export {
+  PLAN_TIER_ORDER,
+  planTierRank,
+  planMeetsMinimum,
+} from './plan-tier-order';
 export { PUBLIC_SCAN_EVIDENCE_TTL_MS } from './public-scan';
 export { PERMISSIONS, hasPermission, type Permission } from './permissions';
 export { getEmailOutboundSummary } from './email';

--- a/packages/config/src/plan-tier-order.ts
+++ b/packages/config/src/plan-tier-order.ts
@@ -1,0 +1,19 @@
+import type { PlanTier } from './plans';
+
+/** Lowest → highest; used for minimum-plan enforcement (self-serve). */
+export const PLAN_TIER_ORDER: PlanTier[] = [
+  'FREE',
+  'STARTER',
+  'PROFESSIONAL',
+  'ENTERPRISE',
+];
+
+export function planTierRank(tier: PlanTier): number {
+  const i = PLAN_TIER_ORDER.indexOf(tier);
+  return i >= 0 ? i : 0;
+}
+
+/** True when `actual` is the same tier or higher than `minimum` on the self-serve ladder. */
+export function planMeetsMinimum(actual: PlanTier, minimum: PlanTier): boolean {
+  return planTierRank(actual) >= planTierRank(minimum);
+}

--- a/packages/config/src/plans.ts
+++ b/packages/config/src/plans.ts
@@ -54,10 +54,10 @@ export const PLANS: Record<PlanTier, PlanConfig> = {
     maxScansPerMonth: 50,
     maxSeats: 10,
     features: [
-      "Scheduled / recurring scans",
+      "Deploy webhook triggers for post-deploy scans (this tier and up)",
       "Human review queues + sign-off trails",
       "Evidence-grade exports (VPAT-ready artifacts)",
-      "Jira + webhook automation",
+      "Integration automation where your operator configures connectors (e.g. Jira)",
       "Bounded AI assist for draft fixes (review required)",
     ],
     priceMonthly: 149,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This pass tightens monetization and operator leverage without broad rewrites.

### Plan / entitlement truth
- **TRIALING** subscriptions are treated as paid for dashboard access (matches Stripe lifecycle).
- Stripe webhook **upsert** no longer snaps an org with an unknown `price_id` to FREE limits when they were already on a paid tier (contract/custom price safety).
- **Deploy webhooks** (POST trigger + GET list) require **Professional+** with **ACTIVE** or **TRIALING** status.
- **AI Copilot** enforces **Professional** minimum server-side (aligns with `aiEnabled` on Professional/Enterprise in config) and fixes the error message.
- **Professional** plan marketing updated so automation claims match enforcement (deploy webhooks; Jira framed as operator-configured).

### Operator / decision support
- **Product decision events** written to `audit_logs` (`product:*` actions): signup completed, checkout started, invite sent, API key created, first private scan queued.
- **System** page adds a **customer org commercial readiness** snapshot (entitlement, seats, API keys, recent product events).
- **Billing** page shows seat usage vs cap, pages/crawl, and explicit past_due/cancelled/downgrade notes.

### Support
- **Support** page clarifies self-serve billing recovery vs contract-shaped enterprise/managed.

### Tests
- Config: `plan-tier-order` tests.
- Web: `getEntitlementState` (TRIALING), deploy webhook plan gate, public packaging assertion, AI copilot route tests updated, Stripe integration test for unknown price preservation, paywall E2E for deploy-webhook GET without session.

## Verification
- `npm install`
- `npm run lint` (pass; pre-existing tenant-boundary warnings)
- `npm run typecheck` (pass)
- `npm run test` (pass)
- `npm run build` (pass)
- Stripe webhook integration file: skipped without `DATABASE_URL` (ran via direct vitest: 7 skipped when DB unreachable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1e19532-94c5-404b-a02c-cbcbf78b1623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1e19532-94c5-404b-a02c-cbcbf78b1623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

