### PR TITLE
Harden marketing discovery metadata, add docs IA, and centralize public routes

### DIFF
--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,7 +1,21 @@
+import type { Metadata } from "next";
 import {
   PRODUCT_DISPLAY_NAME,
   PRODUCT_TAGLINE,
 } from '@/lib/product-brand';
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+    googleBot: {
+      index: false,
+      follow: false,
+      noimageindex: true,
+    },
+  },
+};
 
 export default function AuthLayout({
   children,

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { cookies, headers } from "next/headers";
 import { getSession } from "@/lib/session";
@@ -15,6 +16,19 @@ import { getEntitlementState, isBillingAccessiblePath } from "@/lib/auth-guard";
 import { isEmailVerificationExemptPath } from "@/lib/email-verification-guard";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+    googleBot: {
+      index: false,
+      follow: false,
+      noimageindex: true,
+    },
+  },
+};
 
 const membershipLayoutInclude = {
   organization: {

--- a/apps/web/src/app/docs/api/page.tsx
+++ b/apps/web/src/app/docs/api/page.tsx
@@ -13,15 +13,14 @@ export const metadata: Metadata = marketingSurfaceMetadata(
 export default function DocsApiPage() {
   return (
     <MarketingSiteChrome>
-      <div className="mx-auto max-w-2xl px-6 py-section-md">
+      <div className="mx-auto max-w-3xl px-6 py-section-md">
         <p className="text-sm font-medium text-brand-700">Documentation</p>
         <h1 className="mt-2 text-3xl font-bold text-slate-900">
           API and integrations
         </h1>
         <p className="mt-4 text-slate-600">
-          This product ships integration through authenticated workspace features,
-          not a separate browsable public API reference site. Below is what this
-          repository supports today.
+          This product exposes integration through authenticated workspace
+          features and CLI/MCP tooling—not a broad anonymous public API.
         </p>
 
         <ul className="mt-8 space-y-6 text-slate-700">
@@ -32,7 +31,8 @@ export default function DocsApiPage() {
               <code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-800">
                 npx @aros/mcp-server
               </code>{" "}
-              for tool-based access. See the package README on npm for options.
+              for tool-based access. Use this when you need stable workflows in
+              IDEs/agents without manually wiring HTTP calls.
             </p>
             <a
               href="https://www.npmjs.com/package/@aros/mcp-server"
@@ -43,14 +43,20 @@ export default function DocsApiPage() {
               View @aros/mcp-server on npm
             </a>
           </li>
+
           <li>
             <h2 className="font-semibold text-slate-900">
               Organization API keys
             </h2>
             <p className="mt-1 text-sm">
-              After you sign in, create and rotate keys under Settings → API keys.
-              Usage is org-scoped and subject to plan limits enforced on the server.
+              Create and rotate keys under Settings → API keys after sign-in.
+              Keys are organization-scoped and plan-gated on the server.
             </p>
+            <ul className="mt-2 list-disc pl-5 text-sm text-slate-600">
+              <li>Use separate keys per integration and environment.</li>
+              <li>Rotate keys during offboarding and incident response.</li>
+              <li>Revoke unused keys rather than leaving them dormant.</li>
+            </ul>
             <Link
               href="/signup"
               className="mt-2 inline-block text-sm font-medium text-brand-700 hover:underline"
@@ -58,20 +64,39 @@ export default function DocsApiPage() {
               Create a workspace
             </Link>
           </li>
+
           <li>
-            <h2 className="font-semibold text-slate-900">Webhooks &amp; CI</h2>
+            <h2 className="font-semibold text-slate-900">Webhooks and CI</h2>
             <p className="mt-1 text-sm">
-              Deploy hooks and GitHub Actions integrations are configured in the
-              dashboard per site or repository; see in-app settings for the exact
-              endpoints and secrets your deployment exposes.
+              Deploy hooks and GitHub Actions integrations are configured in-app
+              per site/repository. Endpoint URLs and secrets are not published
+              publicly because they are deployment-specific.
+            </p>
+          </li>
+
+          <li>
+            <h2 className="font-semibold text-slate-900">Error behavior</h2>
+            <p className="mt-1 text-sm">
+              API routes use explicit status codes for auth failures,
+              entitlement gating, and rate limits (for example, 401/403/429)
+              instead of silent degradation. Validate downstream integrations
+              against non-200 flows before launch.
             </p>
           </li>
         </ul>
 
         <p className="mt-10 text-sm text-slate-500">
-          A standalone public OpenAPI browser is not part of this build. If you need
-          machine-readable contracts, use the MCP package source or ask your
-          operator for an export from this deployment.
+          A standalone public OpenAPI browser is not part of this build. If you
+          need machine-readable contracts, use the MCP package source or request
+          a deployment-specific export from your operator. See also{" "}
+          <Link href="/docs/getting-started" className="font-medium text-brand-700 hover:underline">
+            Getting started
+          </Link>{" "}
+          and{" "}
+          <Link href="/docs/plans-and-limits" className="font-medium text-brand-700 hover:underline">
+            Plans and limits
+          </Link>
+          .
         </p>
       </div>
     </MarketingSiteChrome>

--- a/apps/web/src/app/docs/getting-started/page.tsx
+++ b/apps/web/src/app/docs/getting-started/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Getting started",
+  `How to go from signup to first scan and first shareable evidence in ${PRODUCT_DISPLAY_NAME}.`,
+  "/docs/getting-started",
+);
+
+export default function GettingStartedDocsPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Documentation</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          Getting started
+        </h1>
+        <p className="mt-4 text-slate-600">
+          Follow this sequence to get first value quickly while preserving
+          evidence quality and tenant boundaries.
+        </p>
+
+        <ol className="mt-8 space-y-6 text-slate-700">
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              1. Create an account and verify email
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Use{" "}
+              <Link
+                href="/signup"
+                className="font-medium text-brand-700 hover:underline"
+              >
+                signup
+              </Link>{" "}
+              to create your user and workspace. Production signup depends on
+              outbound SMTP for email verification.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              2. Add a site in your workspace
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              In dashboard settings, add each domain you own so scans and
+              findings stay organization-scoped and auditable.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              3. Run an initial private crawl
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Queue a scan to establish baseline findings. Public scans are
+              intentionally shallow; private crawls provide retained history and
+              remediation workflows.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              4. Triage and assign critical findings first
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Use clustered findings to identify repeated root causes before
+              generating exports. Automated results accelerate triage but do not
+              replace manual assistive-technology testing.
+            </p>
+          </li>
+          <li>
+            <h2 className="text-lg font-semibold text-slate-900">
+              5. Create API keys only when needed
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed">
+              Generate org-scoped API keys in Settings → API keys, rotate
+              regularly, and revoke unused keys. See{" "}
+              <Link
+                href="/docs/api"
+                className="font-medium text-brand-700 hover:underline"
+              >
+                API and integrations
+              </Link>
+              .
+            </p>
+          </li>
+        </ol>
+
+        <p className="mt-10 text-sm text-slate-500">
+          Next: {" "}
+          <Link
+            href="/docs/plans-and-limits"
+            className="font-medium text-brand-700 hover:underline"
+          >
+            Plans and limits
+          </Link>{" "}
+          · {" "}
+          <Link href="/docs/api" className="font-medium text-brand-700 hover:underline">
+            API docs
+          </Link>
+          .
+        </p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Documentation",
+  `Evaluation and onboarding docs for ${PRODUCT_DISPLAY_NAME}: getting started, plans and limits, and API integration paths.`,
+  "/docs",
+);
+
+const docsCards = [
+  {
+    href: "/docs/getting-started",
+    title: "Getting started",
+    description:
+      "From account creation to first private scan and first report artifact.",
+  },
+  {
+    href: "/docs/plans-and-limits",
+    title: "Plans and limits",
+    description:
+      "Exact tier limits and what is self-serve versus contract-shaped enterprise scope.",
+  },
+  {
+    href: "/docs/api",
+    title: "API and integrations",
+    description:
+      "Org-scoped API keys, operational limits, and supported integration surfaces in this build.",
+  },
+] as const;
+
+export default function DocsIndexPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-4xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Documentation</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          Evaluate and onboard without guesswork
+        </h1>
+        <p className="mt-4 text-slate-600">
+          These docs are intentionally operational: what works today, what is
+          plan-gated, and where managed enterprise support begins.
+        </p>
+
+        <div className="mt-10 grid gap-4 sm:grid-cols-3">
+          {docsCards.map((card) => (
+            <article
+              key={card.href}
+              className="rounded-xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))] p-5"
+            >
+              <h2 className="text-lg font-semibold text-slate-900">
+                <Link href={card.href} className="hover:underline">
+                  {card.title}
+                </Link>
+              </h2>
+              <p className="mt-2 text-sm text-slate-600">{card.description}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/docs/plans-and-limits/page.tsx
+++ b/apps/web/src/app/docs/plans-and-limits/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { getPublicPlanCards } from "@/lib/public-packaging";
+import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Plans and limits",
+  `Plan limits for ${PRODUCT_DISPLAY_NAME}: scans, seats, domains, AI usage, and where managed enterprise contracts apply.`,
+  "/docs/plans-and-limits",
+);
+
+export default function PlansAndLimitsPage() {
+  const plans = getPublicPlanCards();
+
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-5xl px-6 py-section-md">
+        <p className="text-sm font-medium text-brand-700">Documentation</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
+          Plans and limits
+        </h1>
+        <p className="mt-4 text-slate-600">
+          Public scans remain intentionally bounded for quick signal. Private
+          workspace capabilities and API usage are enforced by plan on the
+          server.
+        </p>
+
+        <div className="mt-8 overflow-x-auto rounded-xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))]">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[rgb(var(--color-border))] bg-slate-50 text-slate-700">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Plan</th>
+                <th className="px-4 py-3 font-semibold">Price / month</th>
+                <th className="px-4 py-3 font-semibold">Operational limits</th>
+              </tr>
+            </thead>
+            <tbody>
+              {plans.map((plan) => (
+                <tr key={plan.tier} className="border-b border-[rgb(var(--color-border))] align-top">
+                  <td className="px-4 py-4 font-semibold text-slate-900">{plan.name}</td>
+                  <td className="px-4 py-4 text-slate-700">${plan.priceMonthly}</td>
+                  <td className="px-4 py-4">
+                    <ul className="space-y-1 text-slate-600">
+                      {plan.bullets.slice(0, 6).map((bullet) => (
+                        <li key={bullet}>• {bullet}</li>
+                      ))}
+                    </ul>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-8 space-y-3 text-sm text-slate-600">
+          <p>
+            Managed enterprise engagements are contract-shaped (SOW, response expectations,
+            and onboarding scope) and may include terms not exposed in self-serve checkout.
+          </p>
+          <p>
+            Need contract review? Contact{" "}
+            <Link href="/support" className="font-medium text-brand-700 hover:underline">
+              support
+            </Link>{" "}
+            and include procurement requirements early.
+          </p>
+          <p>
+            API key management and org-scoped usage details are in{" "}
+            <Link href="/docs/api" className="font-medium text-brand-700 hover:underline">
+              API and integrations
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/metadata-routes.test.ts
+++ b/apps/web/src/app/metadata-routes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import sitemap from "@/app/sitemap";
+import robots from "@/app/robots";
+import { SITEMAP_MARKETING_ROUTES } from "@/lib/marketing-routes";
+
+describe("marketing metadata routes", () => {
+  it("sitemap includes all intended public acquisition and docs routes", () => {
+    const map = sitemap();
+    const urls = map.map((entry) => new URL(entry.url).pathname);
+
+    expect(urls).toEqual(
+      expect.arrayContaining(SITEMAP_MARKETING_ROUTES.map((route) => route.href)),
+    );
+    expect(urls).not.toEqual(expect.arrayContaining(["/login", "/signup"]));
+    expect(urls).not.toEqual(expect.arrayContaining(["/dashboard", "/settings"]));
+  });
+
+  it("robots disallows auth, dashboard, settings, and API prefixes", () => {
+    const data = robots();
+    const rules = Array.isArray(data.rules) ? data.rules[0] : data.rules;
+    const disallow = rules?.disallow ?? [];
+
+    expect(disallow).toEqual(
+      expect.arrayContaining([
+        "/login",
+        "/signup",
+        "/forgot-password",
+        "/dashboard/",
+        "/settings/",
+        "/api/",
+      ]),
+    );
+  });
+});

--- a/apps/web/src/app/non-public-metadata.test.ts
+++ b/apps/web/src/app/non-public-metadata.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { metadata as authMetadata } from "@/app/(auth)/layout";
+import { metadata as dashboardMetadata } from "@/app/(dashboard)/layout";
+
+describe("non-public route metadata", () => {
+  it("marks auth routes as noindex", () => {
+    expect(authMetadata.robots).toMatchObject({
+      index: false,
+      follow: false,
+      nocache: true,
+    });
+  });
+
+  it("marks dashboard routes as noindex", () => {
+    expect(dashboardMetadata.robots).toMatchObject({
+      index: false,
+      follow: false,
+      nocache: true,
+    });
+  });
+});

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -8,7 +8,16 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
-      disallow: ["/dashboard/", "/settings/"],
+      disallow: [
+        "/dashboard/",
+        "/settings/",
+        "/login",
+        "/signup",
+        "/forgot-password",
+        "/reset-password/",
+        "/verify-email",
+        "/api/",
+      ],
     },
     sitemap: `${base}/sitemap.xml`,
     host,

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,29 +1,15 @@
 import type { MetadataRoute } from "next";
+import { SITEMAP_MARKETING_ROUTES } from "@/lib/marketing-routes";
 import { getAppBaseUrl } from "@/lib/site-url";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = getAppBaseUrl();
   const lastModified = new Date();
 
-  const paths = [
-    "",
-    "/docs/api",
-    "/login",
-    "/signup",
-    "/forgot-password",
-    "/trust",
-    "/security",
-    "/privacy",
-    "/support",
-    "/accessibility",
-    "/legal/terms",
-    "/legal/subprocessors",
-  ] as const;
-
-  return paths.map((path) => ({
-    url: `${base}${path}`,
+  return SITEMAP_MARKETING_ROUTES.map((route) => ({
+    url: `${base}${route.href}`,
     lastModified,
-    changeFrequency: path === "" ? "weekly" : "monthly",
-    priority: path === "" ? 1 : 0.7,
+    changeFrequency: route.href === "/" ? "weekly" : "monthly",
+    priority: route.href === "/" ? 1 : 0.7,
   }));
 }

--- a/apps/web/src/components/marketing/marketing-site-chrome.tsx
+++ b/apps/web/src/components/marketing/marketing-site-chrome.tsx
@@ -5,6 +5,7 @@ import {
   PRODUCT_DISPLAY_NAME,
   PRODUCT_LEGAL_LINE,
 } from "@/lib/product-brand";
+import { FOOTER_MARKETING_NAV } from "@/lib/marketing-routes";
 import { MarketingSiteHeader } from "./marketing-site-header";
 
 export function MarketingSiteChrome({ children }: { children: ReactNode }) {
@@ -39,27 +40,15 @@ export function MarketingSiteChrome({ children }: { children: ReactNode }) {
             </p>
           </div>
           <div className="flex flex-wrap gap-6 text-sm text-slate-500">
-            <Link href="/" className="hover:text-slate-800">
-              Home
-            </Link>
-            <Link href="/trust" className="hover:text-slate-800">
-              Trust
-            </Link>
-            <Link href="/security" className="hover:text-slate-800">
-              Security
-            </Link>
-            <Link href="/privacy" className="hover:text-slate-800">
-              Privacy
-            </Link>
-            <Link href="/support" className="hover:text-slate-800">
-              Support
-            </Link>
-            <Link href="/docs/api" className="hover:text-slate-800">
-              Docs
-            </Link>
-            <Link href="/legal/terms" className="hover:text-slate-800">
-              Terms
-            </Link>
+            {FOOTER_MARKETING_NAV.map((route) => (
+              <Link
+                key={route.href}
+                href={route.href}
+                className="hover:text-slate-800"
+              >
+                {route.label}
+              </Link>
+            ))}
           </div>
         </div>
       </footer>

--- a/apps/web/src/components/marketing/marketing-site-header.tsx
+++ b/apps/web/src/components/marketing/marketing-site-header.tsx
@@ -2,17 +2,13 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import {
-  PRODUCT_DISPLAY_NAME,
-  PRODUCT_TAGLINE,
-} from "@/lib/product-brand";
+import { PRODUCT_DISPLAY_NAME, PRODUCT_TAGLINE } from "@/lib/product-brand";
+import { PRIMARY_MARKETING_NAV } from "@/lib/marketing-routes";
 
 const NAV_LINKS = [
   { href: "/#proof", label: "Proof & workflow" },
   { href: "/#pricing", label: "Plans" },
-  { href: "/trust", label: "Trust" },
-  { href: "/docs/api", label: "Integrations" },
-  { href: "/support", label: "Support" },
+  ...PRIMARY_MARKETING_NAV,
   { href: "/login", label: "Sign in" },
 ] as const;
 

--- a/apps/web/src/lib/marketing-routes.ts
+++ b/apps/web/src/lib/marketing-routes.ts
@@ -1,0 +1,95 @@
+import type { Route } from "next";
+
+export type MarketingRoute = {
+  href: Route;
+  label: string;
+  includeInPrimaryNav?: boolean;
+  includeInFooter?: boolean;
+  includeInSitemap?: boolean;
+};
+
+export const MARKETING_ROUTES: readonly MarketingRoute[] = [
+  {
+    href: "/",
+    label: "Home",
+    includeInFooter: true,
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs",
+    label: "Docs",
+    includeInPrimaryNav: true,
+    includeInFooter: true,
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs/getting-started",
+    label: "Getting started",
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs/plans-and-limits",
+    label: "Plans & limits",
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs/api",
+    label: "API & integrations",
+    includeInPrimaryNav: true,
+    includeInSitemap: true,
+  },
+  {
+    href: "/trust",
+    label: "Trust",
+    includeInPrimaryNav: true,
+    includeInFooter: true,
+    includeInSitemap: true,
+  },
+  {
+    href: "/security",
+    label: "Security",
+    includeInFooter: true,
+    includeInSitemap: true,
+  },
+  {
+    href: "/privacy",
+    label: "Privacy",
+    includeInFooter: true,
+    includeInSitemap: true,
+  },
+  {
+    href: "/support",
+    label: "Support",
+    includeInPrimaryNav: true,
+    includeInFooter: true,
+    includeInSitemap: true,
+  },
+  {
+    href: "/accessibility",
+    label: "Accessibility",
+    includeInSitemap: true,
+  },
+  {
+    href: "/legal/terms",
+    label: "Terms",
+    includeInFooter: true,
+    includeInSitemap: true,
+  },
+  {
+    href: "/legal/subprocessors",
+    label: "Subprocessors",
+    includeInSitemap: true,
+  },
+] as const;
+
+export const PRIMARY_MARKETING_NAV = MARKETING_ROUTES.filter(
+  (route) => route.includeInPrimaryNav,
+);
+
+export const FOOTER_MARKETING_NAV = MARKETING_ROUTES.filter(
+  (route) => route.includeInFooter,
+);
+
+export const SITEMAP_MARKETING_ROUTES = MARKETING_ROUTES.filter(
+  (route) => route.includeInSitemap,
+);


### PR DESCRIPTION
### Motivation
- Prevent sitemap/footer/header drift by centralizing marketing route truth and reduce accidental public indexing of auth/API surfaces.  
- Make public documentation and onboarding clearer and operational so evaluators can understand what works today without marketing overclaim.  
- Enforce safer crawl/indexing defaults for non-public routes so private/dashboard surfaces are not indexable.

### Description
- Introduced a single source of truth `MARKETING_ROUTES` and derived `PRIMARY_MARKETING_NAV`, `FOOTER_MARKETING_NAV`, and `SITEMAP_MARKETING_ROUTES` in `apps/web/src/lib/marketing-routes.ts`.  
- Rewired header and footer to use the registry and updated `apps/web/src/components/marketing/*` to consume it.  
- Replaced ad-hoc sitemap path list with `SITEMAP_MARKETING_ROUTES` in `apps/web/src/app/sitemap.ts` and tightened `robots` to disallow auth/API prefixes in `apps/web/src/app/robots.ts`.  
- Added explicit `robots` metadata (`noindex, nofollow, nocache`) to auth and dashboard layouts (`apps/web/src/app/(auth)/layout.tsx` and `apps/web/src/app/(dashboard)/layout.tsx`).  
- Added a small docs IA under `/docs` with pages `Getting started`, `Plans and limits`, and improved `API & integrations` copy to reflect real integration surfaces (files under `apps/web/src/app/docs/*`).  
- Added deterministic tests `apps/web/src/app/metadata-routes.test.ts` and `apps/web/src/app/non-public-metadata.test.ts` to verify sitemap/robots and non-public metadata behavior.

### Testing
- Ran `npm install` which completed successfully.  
- Ran `npm run lint` which completed but surfaced existing tenant-boundary ESLint warnings in unrelated dashboard action files (no new lint errors introduced).  
- Ran `npm run typecheck` which failed due to a pre-existing test/type issue in `apps/web/src/app/api/ai-copilot/route.test.ts` (cannot find `beforeEach`) unrelated to these changes.  
- Ran `npm run test` and full repo tests passed where applicable, and targeted tests `src/app/metadata-routes.test.ts` and `src/app/non-public-metadata.test.ts` passed.  
- Ran `npm run build --workspace=apps/web` which produced a successful production build, though the build emitted the same tenant-boundary warnings reported by lint; build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d437e4b9a483288ea564dc6015dcf5)