### PR TITLE
Tenant boundary closure: dashboard server actions, release gate, audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: npm audit (high and critical must be zero)
+        run: npm audit --audit-level=high
+
       - name: Generate Prisma Client
         env:
           DATABASE_URL: postgresql://aros_user:aros_password@localhost:5432/aros_test?schema=public

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,8 +14,8 @@
     "test:e2e": "playwright test",
     "test:ct": "playwright test -c playwright-ct.config.ts",
     "test:e2e:update": "playwright test --update-snapshots",
-    "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts",
-    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts src/lib/operator-org-resolution.test.ts src/lib/dashboard-org-scoped-prisma.test.ts"
+    "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts src/lib/__tests__/tenant-isolation.integration.test.ts",
+    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts src/lib/operator-org-resolution.test.ts src/lib/dashboard-org-scoped-prisma.test.ts src/lib/dashboard-form-org.test.ts"
   },
   "dependencies": {
     "@aros/config": "*",
@@ -46,7 +46,7 @@
     "@playwright/experimental-ct-react": "^1.58.2",
     "@playwright/test": "^1.49.0",
     "@testing-library/jest-dom": "^6.9.1",
-    "@types/nodemailer": "^6.4.17",
+    "@types/nodemailer": "^8.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/sanitize-html": "^2.16.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "test:ct": "playwright test -c playwright-ct.config.ts",
     "test:e2e:update": "playwright test --update-snapshots",
     "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts",
-    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts src/lib/operator-org-resolution.test.ts"
+    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts src/lib/operator-org-resolution.test.ts src/lib/dashboard-org-scoped-prisma.test.ts"
   },
   "dependencies": {
     "@aros/config": "*",
@@ -28,8 +28,8 @@
     "clsx": "^2.1.0",
     "ioredis": "^5.4.0",
     "lucide-react": "^0.468.0",
-    "nodemailer": "^6.9.16",
     "next": "^15.1.0",
+    "nodemailer": "^8.0.4",
     "postcss": "^8.4.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -46,8 +46,8 @@
     "@playwright/experimental-ct-react": "^1.58.2",
     "@playwright/test": "^1.49.0",
     "@testing-library/jest-dom": "^6.9.1",
-    "@types/react": "^19.0.0",
     "@types/nodemailer": "^6.4.17",
+    "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/sanitize-html": "^2.16.1",
     "@vitejs/plugin-react": "^6.0.1",

--- a/apps/web/src/app/(dashboard)/remediation/[suggestionId]/actions.ts
+++ b/apps/web/src/app/(dashboard)/remediation/[suggestionId]/actions.ts
@@ -12,6 +12,10 @@ import {
   updateRemediationSuggestionExported,
   updateRemediationSuggestionRejected,
 } from "@/lib/dashboard-org-scoped-prisma";
+import {
+  assertFormOrgMatchesActive,
+  parseExpectedOrgFromForm,
+} from "@/lib/dashboard-form-org";
 
 export async function approveSuggestionAction(formData: FormData) {
   const user = await requireSession();
@@ -25,6 +29,11 @@ export async function approveSuggestionAction(formData: FormData) {
   const orgRes = await resolveDashboardOrgMembership(user.id, platformTruth);
   if (orgRes.kind !== "ok") {
     redirect("/remediation?error=not_found");
+  }
+
+  const expectedOrg = parseExpectedOrgFromForm(formData);
+  if (!assertFormOrgMatchesActive(expectedOrg, orgRes.organizationId)) {
+    redirect(`/remediation/${suggestionId}?error=stale_session`);
   }
 
   const { role, entitlement } = await requireOrgAccess(
@@ -79,6 +88,11 @@ export async function rejectSuggestionAction(formData: FormData) {
     redirect("/remediation?error=not_found");
   }
 
+  const expectedOrgReject = parseExpectedOrgFromForm(formData);
+  if (!assertFormOrgMatchesActive(expectedOrgReject, orgRes.organizationId)) {
+    redirect(`/remediation/${suggestionId}?error=stale_session`);
+  }
+
   const { role, entitlement } = await requireOrgAccess(
     orgRes.organizationId,
     "suggestion:approve",
@@ -128,6 +142,11 @@ export async function exportSnippetAction(formData: FormData) {
   const orgRes = await resolveDashboardOrgMembership(user.id, platformTruth);
   if (orgRes.kind !== "ok") {
     redirect("/remediation?error=not_found");
+  }
+
+  const expectedOrgExport = parseExpectedOrgFromForm(formData);
+  if (!assertFormOrgMatchesActive(expectedOrgExport, orgRes.organizationId)) {
+    redirect(`/remediation/${suggestionId}?error=stale_session`);
   }
 
   const { role, entitlement } = await requireOrgAccess(

--- a/apps/web/src/app/(dashboard)/remediation/[suggestionId]/actions.ts
+++ b/apps/web/src/app/(dashboard)/remediation/[suggestionId]/actions.ts
@@ -2,78 +2,35 @@
 
 import { redirect } from "next/navigation";
 import { requireSession } from "@/lib/session";
-import { prisma } from "@/lib/db";
 import { hasPermission } from "@aros/config";
-import { getEntitlementState, requireOrgAccess } from "@/lib/auth-guard";
-
-async function requireSuggestionAccess(suggestionId: string, userId: string) {
-  if (!suggestionId) {
-    redirect("/remediation?error=missing_id");
-  }
-
-  // First get the suggestion and determine the organization
-  const suggestion = await prisma.remediationSuggestion.findUnique({
-    where: { id: suggestionId },
-    select: {
-      id: true,
-      status: true,
-      recipeId: true,
-      finding: {
-        select: {
-          site: {
-            select: {
-              workspace: {
-                select: { organizationId: true },
-              },
-            },
-          },
-        },
-      },
-      cluster: {
-        select: {
-          site: {
-            select: {
-              workspace: {
-                select: { organizationId: true },
-              },
-            },
-          },
-        },
-      },
-    },
-  });
-
-  if (!suggestion) {
-    redirect("/remediation?error=not_found");
-  }
-
-  const organizationId =
-    suggestion.finding?.site.workspace.organizationId ??
-    suggestion.cluster?.site.workspace.organizationId;
-
-  if (!organizationId) {
-    redirect("/remediation?error=invalid_suggestion");
-  }
-
-  // Use centralized auth guard
-  const ctx = await requireOrgAccess(organizationId, "suggestion:approve", {
-    requirePaid: true,
-  });
-
-  return {
-    suggestion,
-    role: ctx.role,
-    entitlement: ctx.entitlement,
-  };
-}
+import { requireOrgAccess } from "@/lib/auth-guard";
+import { getRoutePlatformTruth } from "@/lib/platform-truth-cache";
+import { resolveDashboardOrgMembership } from "@/lib/route-data-boundary";
+import {
+  loadRemediationSuggestionForOrg,
+  updateRemediationSuggestionApproved,
+  updateRemediationSuggestionExported,
+  updateRemediationSuggestionRejected,
+} from "@/lib/dashboard-org-scoped-prisma";
 
 export async function approveSuggestionAction(formData: FormData) {
   const user = await requireSession();
   const suggestionId = (formData.get("suggestionId") as string) || "";
 
-  const { suggestion, role, entitlement } = await requireSuggestionAccess(
-    suggestionId,
-    user.id,
+  if (!suggestionId) {
+    redirect("/remediation?error=missing_id");
+  }
+
+  const platformTruth = await getRoutePlatformTruth();
+  const orgRes = await resolveDashboardOrgMembership(user.id, platformTruth);
+  if (orgRes.kind !== "ok") {
+    redirect("/remediation?error=not_found");
+  }
+
+  const { role, entitlement } = await requireOrgAccess(
+    orgRes.organizationId,
+    "suggestion:approve",
+    { requirePaid: true },
   );
 
   if (!entitlement.hasPaidAccess) {
@@ -84,26 +41,24 @@ export async function approveSuggestionAction(formData: FormData) {
     redirect(`/remediation/${suggestionId}?error=forbidden`);
   }
 
+  const suggestion = await loadRemediationSuggestionForOrg(
+    suggestionId,
+    orgRes.organizationId,
+  );
+  if (!suggestion) {
+    redirect("/remediation?error=not_found");
+  }
+
   if (suggestion.status !== "DRAFT" && suggestion.status !== "VALIDATED") {
     redirect(`/remediation/${suggestionId}?error=invalid_transition`);
   }
 
-  try {
-    await prisma.remediationSuggestion.update({
-      where: { id: suggestionId },
-      data: {
-        status: "APPROVED",
-        appliedBy: user.id,
-        appliedAt: new Date(),
-      },
-    });
-    if (suggestion.recipeId) {
-      await prisma.remediationRecipe.update({
-        where: { id: suggestion.recipeId },
-        data: { successCount: { increment: 1 } },
-      });
-    }
-  } catch {
+  const outcome = await updateRemediationSuggestionApproved(
+    suggestionId,
+    orgRes.organizationId,
+    user.id,
+  );
+  if (!outcome.ok) {
     redirect(`/remediation/${suggestionId}?error=update_failed`);
   }
 
@@ -114,9 +69,20 @@ export async function rejectSuggestionAction(formData: FormData) {
   const user = await requireSession();
   const suggestionId = (formData.get("suggestionId") as string) || "";
 
-  const { suggestion, role, entitlement } = await requireSuggestionAccess(
-    suggestionId,
-    user.id,
+  if (!suggestionId) {
+    redirect("/remediation?error=missing_id");
+  }
+
+  const platformTruth = await getRoutePlatformTruth();
+  const orgRes = await resolveDashboardOrgMembership(user.id, platformTruth);
+  if (orgRes.kind !== "ok") {
+    redirect("/remediation?error=not_found");
+  }
+
+  const { role, entitlement } = await requireOrgAccess(
+    orgRes.organizationId,
+    "suggestion:approve",
+    { requirePaid: true },
   );
 
   if (!entitlement.hasPaidAccess) {
@@ -127,22 +93,23 @@ export async function rejectSuggestionAction(formData: FormData) {
     redirect(`/remediation/${suggestionId}?error=forbidden`);
   }
 
+  const suggestion = await loadRemediationSuggestionForOrg(
+    suggestionId,
+    orgRes.organizationId,
+  );
+  if (!suggestion) {
+    redirect("/remediation?error=not_found");
+  }
+
   if (suggestion.status === "REJECTED" || suggestion.status === "APPLIED") {
     redirect(`/remediation/${suggestionId}?error=invalid_transition`);
   }
 
-  try {
-    await prisma.remediationSuggestion.update({
-      where: { id: suggestionId },
-      data: { status: "REJECTED" },
-    });
-    if (suggestion.recipeId) {
-      await prisma.remediationRecipe.update({
-        where: { id: suggestion.recipeId },
-        data: { rejectionCount: { increment: 1 } },
-      });
-    }
-  } catch {
+  const outcome = await updateRemediationSuggestionRejected(
+    suggestionId,
+    orgRes.organizationId,
+  );
+  if (!outcome.ok) {
     redirect(`/remediation/${suggestionId}?error=update_failed`);
   }
 
@@ -153,9 +120,20 @@ export async function exportSnippetAction(formData: FormData) {
   const user = await requireSession();
   const suggestionId = (formData.get("suggestionId") as string) || "";
 
-  const { suggestion, role, entitlement } = await requireSuggestionAccess(
-    suggestionId,
-    user.id,
+  if (!suggestionId) {
+    redirect("/remediation?error=missing_id");
+  }
+
+  const platformTruth = await getRoutePlatformTruth();
+  const orgRes = await resolveDashboardOrgMembership(user.id, platformTruth);
+  if (orgRes.kind !== "ok") {
+    redirect("/remediation?error=not_found");
+  }
+
+  const { role, entitlement } = await requireOrgAccess(
+    orgRes.organizationId,
+    "suggestion:export",
+    { requirePaid: true },
   );
 
   if (!entitlement.hasPaidAccess) {
@@ -166,16 +144,23 @@ export async function exportSnippetAction(formData: FormData) {
     redirect(`/remediation/${suggestionId}?error=forbidden`);
   }
 
+  const suggestion = await loadRemediationSuggestionForOrg(
+    suggestionId,
+    orgRes.organizationId,
+  );
+  if (!suggestion) {
+    redirect("/remediation?error=not_found");
+  }
+
   if (suggestion.status !== "APPROVED" && suggestion.status !== "VALIDATED") {
     redirect(`/remediation/${suggestionId}?error=invalid_transition`);
   }
 
-  try {
-    await prisma.remediationSuggestion.update({
-      where: { id: suggestionId },
-      data: { status: "EXPORTED" },
-    });
-  } catch {
+  const outcome = await updateRemediationSuggestionExported(
+    suggestionId,
+    orgRes.organizationId,
+  );
+  if (!outcome.ok) {
     redirect(`/remediation/${suggestionId}?error=update_failed`);
   }
 

--- a/apps/web/src/app/(dashboard)/remediation/[suggestionId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/remediation/[suggestionId]/page.tsx
@@ -99,6 +99,8 @@ export default async function SuggestionDetailPage({
         forbidden: "You do not have permission for that action.",
         invalid_transition: "That action is not valid from the current status.",
         update_failed: "Update failed. Please try again.",
+        stale_session:
+          "Your organization context changed. Refresh the page and try again.",
       }[sp.error] ?? "An error occurred.")
     : null;
 
@@ -274,6 +276,11 @@ export default async function SuggestionDetailPage({
                   <form action={approveSuggestionAction}>
                     <input
                       type="hidden"
+                      name="expectedOrganizationId"
+                      value={orgRes.organizationId}
+                    />
+                    <input
+                      type="hidden"
                       name="suggestionId"
                       value={suggestionId}
                     />
@@ -289,6 +296,11 @@ export default async function SuggestionDetailPage({
                   <form action={rejectSuggestionAction}>
                     <input
                       type="hidden"
+                      name="expectedOrganizationId"
+                      value={orgRes.organizationId}
+                    />
+                    <input
+                      type="hidden"
                       name="suggestionId"
                       value={suggestionId}
                     />
@@ -302,6 +314,11 @@ export default async function SuggestionDetailPage({
                 (suggestion.status === "APPROVED" ||
                   suggestion.status === "VALIDATED") && (
                   <form action={exportSnippetAction}>
+                    <input
+                      type="hidden"
+                      name="expectedOrganizationId"
+                      value={orgRes.organizationId}
+                    />
                     <input
                       type="hidden"
                       name="suggestionId"

--- a/apps/web/src/app/(dashboard)/reviews/actions.ts
+++ b/apps/web/src/app/(dashboard)/reviews/actions.ts
@@ -12,6 +12,10 @@ import {
   loadReviewTaskForOrg,
   updateReviewTaskStatusForOrg,
 } from "@/lib/dashboard-org-scoped-prisma";
+import {
+  assertFormOrgMatchesActive,
+  parseExpectedOrgFromForm,
+} from "@/lib/dashboard-form-org";
 
 const VALID_REVIEW_STATUSES: ReviewStatus[] = [
   "PENDING",
@@ -40,6 +44,11 @@ export async function updateReviewAction(formData: FormData) {
   const orgRes = await resolveDashboardOrgMembership(user.id, platformTruth);
   if (orgRes.kind !== "ok") {
     redirect("/reviews?review_error=not_found");
+  }
+
+  const expectedOrg = parseExpectedOrgFromForm(formData);
+  if (!assertFormOrgMatchesActive(expectedOrg, orgRes.organizationId)) {
+    redirect("/reviews?review_error=stale_session");
   }
 
   await requireOrgAccess(orgRes.organizationId, "review:manage", {

--- a/apps/web/src/app/(dashboard)/reviews/actions.ts
+++ b/apps/web/src/app/(dashboard)/reviews/actions.ts
@@ -3,10 +3,15 @@
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { requireSession } from "@/lib/session";
-import { prisma } from "@/lib/db";
 import type { ReviewStatus } from "@aros/db";
-import { hasPermission } from "@aros/config";
-import { getEntitlementState, requireOrgAccess } from "@/lib/auth-guard";
+import type { Prisma } from "@aros/db";
+import { requireOrgAccess } from "@/lib/auth-guard";
+import { getRoutePlatformTruth } from "@/lib/platform-truth-cache";
+import { resolveDashboardOrgMembership } from "@/lib/route-data-boundary";
+import {
+  loadReviewTaskForOrg,
+  updateReviewTaskStatusForOrg,
+} from "@/lib/dashboard-org-scoped-prisma";
 
 const VALID_REVIEW_STATUSES: ReviewStatus[] = [
   "PENDING",
@@ -31,66 +36,36 @@ export async function updateReviewAction(formData: FormData) {
 
   const reviewStatus = status as ReviewStatus;
 
-  const task = await prisma.reviewTask.findUnique({
-    where: { id: taskId },
-    select: {
-      id: true,
-      status: true,
-      suggestion: {
-        select: {
-          cluster: {
-            select: {
-              site: {
-                select: {
-                  workspace: { select: { organizationId: true } },
-                },
-              },
-            },
-          },
-          finding: {
-            select: {
-              site: {
-                select: {
-                  workspace: { select: { organizationId: true } },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
+  const platformTruth = await getRoutePlatformTruth();
+  const orgRes = await resolveDashboardOrgMembership(user.id, platformTruth);
+  if (orgRes.kind !== "ok") {
+    redirect("/reviews?review_error=not_found");
+  }
+
+  await requireOrgAccess(orgRes.organizationId, "review:manage", {
+    requirePaid: true,
   });
 
+  const task = await loadReviewTaskForOrg(taskId, orgRes.organizationId);
   if (!task) {
     redirect("/reviews?review_error=not_found");
   }
 
-  const orgId =
-    task.suggestion?.cluster?.site.workspace.organizationId ??
-    task.suggestion?.finding?.site.workspace.organizationId;
+  const data: Prisma.ReviewTaskUpdateInput = {
+    status: reviewStatus,
+    assignee: { connect: { id: user.id } },
+    reviewedAt:
+      reviewStatus === "APPROVED" || reviewStatus === "REJECTED"
+        ? new Date()
+        : undefined,
+  };
 
-  if (!orgId) {
-    redirect("/reviews?review_error=no_org");
-  }
-
-  // Use centralized auth guard
-  const ctx = await requireOrgAccess(orgId, "review:manage", {
-    requirePaid: true,
-  });
-
-  try {
-    await prisma.reviewTask.update({
-      where: { id: taskId },
-      data: {
-        status: reviewStatus,
-        assigneeId: user.id,
-        reviewedAt:
-          reviewStatus === "APPROVED" || reviewStatus === "REJECTED"
-            ? new Date()
-            : undefined,
-      },
-    });
-  } catch {
+  const updated = await updateReviewTaskStatusForOrg(
+    taskId,
+    orgRes.organizationId,
+    data,
+  );
+  if (!updated) {
     redirect("/reviews?review_error=update_failed");
   }
 

--- a/apps/web/src/app/(dashboard)/reviews/page.tsx
+++ b/apps/web/src/app/(dashboard)/reviews/page.tsx
@@ -43,6 +43,8 @@ export default async function ReviewsPage({
         no_org: "Could not determine organization for this review.",
         forbidden: "You do not have permission to update this review.",
         update_failed: "Failed to update review. Please try again.",
+        stale_session:
+          "Your organization context changed. Refresh the page and try again.",
       }[params.review_error] ?? "An error occurred.")
     : null;
 
@@ -214,6 +216,11 @@ export default async function ReviewsPage({
                 <div className="flex gap-2">
                   {task.status === "PENDING" && (
                     <form action={updateReviewAction}>
+                      <input
+                        type="hidden"
+                        name="expectedOrganizationId"
+                        value={orgRes.organizationId}
+                      />
                       <input type="hidden" name="taskId" value={task.id} />
                       <input type="hidden" name="status" value="IN_PROGRESS" />
                       <button type="submit" className="btn-secondary text-xs">
@@ -224,6 +231,11 @@ export default async function ReviewsPage({
                   {task.status === "IN_PROGRESS" && (
                     <>
                       <form action={updateReviewAction}>
+                        <input
+                          type="hidden"
+                          name="expectedOrganizationId"
+                          value={orgRes.organizationId}
+                        />
                         <input type="hidden" name="taskId" value={task.id} />
                         <input type="hidden" name="status" value="APPROVED" />
                         <button type="submit" className="btn-primary text-xs">
@@ -231,6 +243,11 @@ export default async function ReviewsPage({
                         </button>
                       </form>
                       <form action={updateReviewAction}>
+                        <input
+                          type="hidden"
+                          name="expectedOrganizationId"
+                          value={orgRes.organizationId}
+                        />
                         <input type="hidden" name="taskId" value={task.id} />
                         <input type="hidden" name="status" value="REJECTED" />
                         <button type="submit" className="btn-danger text-xs">

--- a/apps/web/src/app/(dashboard)/settings/api-keys/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/actions.ts
@@ -3,13 +3,19 @@
 import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
-import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
 import { requireOrgAccess } from "@/lib/auth-guard";
 import { ApiError } from "@aros/shared";
 import { hasPermission } from "@aros/config";
 import crypto from "node:crypto";
 import { logProductEvent, PRODUCT_EVENT_ACTIONS } from "@/lib/product-events";
+import {
+  createApiKeyForOrg,
+  findActiveApiKeyForOrg,
+  listApiKeyUsageForOrg,
+  revokeApiKeyForOrg,
+  rotateApiKeyForOrg,
+} from "@/lib/dashboard-org-scoped-prisma";
 
 const API_KEY_PREFIX = "arsk_live_";
 const KEY_BYTES = 32; // 64 hex chars
@@ -150,22 +156,13 @@ export async function createApiKeyAction(
   const { plaintext, hash } = await generateApiKey();
 
   try {
-    const apiKey = await prisma.apiKey.create({
-      data: {
-        organizationId,
-        keyHash: hash,
-        name,
-        scopes,
-        rateLimitPerMinute,
-        expiresAt,
-      },
-      select: {
-        id: true,
-        name: true,
-        scopes: true,
-        rateLimitPerMinute: true,
-        expiresAt: true,
-      },
+    const apiKey = await createApiKeyForOrg({
+      organizationId: ctx.organizationId,
+      keyHash: hash,
+      name,
+      scopes,
+      rateLimitPerMinute,
+      expiresAt,
     });
 
     revalidatePath("/settings/api-keys");
@@ -238,20 +235,7 @@ export async function rotateApiKeyAction(
   }
 
   // Verify key exists and belongs to this organization
-  const existingKey = await prisma.apiKey.findFirst({
-    where: {
-      id: keyId,
-      organizationId,
-      isActive: true,
-    },
-    select: {
-      id: true,
-      name: true,
-      scopes: true,
-      rateLimitPerMinute: true,
-      expiresAt: true,
-    },
-  });
+  const existingKey = await findActiveApiKeyForOrg(ctx.organizationId, keyId);
 
   if (!existingKey) {
     return { success: false, error: "API key not found or already revoked" };
@@ -261,22 +245,12 @@ export async function rotateApiKeyAction(
   const { plaintext, hash } = await generateApiKey();
 
   try {
-    // Delete old key and create new one with same settings in a transaction
-    const [newKey] = await prisma.$transaction([
-      prisma.apiKey.create({
-        data: {
-          organizationId,
-          keyHash: hash,
-          name: existingKey.name,
-          scopes: existingKey.scopes as string[],
-          rateLimitPerMinute: existingKey.rateLimitPerMinute,
-          expiresAt: existingKey.expiresAt,
-        },
-      }),
-      prisma.apiKey.delete({
-        where: { id: keyId },
-      }),
-    ]);
+    const newKey = await rotateApiKeyForOrg(ctx.organizationId, keyId, hash, {
+      name: existingKey.name,
+      scopes: existingKey.scopes as string[],
+      rateLimitPerMinute: existingKey.rateLimitPerMinute,
+      expiresAt: existingKey.expiresAt,
+    });
 
     revalidatePath("/settings/api-keys");
 
@@ -316,24 +290,13 @@ export async function revokeApiKeyAction(formData: FormData): Promise<void> {
 
   // Soft delete by setting isActive to false
   try {
-    const key = await prisma.apiKey.findFirst({
-      where: {
-        id: keyId,
-        organizationId,
-        isActive: true,
-      },
-    });
+    const revoked = await revokeApiKeyForOrg(ctx.organizationId, keyId);
 
-    if (!key) {
+    if (!revoked.ok) {
       redirectApiKeysQuery({
         error: "API key not found or already revoked",
       });
     }
-
-    await prisma.apiKey.update({
-      where: { id: keyId },
-      data: { isActive: false },
-    });
 
     revalidatePath("/settings/api-keys");
     redirectApiKeysQuery({ status: "revoked" });
@@ -354,26 +317,7 @@ export async function getApiKeyUsageStats(organizationId: string) {
     throw ApiError.forbidden("Only admins and owners can view API key usage");
   }
 
-  const keys = await prisma.apiKey.findMany({
-    where: {
-      organizationId,
-      isActive: true,
-    },
-    include: {
-      mcpUsageLogs: {
-        select: {
-          id: true,
-          createdAt: true,
-        },
-        orderBy: {
-          createdAt: "desc",
-        },
-      },
-    },
-    orderBy: {
-      createdAt: "desc",
-    },
-  });
+  const keys = await listApiKeyUsageForOrg(ctx.organizationId);
 
   return keys.map((key) => ({
     id: key.id,

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/actions.ts
@@ -1,10 +1,13 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { prisma } from "@/lib/db";
 import { getCrawlQueue, type CrawlJobData } from "@/lib/queue";
 import { requireSiteAccess } from "@/lib/auth-guard";
 import { ApiError } from "@aros/shared";
+import {
+  markCrawlRunFailedQueue,
+  startCrawlForVerifiedSite,
+} from "@/lib/dashboard-org-scoped-prisma";
 
 export async function startCrawlAction(formData: FormData) {
   const siteId = formData.get("siteId") as string;
@@ -17,37 +20,20 @@ export async function startCrawlAction(formData: FormData) {
       requirePaid: true,
     });
 
-    // Check for running crawl (scoped to the site we verified access to)
-    const runningCrawl = await prisma.crawlRun.findFirst({
-      where: { siteId: ctx.siteId, status: { in: ["PENDING", "RUNNING"] } },
+    const outcome = await startCrawlForVerifiedSite({
+      siteId: ctx.siteId,
+      organizationId: ctx.organizationId,
+      userId: ctx.user.id,
     });
-    if (runningCrawl) {
+
+    if (outcome.kind === "already_running") {
       redirect(`/sites/${ctx.siteId}`);
     }
-
-    const site = await prisma.site.findUnique({
-      where: { id: ctx.siteId },
-      include: { crawlConfig: true },
-    });
-
-    if (!site) {
+    if (outcome.kind === "site_not_found") {
       redirect(`/sites/${ctx.siteId}?error=site_not_found`);
     }
 
-    const config = site.crawlConfig;
-    const crawlRun = await prisma.crawlRun.create({
-      data: { siteId: ctx.siteId, status: "PENDING" },
-    });
-
-    await prisma.auditLog.create({
-      data: {
-        organizationId: ctx.organizationId,
-        userId: ctx.user.id,
-        action: "crawl.started",
-        entityType: "CrawlRun",
-        entityId: crawlRun.id,
-      },
-    });
+    const { crawlRun, site, config } = outcome;
 
     try {
       const jobData: CrawlJobData = {
@@ -73,24 +59,7 @@ export async function startCrawlAction(formData: FormData) {
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : "Queue add failed";
-      await prisma.crawlRun.update({
-        where: { id: crawlRun.id },
-        data: {
-          status: "FAILED",
-          errorMessage: `Crawl queue unavailable: ${message}`,
-          completedAt: new Date(),
-        },
-      });
-      await prisma.auditLog.create({
-        data: {
-          organizationId: ctx.organizationId,
-          userId: ctx.user.id,
-          action: "crawl.enqueue_failed",
-          entityType: "CrawlRun",
-          entityId: crawlRun.id,
-          metadata: { siteId: ctx.siteId, message },
-        },
-      });
+      await markCrawlRunFailedQueue(crawlRun.id, ctx, message);
       redirect(`/sites/${ctx.siteId}?crawl_error=queue_unavailable`);
     }
 

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/scan-actions.ts
@@ -1,14 +1,17 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import {
-  enqueueSiteScan,
-  persistPostCrawlScanKickoffAfterEnqueue,
-} from '@aros/core-services';
 import { ApiError } from '@aros/shared';
-import { prisma } from '@/lib/db';
 import { requireSiteAccess } from '@/lib/auth-guard';
 import { logProductEvent, PRODUCT_EVENT_ACTIONS } from '@/lib/product-events';
+import {
+  countScanRunsForOrg,
+  createScanAuditLog,
+  enqueueSiteScanForDashboard,
+  findCompletedCrawlForSiteOrg,
+  persistPostCrawlKickoffAfterEnqueueDashboard,
+  setPostCrawlScanKickoffRequested,
+} from '@/lib/dashboard-org-scoped-prisma';
 import type { ScanSiteActionState } from './scan-action-state';
 
 export async function startSiteScanAction(
@@ -24,23 +27,18 @@ export async function startSiteScanAction(
     const ctx = await requireSiteAccess(siteId, 'scan:start', {
       requirePaid: true,
     });
-    const result = await enqueueSiteScan(
-      { prisma },
-      {
-        siteId: ctx.siteId,
-        organizationId: ctx.organizationId,
-        monthlyScanLimit: ctx.subscription?.maxScansPerMonth,
-        crawlRunId: null,
-        trigger: 'operator',
-        userId: ctx.user.id,
-      }
-    );
+    const result = await enqueueSiteScanForDashboard({
+      siteId: ctx.siteId,
+      organizationId: ctx.organizationId,
+      monthlyScanLimit: ctx.subscription?.maxScansPerMonth,
+      crawlRunId: null,
+      trigger: 'operator',
+      userId: ctx.user.id,
+    });
 
     if (result.ok) {
       if (result.kind === 'queued') {
-        const priorCount = await prisma.scanRun.count({
-          where: { site: { workspace: { organizationId: ctx.organizationId } } },
-        });
+        const priorCount = await countScanRunsForOrg(ctx.organizationId);
         if (priorCount <= 1) {
           await logProductEvent({
             organizationId: ctx.organizationId,
@@ -136,72 +134,53 @@ export async function retryPostCrawlScanKickoffAction(formData: FormData) {
     const ctx = await requireSiteAccess(siteId, 'scan:start', {
       requirePaid: true,
     });
-    const crawl = await prisma.crawlRun.findFirst({
-      where: {
-        id: crawlRunId,
-        siteId: ctx.siteId,
-        status: 'COMPLETED',
-        pagesCrawled: { gt: 0 },
-        site: { workspace: { organizationId: ctx.organizationId } },
-      },
-      select: { id: true },
-    });
+    const crawl = await findCompletedCrawlForSiteOrg(
+      crawlRunId,
+      ctx.siteId,
+      ctx.organizationId
+    );
     if (!crawl) {
       redirect(`/sites/${siteId}`);
     }
 
-    await prisma.crawlRun.update({
-      where: { id: crawlRunId },
-      data: { postCrawlScanKickoffStatus: 'REQUESTED' },
+    await setPostCrawlScanKickoffRequested(crawlRunId);
+
+    const result = await enqueueSiteScanForDashboard({
+      siteId: ctx.siteId,
+      organizationId: ctx.organizationId,
+      monthlyScanLimit: ctx.subscription?.maxScansPerMonth,
+      crawlRunId,
+      trigger: 'operator',
+      userId: ctx.user.id,
     });
 
-    const result = await enqueueSiteScan(
-      { prisma },
-      {
-        siteId: ctx.siteId,
-        organizationId: ctx.organizationId,
-        monthlyScanLimit: ctx.subscription?.maxScansPerMonth,
-        crawlRunId,
-        trigger: 'operator',
-        userId: ctx.user.id,
-      }
-    );
-
-    await persistPostCrawlScanKickoffAfterEnqueue(prisma, crawlRunId, result);
+    await persistPostCrawlKickoffAfterEnqueueDashboard(crawlRunId, result);
 
     if (result.ok && result.kind === 'queued') {
-      await prisma.auditLog
-        .create({
-          data: {
-            organizationId: ctx.organizationId,
-            userId: ctx.user.id,
-            action: 'scan.queued',
-            entityType: 'CrawlRun',
-            entityId: crawlRunId,
-            metadata: { siteId: ctx.siteId, crawlRunId, trigger: 'operator_retry' },
-          },
-        })
-        .catch(() => undefined);
+      await createScanAuditLog({
+        organizationId: ctx.organizationId,
+        userId: ctx.user.id,
+        action: 'scan.queued',
+        entityType: 'CrawlRun',
+        entityId: crawlRunId,
+        metadata: { siteId: ctx.siteId, crawlRunId, trigger: 'operator_retry' },
+      }).catch(() => undefined);
     }
 
     if (!result.ok && result.kind === 'queue_unavailable') {
-      await prisma.auditLog
-        .create({
-          data: {
-            organizationId: ctx.organizationId,
-            userId: ctx.user.id,
-            action: 'scan.enqueue_failed',
-            entityType: 'CrawlRun',
-            entityId: crawlRunId,
-            metadata: {
-              siteId: ctx.siteId,
-              scanRunId: result.scanRunId,
-              reason: 'queue_unavailable',
-              trigger: 'operator_retry',
-            },
-          },
-        })
-        .catch(() => undefined);
+      await createScanAuditLog({
+        organizationId: ctx.organizationId,
+        userId: ctx.user.id,
+        action: 'scan.enqueue_failed',
+        entityType: 'CrawlRun',
+        entityId: crawlRunId,
+        metadata: {
+          siteId: ctx.siteId,
+          scanRunId: result.scanRunId,
+          reason: 'queue_unavailable',
+          trigger: 'operator_retry',
+        },
+      }).catch(() => undefined);
     }
   } catch (e) {
     if (e instanceof ApiError && e.code === 'SUBSCRIPTION_REQUIRED') {

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.test.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.test.ts
@@ -3,7 +3,7 @@ import { updateAutoScanAfterCrawlAction } from './actions';
 
 vi.mock('@/lib/db', () => ({
   prisma: {
-    crawlConfig: { update: vi.fn() },
+    crawlConfig: { updateMany: vi.fn() },
     auditLog: { create: vi.fn() },
   },
 }));
@@ -29,7 +29,7 @@ describe('updateAutoScanAfterCrawlAction', () => {
       siteId: 's1',
       workspaceId: 'w1',
     } as never);
-    vi.mocked(prisma.crawlConfig.update).mockResolvedValue({} as never);
+    vi.mocked(prisma.crawlConfig.updateMany).mockResolvedValue({ count: 1 } as never);
     vi.mocked(prisma.auditLog.create).mockResolvedValue({} as never);
   });
 
@@ -38,8 +38,8 @@ describe('updateAutoScanAfterCrawlAction', () => {
     fd.set('siteId', 's1');
     const result = await updateAutoScanAfterCrawlAction(undefined, fd);
     expect(result).toEqual({ ok: true });
-    expect(prisma.crawlConfig.update).toHaveBeenCalledWith({
-      where: { siteId: 's1' },
+    expect(prisma.crawlConfig.updateMany).toHaveBeenCalledWith({
+      where: { siteId: 's1', site: { workspace: { organizationId: 'o1' } } },
       data: { autoScanAfterCrawl: false },
     });
   });
@@ -50,8 +50,8 @@ describe('updateAutoScanAfterCrawlAction', () => {
     fd.set('autoScanAfterCrawl', 'on');
     const result = await updateAutoScanAfterCrawlAction(undefined, fd);
     expect(result).toEqual({ ok: true });
-    expect(prisma.crawlConfig.update).toHaveBeenCalledWith({
-      where: { siteId: 's1' },
+    expect(prisma.crawlConfig.updateMany).toHaveBeenCalledWith({
+      where: { siteId: 's1', site: { workspace: { organizationId: 'o1' } } },
       data: { autoScanAfterCrawl: true },
     });
   });

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.ts
@@ -1,8 +1,11 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { prisma } from '@/lib/db';
 import { requireSiteAccess } from '@/lib/auth-guard';
+import {
+  createScanAuditLog,
+  updateCrawlConfigAutoScan,
+} from '@/lib/dashboard-org-scoped-prisma';
 
 export type AutoScanSettingsState = { ok: true } | { ok: false; error: string };
 
@@ -21,23 +24,23 @@ export async function updateAutoScanAfterCrawlAction(
     });
     const enabled = formData.get('autoScanAfterCrawl') === 'on';
 
-    await prisma.crawlConfig.update({
-      where: { siteId: ctx.siteId },
-      data: { autoScanAfterCrawl: enabled },
-    });
+    const updated = await updateCrawlConfigAutoScan(
+      ctx.siteId,
+      ctx.organizationId,
+      enabled
+    );
+    if (!updated) {
+      return { ok: false, error: 'Could not save settings.' };
+    }
 
-    await prisma.auditLog
-      .create({
-        data: {
-          organizationId: ctx.organizationId,
-          userId: ctx.user.id,
-          action: 'crawl.auto_scan_after_crawl.updated',
-          entityType: 'CrawlConfig',
-          entityId: ctx.siteId,
-          metadata: { autoScanAfterCrawl: enabled },
-        },
-      })
-      .catch(() => undefined);
+    await createScanAuditLog({
+      organizationId: ctx.organizationId,
+      userId: ctx.user.id,
+      action: 'crawl.auto_scan_after_crawl.updated',
+      entityType: 'CrawlConfig',
+      entityId: ctx.siteId,
+      metadata: { autoScanAfterCrawl: enabled },
+    }).catch(() => undefined);
 
     revalidatePath(`/sites/${siteId}`);
     revalidatePath(`/sites/${siteId}/settings`);

--- a/apps/web/src/app/(dashboard)/sites/new/actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/new/actions.ts
@@ -3,11 +3,16 @@
 import { redirect } from "next/navigation";
 import { requireSession } from "@/lib/session";
 import { ApiError } from "@aros/shared";
-import { prisma } from "@/lib/db";
 import { getCrawlQueue, type CrawlJobData } from "@/lib/queue";
 import { resolveDashboardOrgMembership } from "@/lib/route-data-boundary";
 import { getRoutePlatformTruth } from "@/lib/platform-truth-cache";
 import { requireOrgAccess } from "@/lib/auth-guard";
+import {
+  countSitesForOrg,
+  createSiteWithCrawlAndAudit,
+  loadMembershipWorkspaceForAddSite,
+  markCrawlRunQueueRetry,
+} from "@/lib/dashboard-org-scoped-prisma";
 
 interface AddSiteState {
   error: string | null;
@@ -58,22 +63,10 @@ export async function addSiteAction(
     throw error;
   }
 
-  const membership = await prisma.membership.findUnique({
-    where: {
-      userId_organizationId: {
-        userId: user.id,
-        organizationId: orgRes.organizationId,
-      },
-    },
-    include: {
-      organization: {
-        include: {
-          workspaces: { take: 1 },
-          subscription: true,
-        },
-      },
-    },
-  });
+  const membership = await loadMembershipWorkspaceForAddSite(
+    user.id,
+    orgRes.organizationId,
+  );
 
   if (!membership || membership.organization.workspaces.length === 0) {
     return { error: "No workspace found. Please contact support." };
@@ -83,9 +76,7 @@ export async function addSiteAction(
   const subscription = membership.organization.subscription;
 
   if (subscription) {
-    const siteCount = await prisma.site.count({
-      where: { workspace: { organizationId: orgRes.organizationId } },
-    });
+    const siteCount = await countSitesForOrg(orgRes.organizationId);
     if (siteCount >= subscription.maxDomains) {
       return {
         error: `You have reached your plan limit of ${subscription.maxDomains} site(s). Please upgrade.`,
@@ -97,46 +88,18 @@ export async function addSiteAction(
     ? Math.min(maxPages, subscription.maxPagesPerCrawl)
     : maxPages;
 
-  const result = await prisma.$transaction(async (tx) => {
-    const site = await tx.site.create({
-      data: {
-        workspaceId: workspace.id,
-        name,
-        domain,
-        environment: environment as "PRODUCTION" | "STAGING" | "DEVELOPMENT",
-      },
-    });
-
-    await tx.crawlConfig.create({
-      data: {
-        siteId: site.id,
-        sitemapUrl,
-        maxDepth,
-        maxPages: effectiveMaxPages,
-        respectRobots,
-        renderJavaScript,
-      },
-    });
-
-    const crawlRun = await tx.crawlRun.create({
-      data: {
-        siteId: site.id,
-        status: "PENDING",
-      },
-    });
-
-    await tx.auditLog.create({
-      data: {
-        organizationId: orgRes.organizationId,
-        userId: user.id,
-        action: "site.created",
-        entityType: "Site",
-        entityId: site.id,
-        metadata: { name, domain },
-      },
-    });
-
-    return { site, crawlRun };
+  const result = await createSiteWithCrawlAndAudit({
+    workspaceId: workspace.id,
+    organizationId: orgRes.organizationId,
+    userId: user.id,
+    name,
+    domain,
+    environment: environment as "PRODUCTION" | "STAGING" | "DEVELOPMENT",
+    sitemapUrl,
+    maxDepth,
+    maxPages: effectiveMaxPages,
+    respectRobots,
+    renderJavaScript,
   });
 
   try {
@@ -162,13 +125,7 @@ export async function addSiteAction(
       backoff: { type: "exponential", delay: 5000 },
     });
   } catch {
-    await prisma.crawlRun.update({
-      where: { id: result.crawlRun.id },
-      data: {
-        status: "PENDING",
-        errorMessage: "Queue not available - will retry",
-      },
-    });
+    await markCrawlRunQueueRetry(result.crawlRun.id);
   }
 
   redirect(`/sites/${result.site.id}`);

--- a/apps/web/src/app/(dashboard)/system/operator/actions.ts
+++ b/apps/web/src/app/(dashboard)/system/operator/actions.ts
@@ -1,132 +1,31 @@
 "use server";
 
 import { cookies } from "next/headers";
-import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/session";
-import type { MemberRole, SubscriptionStatus } from "@aros/db";
+import type { MemberRole } from "@aros/db";
 import { ApiError } from "@aros/shared";
 import { resolveOperatorScopedMembership } from "@/lib/operator-org-resolution";
+import { loadMembershipsForOperatorResolution } from "@/lib/operator-membership-db";
+import {
+  createOperatorDismissAudit,
+  fetchOperatorHealthPayload,
+} from "@/lib/operator-console-queries";
+
+export type {
+  StaleSite,
+  OrgWithSubscription,
+  FailedRun,
+  AgedFinding,
+  HighImpactCluster,
+  WorkQueueItem,
+  AccountHealthRollup,
+  CustomerWorkQueue,
+  RenewalWatchlist,
+  ExceptionRouting,
+  OperatorHealthPayload,
+} from "@/lib/operator-console-types";
 
 const ACTIVE_ORG_COOKIE = "aros_active_org";
-
-const DAYS_30_MS = 30 * 24 * 60 * 60 * 1000;
-const DAYS_90_MS = 90 * 24 * 60 * 60 * 1000;
-const DAYS_7_MS = 7 * 24 * 60 * 60 * 1000;
-
-export interface StaleSite {
-  id: string;
-  name: string;
-  domain: string;
-  lastScanAt: Date | null;
-  daysStale: number;
-  openFindings: number;
-  criticalFindings: number;
-}
-
-export interface OrgWithSubscription {
-  id: string;
-  name: string;
-  slug: string;
-  siteCount: number;
-  subscription: {
-    status: SubscriptionStatus;
-    plan: string;
-    currentPeriodEnd: Date | null;
-    cancelAtPeriodEnd: boolean;
-  } | null;
-  daysToRenewal: number | null;
-  usagePercent: number;
-}
-
-export interface FailedRun {
-  id: string;
-  type: "crawl" | "scan";
-  siteId: string;
-  siteName: string;
-  siteDomain: string;
-  errorMessage: string | null;
-  failedAt: Date;
-}
-
-export interface AgedFinding {
-  id: string;
-  ruleId: string;
-  impact: string;
-  description: string;
-  siteId: string;
-  siteName: string;
-  siteDomain: string;
-  daysOpen: number;
-  occurrenceCount: number;
-  /** Distinct completed scan runs where this fingerprint was re-detected. */
-  distinctScanRunsObserved: number;
-}
-
-export interface HighImpactCluster {
-  id: string;
-  name: string;
-  siteId: string;
-  siteName: string;
-  siteDomain: string;
-  severity: string;
-  impactScore: number;
-  findingCount: number;
-  pageCount: number;
-}
-
-export interface WorkQueueItem {
-  id: string;
-  type: "onboarding" | "attention" | "churn-risk";
-  priority: "high" | "medium" | "low";
-  title: string;
-  description: string;
-  orgId: string;
-  orgName: string;
-  entityId?: string;
-  entityName?: string;
-  createdAt: Date;
-  actionLabel: string;
-  actionHref: string;
-}
-
-export interface AccountHealthRollup {
-  staleSites: StaleSite[];
-  staleSitesCount: number;
-  criticalFindingsCount: number;
-  criticalFindings: AgedFinding[];
-  subsNearRenewal: OrgWithSubscription[];
-  subsNearRenewalCount: number;
-  failedRuns: FailedRun[];
-  failedRunsCount: number;
-}
-
-export interface CustomerWorkQueue {
-  items: WorkQueueItem[];
-  highPriorityCount: number;
-  mediumPriorityCount: number;
-  onboardingCount: number;
-}
-
-export interface RenewalWatchlist {
-  pastDue: OrgWithSubscription[];
-  failedPayment: OrgWithSubscription[];
-  approachingLimits: OrgWithSubscription[];
-  totalAtRisk: number;
-}
-
-export interface ExceptionRouting {
-  criticalAgedFindings: AgedFinding[];
-  highImpactClusters: HighImpactCluster[];
-  totalExceptions: number;
-}
-
-export interface OperatorHealthPayload {
-  accountHealth: AccountHealthRollup;
-  workQueue: CustomerWorkQueue;
-  renewalWatchlist: RenewalWatchlist;
-  exceptionRouting: ExceptionRouting;
-  generatedAt: Date;
-}
 
 async function requireOperatorAccess(): Promise<{
   user: { id: string; email: string; name: string | null };
@@ -135,10 +34,7 @@ async function requireOperatorAccess(): Promise<{
 }> {
   const user = await requireSession();
 
-  const memberships = await prisma.membership.findMany({
-    where: { userId: user.id },
-    select: { organizationId: true, role: true, createdAt: true },
-  });
+  const memberships = await loadMembershipsForOperatorResolution(user.id);
 
   if (memberships.length === 0) {
     throw ApiError.forbidden("No organization membership found");
@@ -168,368 +64,17 @@ async function requireOperatorAccess(): Promise<{
   };
 }
 
-export async function getOperatorHealthData(): Promise<OperatorHealthPayload> {
+export async function getOperatorHealthData() {
   const ctx = await requireOperatorAccess();
-  const now = new Date();
-  const thirtyDaysAgo = new Date(now.getTime() - DAYS_30_MS);
-  const ninetyDaysAgo = new Date(now.getTime() - DAYS_90_MS);
-  const sevenDaysAgo = new Date(now.getTime() - DAYS_7_MS);
-  const thirtyDaysFromNow = new Date(now.getTime() + DAYS_30_MS);
-
-  const [
-    staleSitesData,
-    criticalFindingsData,
-    subsData,
-    failedRunsData,
-    clustersData,
-  ] = await Promise.all([
-    // Stale sites (no scan in 30+ days)
-    prisma.site.findMany({
-      where: {
-        workspace: { organizationId: ctx.organizationId },
-        OR: [
-          { scanRuns: { none: {} } },
-          {
-            scanRuns: {
-              every: { completedAt: { lt: thirtyDaysAgo } },
-            },
-          },
-        ],
-      },
-      include: {
-        workspace: { select: { organizationId: true } },
-        scanRuns: { orderBy: { completedAt: "desc" }, take: 1 },
-        canonicalFindings: {
-          where: { status: "OPEN" },
-          select: { id: true, impact: true },
-        },
-      },
-    }),
-
-    // Critical findings open > 90 days
-    prisma.canonicalFinding.findMany({
-      where: {
-        site: { workspace: { organizationId: ctx.organizationId } },
-        status: "OPEN",
-        impact: "CRITICAL",
-        firstSeenAt: { lt: ninetyDaysAgo },
-      },
-      include: {
-        site: { select: { id: true, name: true, domain: true } },
-      },
-      orderBy: [
-        { distinctScanRunsObserved: "desc" },
-        { reopenedCount: "desc" },
-        { firstSeenAt: "asc" },
-      ],
-      take: 50,
-    }),
-
-    // Subscription data for renewal/expiry tracking
-    prisma.organization.findUnique({
-      where: { id: ctx.organizationId },
-      include: {
-        subscription: true,
-        workspaces: {
-          include: {
-            _count: { select: { sites: true } },
-          },
-        },
-        _count: { select: { memberships: true } },
-      },
-    }),
-
-    // Failed runs in last 7 days
-    prisma.$transaction([
-      prisma.crawlRun.findMany({
-        where: {
-          site: { workspace: { organizationId: ctx.organizationId } },
-          status: "FAILED",
-          createdAt: { gte: sevenDaysAgo },
-        },
-        include: { site: { select: { id: true, name: true, domain: true } } },
-        orderBy: { createdAt: "desc" },
-      }),
-      prisma.scanRun.findMany({
-        where: {
-          site: { workspace: { organizationId: ctx.organizationId } },
-          status: "FAILED",
-          createdAt: { gte: sevenDaysAgo },
-        },
-        include: { site: { select: { id: true, name: true, domain: true } } },
-        orderBy: { createdAt: "desc" },
-      }),
-    ]),
-
-    // High impact clusters
-    prisma.issueCluster.findMany({
-      where: {
-        site: { workspace: { organizationId: ctx.organizationId } },
-        impactScore: { gte: 50 },
-      },
-      include: {
-        site: { select: { id: true, name: true, domain: true } },
-        impact: true,
-      },
-      orderBy: { impactScore: "desc" },
-      take: 20,
-    }),
-  ]);
-
-  // Process stale sites
-  const staleSites: StaleSite[] = staleSitesData.map((site) => {
-    const lastScanAt = site.scanRuns[0]?.completedAt ?? null;
-    const daysStale = lastScanAt
-      ? Math.floor(
-          (now.getTime() - lastScanAt.getTime()) / (24 * 60 * 60 * 1000),
-        )
-      : 999;
-    const criticalFindings = site.canonicalFindings.filter(
-      (f) => f.impact === "CRITICAL",
-    ).length;
-
-    return {
-      id: site.id,
-      name: site.name,
-      domain: site.domain,
-      lastScanAt,
-      daysStale,
-      openFindings: site.canonicalFindings.length,
-      criticalFindings,
-    };
-  });
-
-  // Process critical findings
-  const criticalFindings: AgedFinding[] = criticalFindingsData.map((f) => ({
-    id: f.id,
-    ruleId: f.ruleId,
-    impact: f.impact,
-    description: f.description,
-    siteId: f.site.id,
-    siteName: f.site.name,
-    siteDomain: f.site.domain,
-    daysOpen: Math.floor(
-      (now.getTime() - f.firstSeenAt.getTime()) / (24 * 60 * 60 * 1000),
-    ),
-    occurrenceCount: f.occurrenceCount,
-    distinctScanRunsObserved: f.distinctScanRunsObserved,
-  }));
-
-  // Process subscriptions
-  const org = subsData;
-  const totalSites =
-    org?.workspaces.reduce((sum, w) => sum + w._count.sites, 0) ?? 0;
-  const seatCount = org?._count.memberships ?? 0;
-
-  const subsNearRenewal: OrgWithSubscription[] = [];
-  const pastDue: OrgWithSubscription[] = [];
-  const approachingLimits: OrgWithSubscription[] = [];
-
-  if (org?.subscription) {
-    const sub = org.subscription;
-    const daysToRenewal = sub.currentPeriodEnd
-      ? Math.floor(
-          (sub.currentPeriodEnd.getTime() - now.getTime()) /
-            (24 * 60 * 60 * 1000),
-        )
-      : null;
-
-    const orgSub: OrgWithSubscription = {
-      id: org.id,
-      name: org.name,
-      slug: org.slug,
-      siteCount: totalSites,
-      subscription: {
-        status: sub.status,
-        plan: sub.plan,
-        currentPeriodEnd: sub.currentPeriodEnd,
-        cancelAtPeriodEnd: sub.cancelAtPeriodEnd,
-      },
-      daysToRenewal,
-      usagePercent: Math.min(
-        100,
-        Math.round(
-          ((totalSites / Math.max(1, sub.maxDomains)) * 0.5 +
-            (seatCount / Math.max(1, sub.maxSeats)) * 0.5) *
-            100,
-        ),
-      ),
-    };
-
-    if (sub.status === "PAST_DUE") {
-      pastDue.push(orgSub);
-    } else if (daysToRenewal !== null && daysToRenewal <= 30) {
-      subsNearRenewal.push(orgSub);
-    }
-
-    if (totalSites >= sub.maxDomains * 0.8 || seatCount >= sub.maxSeats * 0.8) {
-      approachingLimits.push(orgSub);
-    }
-  }
-
-  // Process failed runs
-  const [failedCrawls, failedScans] = failedRunsData;
-  const failedRuns: FailedRun[] = [
-    ...failedCrawls.map((c) => ({
-      id: c.id,
-      type: "crawl" as const,
-      siteId: c.site.id,
-      siteName: c.site.name,
-      siteDomain: c.site.domain,
-      errorMessage: c.errorMessage,
-      failedAt: c.createdAt,
-    })),
-    ...failedScans.map((s) => ({
-      id: s.id,
-      type: "scan" as const,
-      siteId: s.site.id,
-      siteName: s.site.name,
-      siteDomain: s.site.domain,
-      errorMessage: s.errorMessage,
-      failedAt: s.createdAt,
-    })),
-  ].sort((a, b) => b.failedAt.getTime() - a.failedAt.getTime());
-
-  // Process high impact clusters
-  const highImpactClusters: HighImpactCluster[] = clustersData.map((c) => ({
-    id: c.id,
-    name: c.name,
-    siteId: c.site.id,
-    siteName: c.site.name,
-    siteDomain: c.site.domain,
-    severity: c.severity,
-    impactScore: Math.round(c.impactScore),
-    findingCount: c.findingCount,
-    pageCount: c.pageCount,
-  }));
-
-  // Build work queue
-  const workQueueItems: WorkQueueItem[] = [];
-
-  // New sites needing onboarding (created in last 7 days)
-  const newSites = await prisma.site.findMany({
-    where: {
-      workspace: { organizationId: ctx.organizationId },
-      createdAt: { gte: sevenDaysAgo },
-    },
-    include: { workspace: { include: { organization: true } } },
-  });
-
-  for (const site of newSites) {
-    workQueueItems.push({
-      id: `onboarding-${site.id}`,
-      type: "onboarding",
-      priority: "medium",
-      title: "New site needs onboarding",
-      description: `${site.name} (${site.domain}) was added recently. Verify crawl config and run initial scan.`,
-      orgId: site.workspace.organizationId,
-      orgName: site.workspace.organization.name,
-      entityId: site.id,
-      entityName: site.name,
-      createdAt: site.createdAt,
-      actionLabel: "Configure",
-      actionHref: `/sites/${site.id}/settings`,
-    });
-  }
-
-  // Sites needing attention (stale with many findings)
-  for (const site of staleSites.filter((s) => s.openFindings > 10)) {
-    workQueueItems.push({
-      id: `attention-${site.id}`,
-      type: "attention",
-      priority: site.criticalFindings > 0 ? "high" : "medium",
-      title: `Site needs attention: ${site.name}`,
-      description: `${site.openFindings} open findings (${site.criticalFindings} critical), ${site.daysStale} days since last scan.`,
-      orgId: ctx.organizationId,
-      orgName: org?.name ?? "",
-      entityId: site.id,
-      entityName: site.name,
-      createdAt: now,
-      actionLabel: "Review",
-      actionHref: `/sites/${site.id}/findings`,
-    });
-  }
-
-  // Orgs with no sites (churn risk)
-  const orgsWithNoSites = await prisma.organization.findMany({
-    where: {
-      id: ctx.organizationId,
-      workspaces: { every: { sites: { none: {} } } },
-    },
-  });
-
-  for (const o of orgsWithNoSites) {
-    workQueueItems.push({
-      id: `churn-${o.id}`,
-      type: "churn-risk",
-      priority: "high",
-      title: "No sites configured",
-      description: `${o.name} has no sites set up. Reach out to help them get started.`,
-      orgId: o.id,
-      orgName: o.name,
-      createdAt: now,
-      actionLabel: "Add site",
-      actionHref: "/sites/new",
-    });
-  }
-
-  // Sort work queue by priority
-  const priorityOrder = { high: 0, medium: 1, low: 2 };
-  workQueueItems.sort(
-    (a, b) => priorityOrder[a.priority] - priorityOrder[b.priority],
-  );
-
-  return {
-    accountHealth: {
-      staleSites,
-      staleSitesCount: staleSites.length,
-      criticalFindingsCount: criticalFindings.length,
-      criticalFindings,
-      subsNearRenewal,
-      subsNearRenewalCount: subsNearRenewal.length,
-      failedRuns: failedRuns.slice(0, 20),
-      failedRunsCount: failedRuns.length,
-    },
-    workQueue: {
-      items: workQueueItems.slice(0, 50),
-      highPriorityCount: workQueueItems.filter((i) => i.priority === "high")
-        .length,
-      mediumPriorityCount: workQueueItems.filter((i) => i.priority === "medium")
-        .length,
-      onboardingCount: workQueueItems.filter((i) => i.type === "onboarding")
-        .length,
-    },
-    renewalWatchlist: {
-      pastDue,
-      failedPayment: pastDue.filter(
-        (o) => o.subscription?.status === "PAST_DUE",
-      ),
-      approachingLimits,
-      totalAtRisk: pastDue.length + approachingLimits.length,
-    },
-    exceptionRouting: {
-      criticalAgedFindings: criticalFindings.filter((f) => f.daysOpen > 30),
-      highImpactClusters,
-      totalExceptions:
-        criticalFindings.filter((f) => f.daysOpen > 30).length +
-        highImpactClusters.length,
-    },
-    generatedAt: now,
-  };
+  return fetchOperatorHealthPayload(ctx.organizationId);
 }
 
 export async function dismissWorkQueueItem(itemId: string): Promise<void> {
   const ctx = await requireOperatorAccess();
 
-  // In a real implementation, this would persist dismissed items
-  // For now, we just validate access and return
-  await prisma.auditLog.create({
-    data: {
-      organizationId: ctx.organizationId,
-      userId: ctx.user.id,
-      action: "operator.dismiss_work_item",
-      entityType: "WorkQueueItem",
-      entityId: itemId,
-    },
+  await createOperatorDismissAudit({
+    organizationId: ctx.organizationId,
+    userId: ctx.user.id,
+    itemId,
   });
 }

--- a/apps/web/src/app/(dashboard)/system/operator/page.tsx
+++ b/apps/web/src/app/(dashboard)/system/operator/page.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { requireSession } from "@/lib/session";
-import { prisma } from "@/lib/db";
 import { hasPermission } from "@aros/config";
 import type { MemberRole } from "@aros/db";
+import { resolveOperatorDashboardPageContext } from "@/lib/operator-dashboard-org";
 import { getOperatorHealthData } from "./actions";
 import {
   AccountHealthCards,
@@ -22,13 +22,9 @@ export const metadata = { title: "Operator Dashboard" };
 export default async function OperatorDashboardPage() {
   const user = await requireSession();
 
-  // Get user's membership with organization
-  const membership = await prisma.membership.findFirst({
-    where: { userId: user.id },
-    include: { organization: { select: { id: true, name: true, slug: true } } },
-  });
+  const opCtx = await resolveOperatorDashboardPageContext(user.id);
 
-  if (!membership) {
+  if (opCtx.kind === "no_membership") {
     return (
       <div className="card text-center py-12">
         <h1 className="text-lg font-semibold text-slate-900">
@@ -41,13 +37,12 @@ export default async function OperatorDashboardPage() {
     );
   }
 
-  // Check permission
-  if (!hasPermission(membership.role as MemberRole, "org:system:view")) {
+  if (opCtx.kind === "no_operator_access") {
     redirect("/dashboard");
   }
 
   const canManage = hasPermission(
-    membership.role as MemberRole,
+    opCtx.role as MemberRole,
     "org:system:manage",
   );
 
@@ -112,7 +107,8 @@ export default async function OperatorDashboardPage() {
           </h1>
           <p className="text-slate-500 mt-1">
             Real-time account health, work queues, and exception routing for{" "}
-            {membership.organization.name}.
+            {opCtx.organizationName}. Data is scoped to your selected operator
+            organization (same as the active org cookie when you have access).
           </p>
         </div>
         <div className="flex items-center gap-3">

--- a/apps/web/src/lib/__tests__/tenant-isolation.integration.test.ts
+++ b/apps/web/src/lib/__tests__/tenant-isolation.integration.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { PrismaClient } from "@aros/db";
+import {
+  loadRemediationSuggestionForOrg,
+  loadReviewTaskForOrg,
+  updateReviewTaskStatusForOrg,
+} from "@/lib/dashboard-org-scoped-prisma";
+
+const prisma = new PrismaClient();
+
+let databaseReachable = false;
+if (process.env.DATABASE_URL) {
+  try {
+    await prisma.$connect();
+    await prisma.$queryRaw`SELECT 1`;
+    databaseReachable = true;
+  } catch {
+    await prisma.$disconnect().catch(() => {});
+  }
+}
+
+const describeDb = databaseReachable ? describe.sequential : describe.skip;
+
+describeDb("tenant isolation (org-scoped helpers)", () => {
+  const suffix = `ti-${Date.now()}`;
+  let orgAId: string;
+  let orgBId: string;
+  let siteAId: string;
+  let suggestionId: string;
+  let reviewTaskId: string;
+
+  beforeAll(async () => {
+    const orgA = await prisma.organization.create({
+      data: { name: `Tenant A ${suffix}`, slug: `tenant-a-${suffix}` },
+    });
+    orgAId = orgA.id;
+    const orgB = await prisma.organization.create({
+      data: { name: `Tenant B ${suffix}`, slug: `tenant-b-${suffix}` },
+    });
+    orgBId = orgB.id;
+
+    await prisma.subscription.create({
+      data: {
+        organizationId: orgAId,
+        plan: "STARTER",
+        status: "ACTIVE",
+        maxDomains: 10,
+        maxPagesPerCrawl: 500,
+        maxScansPerMonth: 100,
+        maxSeats: 10,
+      },
+    });
+
+    const wsA = await prisma.workspace.create({
+      data: {
+        organizationId: orgAId,
+        name: "Main",
+        slug: `main-${suffix}`,
+      },
+    });
+    await prisma.workspace.create({
+      data: {
+        organizationId: orgBId,
+        name: "Main",
+        slug: `main-b-${suffix}`,
+      },
+    });
+
+    const siteA = await prisma.site.create({
+      data: {
+        workspaceId: wsA.id,
+        name: "Site A",
+        domain: `https://a-${suffix}.example.com`,
+      },
+    });
+    siteAId = siteA.id;
+
+    const cluster = await prisma.issueCluster.create({
+      data: {
+        siteId: siteAId,
+        name: "Cluster",
+        severity: "SERIOUS",
+        impactScore: 10,
+        findingCount: 1,
+        pageCount: 1,
+      },
+    });
+
+    const suggestion = await prisma.remediationSuggestion.create({
+      data: {
+        clusterId: cluster.id,
+        type: "ALT_TEXT",
+        status: "DRAFT",
+        originalCode: "<img src=x>",
+        suggestedCode: "<img src=x alt=y>",
+        rationale: "test",
+      },
+    });
+    suggestionId = suggestion.id;
+
+    const task = await prisma.reviewTask.create({
+      data: {
+        suggestionId: suggestion.id,
+        type: "SUGGESTION_REVIEW",
+        status: "PENDING",
+        title: "Review",
+      },
+    });
+    reviewTaskId = task.id;
+  });
+
+  afterAll(async () => {
+    await prisma.reviewTask.deleteMany({ where: { id: reviewTaskId } }).catch(() => {});
+    await prisma.remediationSuggestion.deleteMany({ where: { id: suggestionId } }).catch(() => {});
+    await prisma.issueCluster.deleteMany({ where: { siteId: siteAId } }).catch(() => {});
+    await prisma.site.deleteMany({ where: { id: siteAId } }).catch(() => {});
+    await prisma.workspace.deleteMany({
+      where: { organizationId: { in: [orgAId, orgBId] } },
+    }).catch(() => {});
+    await prisma.subscription.deleteMany({ where: { organizationId: orgAId } }).catch(() => {});
+    await prisma.organization.deleteMany({ where: { id: { in: [orgAId, orgBId] } } }).catch(() => {});
+    await prisma.$disconnect();
+  });
+
+  it("does not load another org's remediation suggestion by id", async () => {
+    const row = await loadRemediationSuggestionForOrg(suggestionId, orgBId);
+    expect(row).toBeNull();
+  });
+
+  it("loads the suggestion when organization matches", async () => {
+    const row = await loadRemediationSuggestionForOrg(suggestionId, orgAId);
+    expect(row).not.toBeNull();
+    expect(row?.id).toBe(suggestionId);
+  });
+
+  it("does not load another org's review task by id", async () => {
+    const row = await loadReviewTaskForOrg(reviewTaskId, orgBId);
+    expect(row).toBeNull();
+  });
+
+  it("does not update review task when scoped to wrong org", async () => {
+    const ok = await updateReviewTaskStatusForOrg(reviewTaskId, orgBId, {
+      status: "APPROVED",
+    });
+    expect(ok).toBe(false);
+    const unchanged = await prisma.reviewTask.findUnique({
+      where: { id: reviewTaskId },
+      select: { status: true },
+    });
+    expect(unchanged?.status).toBe("PENDING");
+  });
+});

--- a/apps/web/src/lib/dashboard-form-org.test.ts
+++ b/apps/web/src/lib/dashboard-form-org.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertFormOrgMatchesActive,
+  parseExpectedOrgFromForm,
+} from "./dashboard-form-org";
+
+describe("dashboard-form-org", () => {
+  it("parses expected org from FormData", () => {
+    const fd = new FormData();
+    fd.set("expectedOrganizationId", " org-1 ");
+    expect(parseExpectedOrgFromForm(fd)).toBe("org-1");
+  });
+
+  it("returns null when field absent", () => {
+    expect(parseExpectedOrgFromForm(new FormData())).toBeNull();
+  });
+
+  it("allows submit when no expected org (backwards compatible)", () => {
+    expect(assertFormOrgMatchesActive(null, "org-a")).toBe(true);
+  });
+
+  it("rejects mismatch", () => {
+    expect(assertFormOrgMatchesActive("org-a", "org-b")).toBe(false);
+  });
+
+  it("accepts exact match", () => {
+    expect(assertFormOrgMatchesActive("org-a", "org-a")).toBe(true);
+  });
+});

--- a/apps/web/src/lib/dashboard-form-org.ts
+++ b/apps/web/src/lib/dashboard-form-org.ts
@@ -1,0 +1,18 @@
+/**
+ * Validates that a server action received the same organization the page rendered under.
+ * Mitigates stale forms after org switch / multi-tab without weakening scoped queries.
+ */
+export function parseExpectedOrgFromForm(formData: FormData): string | null {
+  const raw = formData.get("expectedOrganizationId");
+  if (raw == null) return null;
+  const s = String(raw).trim();
+  return s.length > 0 ? s : null;
+}
+
+export function assertFormOrgMatchesActive(
+  expectedFromForm: string | null,
+  activeOrganizationId: string,
+): boolean {
+  if (!expectedFromForm) return true;
+  return expectedFromForm === activeOrganizationId;
+}

--- a/apps/web/src/lib/dashboard-org-scoped-prisma.test.ts
+++ b/apps/web/src/lib/dashboard-org-scoped-prisma.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const findFirstRemediation = vi.fn();
+const updateManyRemediation = vi.fn();
+const findFirstReviewTask = vi.fn();
+const updateManyReviewTask = vi.fn();
+const findFirstApiKey = vi.fn();
+const updateManyCrawlConfig = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    remediationSuggestion: {
+      findFirst: (...args: unknown[]) => findFirstRemediation(...args),
+      updateMany: (...args: unknown[]) => updateManyRemediation(...args),
+    },
+    remediationRecipe: { update: vi.fn() },
+    reviewTask: {
+      findFirst: (...args: unknown[]) => findFirstReviewTask(...args),
+      updateMany: (...args: unknown[]) => updateManyReviewTask(...args),
+    },
+    apiKey: {
+      findFirst: (...args: unknown[]) => findFirstApiKey(...args),
+      update: vi.fn(),
+    },
+    crawlConfig: {
+      updateMany: (...args: unknown[]) => updateManyCrawlConfig(...args),
+    },
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
+  },
+}));
+
+vi.mock("@aros/core-services", () => ({
+  enqueueSiteScan: vi.fn(),
+  persistPostCrawlScanKickoffAfterEnqueue: vi.fn(),
+}));
+
+import {
+  loadRemediationSuggestionForOrg,
+  loadReviewTaskForOrg,
+  revokeApiKeyForOrg,
+  updateCrawlConfigAutoScan,
+  updateReviewTaskStatusForOrg,
+} from "./dashboard-org-scoped-prisma";
+
+describe("dashboard-org-scoped-prisma", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scopes remediation suggestion load by organizationId in the where clause", async () => {
+    findFirstRemediation.mockResolvedValueOnce(null);
+    await loadRemediationSuggestionForOrg("sug-1", "org-a");
+    expect(findFirstRemediation).toHaveBeenCalledTimes(1);
+    const arg = findFirstRemediation.mock.calls[0][0];
+    expect(arg.where.id).toBe("sug-1");
+    expect(arg.where.OR).toBeDefined();
+    expect(JSON.stringify(arg.where)).toContain("org-a");
+  });
+
+  it("scopes review task load by organizationId in the where clause", async () => {
+    findFirstReviewTask.mockResolvedValueOnce(null);
+    await loadReviewTaskForOrg("task-1", "org-b");
+    expect(findFirstReviewTask).toHaveBeenCalledTimes(1);
+    const arg = findFirstReviewTask.mock.calls[0][0];
+    expect(arg.where.id).toBe("task-1");
+    expect(arg.where.suggestion).toBeDefined();
+    expect(JSON.stringify(arg.where)).toContain("org-b");
+  });
+
+  it("updateReviewTaskStatusForOrg returns false when no row matches org scope", async () => {
+    updateManyReviewTask.mockResolvedValueOnce({ count: 0 });
+    const ok = await updateReviewTaskStatusForOrg("task-1", "org-c", {
+      status: "APPROVED",
+    });
+    expect(ok).toBe(false);
+    expect(updateManyReviewTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "task-1",
+          suggestion: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  it("revokeApiKeyForOrg only revokes when key belongs to org", async () => {
+    findFirstApiKey.mockResolvedValueOnce(null);
+    const r = await revokeApiKeyForOrg("org-x", "key-1");
+    expect(r.ok).toBe(false);
+    expect(findFirstApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "key-1",
+          organizationId: "org-x",
+          isActive: true,
+        }),
+      }),
+    );
+  });
+
+  it("updateCrawlConfigAutoScan requires matching site workspace org", async () => {
+    updateManyCrawlConfig.mockResolvedValueOnce({ count: 0 });
+    const ok = await updateCrawlConfigAutoScan("site-1", "org-y", true);
+    expect(ok).toBe(false);
+    expect(updateManyCrawlConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          siteId: "site-1",
+          site: { workspace: { organizationId: "org-y" } },
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web/src/lib/dashboard-org-scoped-prisma.ts
+++ b/apps/web/src/lib/dashboard-org-scoped-prisma.ts
@@ -1,0 +1,543 @@
+import {
+  enqueueSiteScan,
+  persistPostCrawlScanKickoffAfterEnqueue,
+  type EnqueueSiteScanParams,
+  type EnqueueSiteScanResult,
+} from "@aros/core-services";
+import { prisma } from "@/lib/db";
+import type { Prisma } from "@aros/db";
+
+const suggestionOrgScope = (organizationId: string) =>
+  ({
+    OR: [
+      {
+        finding: {
+          occurrences: {
+            some: {
+              page: {
+                site: { workspace: { organizationId } },
+              },
+            },
+          },
+        },
+      },
+      {
+        cluster: {
+          site: { workspace: { organizationId } },
+        },
+      },
+    ],
+  }) satisfies Prisma.RemediationSuggestionWhereInput;
+
+const reviewTaskOrgScope = (organizationId: string) =>
+  ({
+    suggestion: suggestionOrgScope(organizationId),
+  }) satisfies Prisma.ReviewTaskWhereInput;
+
+export async function loadRemediationSuggestionForOrg(
+  suggestionId: string,
+  organizationId: string,
+) {
+  return prisma.remediationSuggestion.findFirst({
+    where: { id: suggestionId, ...suggestionOrgScope(organizationId) },
+    select: {
+      id: true,
+      status: true,
+      recipeId: true,
+      finding: {
+        select: {
+          site: {
+            select: {
+              workspace: { select: { organizationId: true } },
+            },
+          },
+        },
+      },
+      cluster: {
+        select: {
+          site: {
+            select: {
+              workspace: { select: { organizationId: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+export async function updateRemediationSuggestionApproved(
+  suggestionId: string,
+  organizationId: string,
+  userId: string,
+) {
+  return prisma.$transaction(async (tx) => {
+    const updated = await tx.remediationSuggestion.updateMany({
+      where: {
+        id: suggestionId,
+        status: { in: ["DRAFT", "VALIDATED"] },
+        ...suggestionOrgScope(organizationId),
+      },
+      data: {
+        status: "APPROVED",
+        appliedBy: userId,
+        appliedAt: new Date(),
+      },
+    });
+    if (updated.count !== 1) {
+      return { ok: false as const, reason: "update_mismatch" as const };
+    }
+    const row = await tx.remediationSuggestion.findFirst({
+      where: { id: suggestionId },
+      select: { recipeId: true },
+    });
+    if (row?.recipeId) {
+      await tx.remediationRecipe.update({
+        where: { id: row.recipeId },
+        data: { successCount: { increment: 1 } },
+      });
+    }
+    return { ok: true as const };
+  });
+}
+
+export async function updateRemediationSuggestionRejected(
+  suggestionId: string,
+  organizationId: string,
+) {
+  return prisma.$transaction(async (tx) => {
+    const updated = await tx.remediationSuggestion.updateMany({
+      where: {
+        id: suggestionId,
+        status: { notIn: ["REJECTED", "APPLIED"] },
+        ...suggestionOrgScope(organizationId),
+      },
+      data: { status: "REJECTED" },
+    });
+    if (updated.count !== 1) {
+      return { ok: false as const, reason: "update_mismatch" as const };
+    }
+    const row = await tx.remediationSuggestion.findFirst({
+      where: { id: suggestionId },
+      select: { recipeId: true },
+    });
+    if (row?.recipeId) {
+      await tx.remediationRecipe.update({
+        where: { id: row.recipeId },
+        data: { rejectionCount: { increment: 1 } },
+      });
+    }
+    return { ok: true as const };
+  });
+}
+
+export async function updateRemediationSuggestionExported(
+  suggestionId: string,
+  organizationId: string,
+) {
+  const updated = await prisma.remediationSuggestion.updateMany({
+    where: {
+      id: suggestionId,
+      status: { in: ["APPROVED", "VALIDATED"] },
+      ...suggestionOrgScope(organizationId),
+    },
+    data: { status: "EXPORTED" },
+  });
+  return updated.count === 1
+    ? ({ ok: true as const })
+    : ({ ok: false as const, reason: "update_mismatch" as const });
+}
+
+export async function loadReviewTaskForOrg(taskId: string, organizationId: string) {
+  return prisma.reviewTask.findFirst({
+    where: { id: taskId, ...reviewTaskOrgScope(organizationId) },
+    select: {
+      id: true,
+      status: true,
+      suggestion: {
+        select: {
+          cluster: {
+            select: {
+              site: {
+                select: {
+                  workspace: { select: { organizationId: true } },
+                },
+              },
+            },
+          },
+          finding: {
+            select: {
+              site: {
+                select: {
+                  workspace: { select: { organizationId: true } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+export async function updateReviewTaskStatusForOrg(
+  taskId: string,
+  organizationId: string,
+  data: Prisma.ReviewTaskUpdateInput,
+) {
+  const updated = await prisma.reviewTask.updateMany({
+    where: { id: taskId, ...reviewTaskOrgScope(organizationId) },
+    data,
+  });
+  return updated.count === 1;
+}
+
+export async function createApiKeyForOrg(input: {
+  organizationId: string;
+  keyHash: string;
+  name: string;
+  scopes: string[];
+  rateLimitPerMinute: number;
+  expiresAt: Date | null;
+}) {
+  return prisma.apiKey.create({
+    data: {
+      organizationId: input.organizationId,
+      keyHash: input.keyHash,
+      name: input.name,
+      scopes: input.scopes,
+      rateLimitPerMinute: input.rateLimitPerMinute,
+      expiresAt: input.expiresAt,
+    },
+    select: {
+      id: true,
+      name: true,
+      scopes: true,
+      rateLimitPerMinute: true,
+      expiresAt: true,
+    },
+  });
+}
+
+export async function findActiveApiKeyForOrg(organizationId: string, keyId: string) {
+  return prisma.apiKey.findFirst({
+    where: {
+      id: keyId,
+      organizationId,
+      isActive: true,
+    },
+    select: {
+      id: true,
+      name: true,
+      scopes: true,
+      rateLimitPerMinute: true,
+      expiresAt: true,
+    },
+  });
+}
+
+export async function rotateApiKeyForOrg(
+  organizationId: string,
+  keyId: string,
+  newHash: string,
+  existing: {
+    name: string;
+    scopes: string[];
+    rateLimitPerMinute: number;
+    expiresAt: Date | null;
+  },
+) {
+  const [newKey] = await prisma.$transaction([
+    prisma.apiKey.create({
+      data: {
+        organizationId,
+        keyHash: newHash,
+        name: existing.name,
+        scopes: existing.scopes,
+        rateLimitPerMinute: existing.rateLimitPerMinute,
+        expiresAt: existing.expiresAt,
+      },
+    }),
+    prisma.apiKey.delete({
+      where: { id: keyId },
+    }),
+  ]);
+  return newKey;
+}
+
+export async function revokeApiKeyForOrg(organizationId: string, keyId: string) {
+  const key = await prisma.apiKey.findFirst({
+    where: {
+      id: keyId,
+      organizationId,
+      isActive: true,
+    },
+  });
+  if (!key) return { ok: false as const };
+  await prisma.apiKey.update({
+    where: { id: keyId },
+    data: { isActive: false },
+  });
+  return { ok: true as const };
+}
+
+export async function listApiKeyUsageForOrg(organizationId: string) {
+  return prisma.apiKey.findMany({
+    where: {
+      organizationId,
+      isActive: true,
+    },
+    include: {
+      mcpUsageLogs: {
+        select: {
+          id: true,
+          createdAt: true,
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+}
+
+export async function startCrawlForVerifiedSite(ctx: {
+  siteId: string;
+  organizationId: string;
+  userId: string;
+}) {
+  const runningCrawl = await prisma.crawlRun.findFirst({
+    where: { siteId: ctx.siteId, status: { in: ["PENDING", "RUNNING"] } },
+  });
+  if (runningCrawl) {
+    return { kind: "already_running" as const };
+  }
+
+  const site = await prisma.site.findUnique({
+    where: { id: ctx.siteId },
+    include: { crawlConfig: true },
+  });
+  if (!site) {
+    return { kind: "site_not_found" as const };
+  }
+
+  const config = site.crawlConfig;
+  const crawlRun = await prisma.crawlRun.create({
+    data: { siteId: ctx.siteId, status: "PENDING" },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      action: "crawl.started",
+      entityType: "CrawlRun",
+      entityId: crawlRun.id,
+    },
+  });
+
+  return {
+    kind: "started" as const,
+    crawlRun,
+    site,
+    config,
+  };
+}
+
+export async function markCrawlRunFailedQueue(
+  crawlRunId: string,
+  ctx: { organizationId: string; user: { id: string }; siteId: string },
+  message: string,
+) {
+  await prisma.crawlRun.update({
+    where: { id: crawlRunId },
+    data: {
+      status: "FAILED",
+      errorMessage: `Crawl queue unavailable: ${message}`,
+      completedAt: new Date(),
+    },
+  });
+  await prisma.auditLog.create({
+    data: {
+      organizationId: ctx.organizationId,
+      userId: ctx.user.id,
+      action: "crawl.enqueue_failed",
+      entityType: "CrawlRun",
+      entityId: crawlRunId,
+      metadata: { siteId: ctx.siteId, message },
+    },
+  });
+}
+
+export async function countScanRunsForOrg(organizationId: string) {
+  return prisma.scanRun.count({
+    where: { site: { workspace: { organizationId } } },
+  });
+}
+
+export async function findCompletedCrawlForSiteOrg(
+  crawlRunId: string,
+  siteId: string,
+  organizationId: string,
+) {
+  return prisma.crawlRun.findFirst({
+    where: {
+      id: crawlRunId,
+      siteId,
+      status: "COMPLETED",
+      pagesCrawled: { gt: 0 },
+      site: { workspace: { organizationId } },
+    },
+    select: { id: true },
+  });
+}
+
+export async function setPostCrawlScanKickoffRequested(crawlRunId: string) {
+  return prisma.crawlRun.update({
+    where: { id: crawlRunId },
+    data: { postCrawlScanKickoffStatus: "REQUESTED" },
+  });
+}
+
+export async function createScanAuditLog(input: {
+  organizationId: string;
+  userId: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  metadata?: Record<string, unknown>;
+}) {
+  return prisma.auditLog.create({
+    data: {
+      organizationId: input.organizationId,
+      userId: input.userId,
+      action: input.action,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      metadata: input.metadata as Prisma.InputJsonValue | undefined,
+    },
+  });
+}
+
+export async function updateCrawlConfigAutoScan(
+  siteId: string,
+  organizationId: string,
+  enabled: boolean,
+) {
+  const updated = await prisma.crawlConfig.updateMany({
+    where: { siteId, site: { workspace: { organizationId } } },
+    data: { autoScanAfterCrawl: enabled },
+  });
+  return updated.count === 1;
+}
+
+export async function loadMembershipWorkspaceForAddSite(
+  userId: string,
+  organizationId: string,
+) {
+  return prisma.membership.findUnique({
+    where: {
+      userId_organizationId: {
+        userId,
+        organizationId,
+      },
+    },
+    include: {
+      organization: {
+        include: {
+          workspaces: { take: 1 },
+          subscription: true,
+        },
+      },
+    },
+  });
+}
+
+export async function countSitesForOrg(organizationId: string) {
+  return prisma.site.count({
+    where: { workspace: { organizationId } },
+  });
+}
+
+export async function createSiteWithCrawlAndAudit(input: {
+  workspaceId: string;
+  organizationId: string;
+  userId: string;
+  name: string;
+  domain: string;
+  environment: "PRODUCTION" | "STAGING" | "DEVELOPMENT";
+  sitemapUrl: string | null;
+  maxDepth: number;
+  maxPages: number;
+  respectRobots: boolean;
+  renderJavaScript: boolean;
+}) {
+  return prisma.$transaction(async (tx) => {
+    const site = await tx.site.create({
+      data: {
+        workspaceId: input.workspaceId,
+        name: input.name,
+        domain: input.domain,
+        environment: input.environment,
+      },
+    });
+
+    await tx.crawlConfig.create({
+      data: {
+        siteId: site.id,
+        sitemapUrl: input.sitemapUrl,
+        maxDepth: input.maxDepth,
+        maxPages: input.maxPages,
+        respectRobots: input.respectRobots,
+        renderJavaScript: input.renderJavaScript,
+      },
+    });
+
+    const crawlRun = await tx.crawlRun.create({
+      data: {
+        siteId: site.id,
+        status: "PENDING",
+      },
+    });
+
+    await tx.auditLog.create({
+      data: {
+        organizationId: input.organizationId,
+        userId: input.userId,
+        action: "site.created",
+        entityType: "Site",
+        entityId: site.id,
+        metadata: { name: input.name, domain: input.domain },
+      },
+    });
+
+    return { site, crawlRun };
+  });
+}
+
+export async function markCrawlRunQueueRetry(crawlRunId: string) {
+  return prisma.crawlRun.update({
+    where: { id: crawlRunId },
+    data: {
+      status: "PENDING",
+      errorMessage: "Queue not available - will retry",
+    },
+  });
+}
+
+/** Wraps core-services scan enqueue with the app Prisma client (keeps `prisma` out of server actions). */
+export async function enqueueSiteScanForDashboard(
+  params: EnqueueSiteScanParams,
+): Promise<EnqueueSiteScanResult> {
+  return enqueueSiteScan({ prisma }, params);
+}
+
+export async function persistPostCrawlKickoffAfterEnqueueDashboard(
+  crawlRunId: string,
+  result: EnqueueSiteScanResult,
+) {
+  return persistPostCrawlScanKickoffAfterEnqueue(prisma, crawlRunId, result);
+}

--- a/apps/web/src/lib/operator-console-queries.ts
+++ b/apps/web/src/lib/operator-console-queries.ts
@@ -1,0 +1,372 @@
+import { prisma } from "@/lib/db";
+import type {
+  AgedFinding,
+  CustomerWorkQueue,
+  ExceptionRouting,
+  FailedRun,
+  HighImpactCluster,
+  OperatorHealthPayload,
+  OrgWithSubscription,
+  RenewalWatchlist,
+  StaleSite,
+  WorkQueueItem,
+} from "@/lib/operator-console-types";
+
+const DAYS_30_MS = 30 * 24 * 60 * 60 * 1000;
+const DAYS_90_MS = 90 * 24 * 60 * 60 * 1000;
+const DAYS_7_MS = 7 * 24 * 60 * 60 * 1000;
+
+export async function fetchOperatorHealthPayload(
+  organizationId: string,
+): Promise<OperatorHealthPayload> {
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - DAYS_30_MS);
+  const ninetyDaysAgo = new Date(now.getTime() - DAYS_90_MS);
+  const sevenDaysAgo = new Date(now.getTime() - DAYS_7_MS);
+
+  const [
+    staleSitesData,
+    criticalFindingsData,
+    subsData,
+    failedRunsData,
+    clustersData,
+  ] = await Promise.all([
+    prisma.site.findMany({
+      where: {
+        workspace: { organizationId },
+        OR: [
+          { scanRuns: { none: {} } },
+          {
+            scanRuns: {
+              every: { completedAt: { lt: thirtyDaysAgo } },
+            },
+          },
+        ],
+      },
+      include: {
+        workspace: { select: { organizationId: true } },
+        scanRuns: { orderBy: { completedAt: "desc" }, take: 1 },
+        canonicalFindings: {
+          where: { status: "OPEN" },
+          select: { id: true, impact: true },
+        },
+      },
+    }),
+
+    prisma.canonicalFinding.findMany({
+      where: {
+        site: { workspace: { organizationId } },
+        status: "OPEN",
+        impact: "CRITICAL",
+        firstSeenAt: { lt: ninetyDaysAgo },
+      },
+      include: {
+        site: { select: { id: true, name: true, domain: true } },
+      },
+      orderBy: [
+        { distinctScanRunsObserved: "desc" },
+        { reopenedCount: "desc" },
+        { firstSeenAt: "asc" },
+      ],
+      take: 50,
+    }),
+
+    prisma.organization.findUnique({
+      where: { id: organizationId },
+      include: {
+        subscription: true,
+        workspaces: {
+          include: {
+            _count: { select: { sites: true } },
+          },
+        },
+        _count: { select: { memberships: true } },
+      },
+    }),
+
+    prisma.$transaction([
+      prisma.crawlRun.findMany({
+        where: {
+          site: { workspace: { organizationId } },
+          status: "FAILED",
+          createdAt: { gte: sevenDaysAgo },
+        },
+        include: { site: { select: { id: true, name: true, domain: true } } },
+        orderBy: { createdAt: "desc" },
+      }),
+      prisma.scanRun.findMany({
+        where: {
+          site: { workspace: { organizationId } },
+          status: "FAILED",
+          createdAt: { gte: sevenDaysAgo },
+        },
+        include: { site: { select: { id: true, name: true, domain: true } } },
+        orderBy: { createdAt: "desc" },
+      }),
+    ]),
+
+    prisma.issueCluster.findMany({
+      where: {
+        site: { workspace: { organizationId } },
+        impactScore: { gte: 50 },
+      },
+      include: {
+        site: { select: { id: true, name: true, domain: true } },
+        impact: true,
+      },
+      orderBy: { impactScore: "desc" },
+      take: 20,
+    }),
+  ]);
+
+  const staleSites: StaleSite[] = staleSitesData.map((site) => {
+    const lastScanAt = site.scanRuns[0]?.completedAt ?? null;
+    const daysStale = lastScanAt
+      ? Math.floor(
+          (now.getTime() - lastScanAt.getTime()) / (24 * 60 * 60 * 1000),
+        )
+      : 999;
+    const criticalFindings = site.canonicalFindings.filter(
+      (f) => f.impact === "CRITICAL",
+    ).length;
+
+    return {
+      id: site.id,
+      name: site.name,
+      domain: site.domain,
+      lastScanAt,
+      daysStale,
+      openFindings: site.canonicalFindings.length,
+      criticalFindings,
+    };
+  });
+
+  const criticalFindings: AgedFinding[] = criticalFindingsData.map((f) => ({
+    id: f.id,
+    ruleId: f.ruleId,
+    impact: f.impact,
+    description: f.description,
+    siteId: f.site.id,
+    siteName: f.site.name,
+    siteDomain: f.site.domain,
+    daysOpen: Math.floor(
+      (now.getTime() - f.firstSeenAt.getTime()) / (24 * 60 * 60 * 1000),
+    ),
+    occurrenceCount: f.occurrenceCount,
+    distinctScanRunsObserved: f.distinctScanRunsObserved,
+  }));
+
+  const org = subsData;
+  const totalSites =
+    org?.workspaces.reduce((sum, w) => sum + w._count.sites, 0) ?? 0;
+  const seatCount = org?._count.memberships ?? 0;
+
+  const subsNearRenewal: OrgWithSubscription[] = [];
+  const pastDue: OrgWithSubscription[] = [];
+  const approachingLimits: OrgWithSubscription[] = [];
+
+  if (org?.subscription) {
+    const sub = org.subscription;
+    const daysToRenewal = sub.currentPeriodEnd
+      ? Math.floor(
+          (sub.currentPeriodEnd.getTime() - now.getTime()) /
+            (24 * 60 * 60 * 1000),
+        )
+      : null;
+
+    const orgSub: OrgWithSubscription = {
+      id: org.id,
+      name: org.name,
+      slug: org.slug,
+      siteCount: totalSites,
+      subscription: {
+        status: sub.status,
+        plan: sub.plan,
+        currentPeriodEnd: sub.currentPeriodEnd,
+        cancelAtPeriodEnd: sub.cancelAtPeriodEnd,
+      },
+      daysToRenewal,
+      usagePercent: Math.min(
+        100,
+        Math.round(
+          ((totalSites / Math.max(1, sub.maxDomains)) * 0.5 +
+            (seatCount / Math.max(1, sub.maxSeats)) * 0.5) *
+            100,
+        ),
+      ),
+    };
+
+    if (sub.status === "PAST_DUE") {
+      pastDue.push(orgSub);
+    } else if (daysToRenewal !== null && daysToRenewal <= 30) {
+      subsNearRenewal.push(orgSub);
+    }
+
+    if (totalSites >= sub.maxDomains * 0.8 || seatCount >= sub.maxSeats * 0.8) {
+      approachingLimits.push(orgSub);
+    }
+  }
+
+  const [failedCrawls, failedScans] = failedRunsData;
+  const failedRuns: FailedRun[] = [
+    ...failedCrawls.map((c) => ({
+      id: c.id,
+      type: "crawl" as const,
+      siteId: c.site.id,
+      siteName: c.site.name,
+      siteDomain: c.site.domain,
+      errorMessage: c.errorMessage,
+      failedAt: c.createdAt,
+    })),
+    ...failedScans.map((s) => ({
+      id: s.id,
+      type: "scan" as const,
+      siteId: s.site.id,
+      siteName: s.site.name,
+      siteDomain: s.site.domain,
+      errorMessage: s.errorMessage,
+      failedAt: s.createdAt,
+    })),
+  ].sort((a, b) => b.failedAt.getTime() - a.failedAt.getTime());
+
+  const highImpactClusters: HighImpactCluster[] = clustersData.map((c) => ({
+    id: c.id,
+    name: c.name,
+    siteId: c.site.id,
+    siteName: c.site.name,
+    siteDomain: c.site.domain,
+    severity: c.severity,
+    impactScore: Math.round(c.impactScore),
+    findingCount: c.findingCount,
+    pageCount: c.pageCount,
+  }));
+
+  const workQueueItems: WorkQueueItem[] = [];
+
+  const newSites = await prisma.site.findMany({
+    where: {
+      workspace: { organizationId },
+      createdAt: { gte: sevenDaysAgo },
+    },
+    include: { workspace: { include: { organization: true } } },
+  });
+
+  for (const site of newSites) {
+    workQueueItems.push({
+      id: `onboarding-${site.id}`,
+      type: "onboarding",
+      priority: "medium",
+      title: "New site needs onboarding",
+      description: `${site.name} (${site.domain}) was added recently. Verify crawl config and run initial scan.`,
+      orgId: site.workspace.organizationId,
+      orgName: site.workspace.organization.name,
+      entityId: site.id,
+      entityName: site.name,
+      createdAt: site.createdAt,
+      actionLabel: "Configure",
+      actionHref: `/sites/${site.id}/settings`,
+    });
+  }
+
+  for (const site of staleSites.filter((s) => s.openFindings > 10)) {
+    workQueueItems.push({
+      id: `attention-${site.id}`,
+      type: "attention",
+      priority: site.criticalFindings > 0 ? "high" : "medium",
+      title: `Site needs attention: ${site.name}`,
+      description: `${site.openFindings} open findings (${site.criticalFindings} critical), ${site.daysStale} days since last scan.`,
+      orgId: organizationId,
+      orgName: org?.name ?? "",
+      entityId: site.id,
+      entityName: site.name,
+      createdAt: now,
+      actionLabel: "Review",
+      actionHref: `/sites/${site.id}/findings`,
+    });
+  }
+
+  const orgsWithNoSites = await prisma.organization.findMany({
+    where: {
+      id: organizationId,
+      workspaces: { every: { sites: { none: {} } } },
+    },
+  });
+
+  for (const o of orgsWithNoSites) {
+    workQueueItems.push({
+      id: `churn-${o.id}`,
+      type: "churn-risk",
+      priority: "high",
+      title: "No sites configured",
+      description: `${o.name} has no sites set up. Reach out to help them get started.`,
+      orgId: o.id,
+      orgName: o.name,
+      createdAt: now,
+      actionLabel: "Add site",
+      actionHref: "/sites/new",
+    });
+  }
+
+  const priorityOrder = { high: 0, medium: 1, low: 2 };
+  workQueueItems.sort(
+    (a, b) => priorityOrder[a.priority] - priorityOrder[b.priority],
+  );
+
+  const renewalWatchlist: RenewalWatchlist = {
+    pastDue,
+    failedPayment: pastDue.filter((o) => o.subscription?.status === "PAST_DUE"),
+    approachingLimits,
+    totalAtRisk: pastDue.length + approachingLimits.length,
+  };
+
+  const exceptionRouting: ExceptionRouting = {
+    criticalAgedFindings: criticalFindings.filter((f) => f.daysOpen > 30),
+    highImpactClusters,
+    totalExceptions:
+      criticalFindings.filter((f) => f.daysOpen > 30).length +
+      highImpactClusters.length,
+  };
+
+  const workQueue: CustomerWorkQueue = {
+    items: workQueueItems.slice(0, 50),
+    highPriorityCount: workQueueItems.filter((i) => i.priority === "high").length,
+    mediumPriorityCount: workQueueItems.filter((i) => i.priority === "medium")
+      .length,
+    onboardingCount: workQueueItems.filter((i) => i.type === "onboarding").length,
+  };
+
+  const accountHealth = {
+    staleSites,
+    staleSitesCount: staleSites.length,
+    criticalFindingsCount: criticalFindings.length,
+    criticalFindings,
+    subsNearRenewal,
+    subsNearRenewalCount: subsNearRenewal.length,
+    failedRuns: failedRuns.slice(0, 20),
+    failedRunsCount: failedRuns.length,
+  };
+
+  return {
+    accountHealth,
+    workQueue,
+    renewalWatchlist,
+    exceptionRouting,
+    generatedAt: now,
+  };
+}
+
+export async function createOperatorDismissAudit(input: {
+  organizationId: string;
+  userId: string;
+  itemId: string;
+}) {
+  return prisma.auditLog.create({
+    data: {
+      organizationId: input.organizationId,
+      userId: input.userId,
+      action: "operator.dismiss_work_item",
+      entityType: "WorkQueueItem",
+      entityId: input.itemId,
+    },
+  });
+}

--- a/apps/web/src/lib/operator-console-types.ts
+++ b/apps/web/src/lib/operator-console-types.ts
@@ -1,0 +1,116 @@
+import type { SubscriptionStatus } from "@aros/db";
+
+export interface StaleSite {
+  id: string;
+  name: string;
+  domain: string;
+  lastScanAt: Date | null;
+  daysStale: number;
+  openFindings: number;
+  criticalFindings: number;
+}
+
+export interface OrgWithSubscription {
+  id: string;
+  name: string;
+  slug: string;
+  siteCount: number;
+  subscription: {
+    status: SubscriptionStatus;
+    plan: string;
+    currentPeriodEnd: Date | null;
+    cancelAtPeriodEnd: boolean;
+  } | null;
+  daysToRenewal: number | null;
+  usagePercent: number;
+}
+
+export interface FailedRun {
+  id: string;
+  type: "crawl" | "scan";
+  siteId: string;
+  siteName: string;
+  siteDomain: string;
+  errorMessage: string | null;
+  failedAt: Date;
+}
+
+export interface AgedFinding {
+  id: string;
+  ruleId: string;
+  impact: string;
+  description: string;
+  siteId: string;
+  siteName: string;
+  siteDomain: string;
+  daysOpen: number;
+  occurrenceCount: number;
+  /** Distinct completed scan runs where this fingerprint was re-detected. */
+  distinctScanRunsObserved: number;
+}
+
+export interface HighImpactCluster {
+  id: string;
+  name: string;
+  siteId: string;
+  siteName: string;
+  siteDomain: string;
+  severity: string;
+  impactScore: number;
+  findingCount: number;
+  pageCount: number;
+}
+
+export interface WorkQueueItem {
+  id: string;
+  type: "onboarding" | "attention" | "churn-risk";
+  priority: "high" | "medium" | "low";
+  title: string;
+  description: string;
+  orgId: string;
+  orgName: string;
+  entityId?: string;
+  entityName?: string;
+  createdAt: Date;
+  actionLabel: string;
+  actionHref: string;
+}
+
+export interface AccountHealthRollup {
+  staleSites: StaleSite[];
+  staleSitesCount: number;
+  criticalFindingsCount: number;
+  criticalFindings: AgedFinding[];
+  subsNearRenewal: OrgWithSubscription[];
+  subsNearRenewalCount: number;
+  failedRuns: FailedRun[];
+  failedRunsCount: number;
+}
+
+export interface CustomerWorkQueue {
+  items: WorkQueueItem[];
+  highPriorityCount: number;
+  mediumPriorityCount: number;
+  onboardingCount: number;
+}
+
+export interface RenewalWatchlist {
+  pastDue: OrgWithSubscription[];
+  failedPayment: OrgWithSubscription[];
+  approachingLimits: OrgWithSubscription[];
+  totalAtRisk: number;
+}
+
+export interface ExceptionRouting {
+  criticalAgedFindings: AgedFinding[];
+  highImpactClusters: HighImpactCluster[];
+  totalExceptions: number;
+}
+
+export interface OperatorHealthPayload {
+  accountHealth: AccountHealthRollup;
+  workQueue: CustomerWorkQueue;
+  renewalWatchlist: RenewalWatchlist;
+  exceptionRouting: ExceptionRouting;
+  generatedAt: Date;
+}

--- a/apps/web/src/lib/operator-dashboard-org.ts
+++ b/apps/web/src/lib/operator-dashboard-org.ts
@@ -1,0 +1,61 @@
+import { cookies } from "next/headers";
+import { prisma } from "@/lib/db";
+import type { MemberRole } from "@aros/db";
+import { resolveOperatorScopedMembership } from "@/lib/operator-org-resolution";
+import { loadMembershipsForOperatorResolution } from "@/lib/operator-membership-db";
+
+const ACTIVE_ORG_COOKIE = "aros_active_org";
+
+export type OperatorDashboardPageContext =
+  | { kind: "no_membership" }
+  | { kind: "no_operator_access" }
+  | {
+      kind: "ok";
+      organizationId: string;
+      organizationName: string;
+      role: MemberRole;
+    };
+
+/**
+ * Single resolution path for `/system/operator` UI — matches `requireOperatorAccess`
+ * in `system/operator/actions.ts` (cookie + `org:system:view` on eligible memberships).
+ */
+export async function resolveOperatorDashboardPageContext(
+  userId: string,
+): Promise<OperatorDashboardPageContext> {
+  const memberships = await loadMembershipsForOperatorResolution(userId);
+  if (memberships.length === 0) {
+    return { kind: "no_membership" };
+  }
+
+  const cookieStore = await cookies();
+  const preferredOrgId = cookieStore.get(ACTIVE_ORG_COOKIE)?.value;
+
+  const resolved = resolveOperatorScopedMembership(
+    memberships.map((m) => ({
+      organizationId: m.organizationId,
+      role: m.role,
+      createdAt: m.createdAt,
+    })),
+    preferredOrgId ?? undefined,
+    "org:system:view",
+  );
+  if (!resolved) {
+    return { kind: "no_operator_access" };
+  }
+
+  const org = await prisma.organization.findUnique({
+    where: { id: resolved.organizationId },
+    select: { id: true, name: true },
+  });
+  if (!org) {
+    return { kind: "no_operator_access" };
+  }
+
+  return {
+    kind: "ok",
+    organizationId: org.id,
+    organizationName: org.name,
+    role: resolved.role,
+  };
+}

--- a/apps/web/src/lib/operator-membership-db.ts
+++ b/apps/web/src/lib/operator-membership-db.ts
@@ -1,0 +1,15 @@
+import { prisma } from "@/lib/db";
+import type { MemberRole } from "@aros/db";
+
+/**
+ * Loads membership rows for operator console resolution.
+ * Kept outside server `actions.ts` modules so tenant-boundary lint stays focused on mutation paths.
+ */
+export async function loadMembershipsForOperatorResolution(userId: string): Promise<
+  { organizationId: string; role: MemberRole; createdAt: Date }[]
+> {
+  return prisma.membership.findMany({
+    where: { userId },
+    select: { organizationId: true, role: true, createdAt: true },
+  });
+}

--- a/docs/ROUTE_SAFE_BOUNDARY.md
+++ b/docs/ROUTE_SAFE_BOUNDARY.md
@@ -30,6 +30,8 @@ Dashboard routes should not duplicate ad hoc `try/catch` around membership and o
 
 - Never skip org scoping in degraded paths. Use `runOrgScopedQuery` with queries filtered by `organizationId`.
 - Finding detail and similar routes must scope by org (e.g. `findFirst` with `occurrences.some.site.workspace.organizationId`).
+- For server actions that resolve the active org at submit time, include a hidden `expectedOrganizationId` matching the page’s org and validate with `assertFormOrgMatchesActive` (`dashboard-form-org.ts`) so stale tabs after an org switch get a clear error instead of silent mismatch.
+- Operator console (`/system/operator`) scopes health data to the same org as `getOperatorHealthData` (active-org cookie when permitted, else oldest eligible membership with `org:system:view`). It is not a cross-tenant super-admin view.
 - Operator-only detail stays on `/system` and `org:system:view` APIs; shell banners use `audience: 'operator' | 'user'` for extra hints.
 
 ## Testing

--- a/docs/ROUTE_SAFE_BOUNDARY.md
+++ b/docs/ROUTE_SAFE_BOUNDARY.md
@@ -11,6 +11,8 @@ Dashboard routes should not duplicate ad hoc `try/catch` around membership and o
   - `resolveDashboardOrgMembership(userId, truth)` — returns `ok | none | platform_blocked | error`. When `truth.allowOrgScopedDbReads` is false, **does not** query Prisma for membership (avoids cascading DB errors).  
   - `runOrgScopedQuery(ctx, fn)` — wraps org-scoped work in `{ ok, data } | { ok: false, message }` instead of throwing.
 
+- `apps/web/src/lib/dashboard-org-scoped-prisma.ts` — **pre-wrapped Prisma helpers** for server actions (API keys, site/crawl flows, remediation/review updates, scan enqueue wrappers). ESLint’s tenant-boundary rule allows importing from here instead of calling `prisma` directly inside `actions.ts` / `scan-actions.ts`. Prefer adding new org-scoped queries here (with `organizationId` / site–workspace filters in the helper) rather than duplicating raw Prisma in action files.
+
 - `apps/web/src/components/reliability/*` — `PlatformShellBanner`, `RouteReliabilityNotice` for consistent copy and roles.
 
 ## How to add a new dashboard page

--- a/docs/verification-gates.md
+++ b/docs/verification-gates.md
@@ -13,7 +13,7 @@ Runs in this exact order:
 ## Tier 2 — Release gate (`npm run verify:release`)
 
 Includes Tier 1 and adds release-blocking tenant isolation + launch-critical truth checks + env-bound integration tests:
-- `npm run verify:tenant-boundary` (fails if critical server entrypoints regress with tenant-boundary lint violations)
+- `npm run verify:tenant-boundary` (fails if critical server entrypoints regress with tenant-boundary lint violations, including high-risk dashboard server actions listed in `scripts/check-tenant-boundary-critical.mjs`)
 - `npm run test:launch-critical` (targeted suites for public-scan validity/expiry truth and canonical org-boundary regression checks on critical routes)
 - `npm run test:integration` (currently `apps/web` Vitest integration suite)
 

--- a/docs/verification-gates.md
+++ b/docs/verification-gates.md
@@ -15,7 +15,7 @@ Runs in this exact order:
 Includes Tier 1 and adds release-blocking tenant isolation + launch-critical truth checks + env-bound integration tests:
 - `npm run verify:tenant-boundary` (fails if critical server entrypoints regress with tenant-boundary lint violations, including high-risk dashboard server actions listed in `scripts/check-tenant-boundary-critical.mjs`)
 - `npm run test:launch-critical` (targeted suites for public-scan validity/expiry truth and canonical org-boundary regression checks on critical routes)
-- `npm run test:integration` (currently `apps/web` Vitest integration suite)
+- `npm run test:integration` (`apps/web` Vitest integration suite: Stripe webhook + tenant-isolation DB checks when `DATABASE_URL` is reachable)
 
 ## Tier 3 — Browser/system gate (CI + optional local)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@playwright/experimental-ct-react": "^1.58.2",
         "@playwright/test": "^1.49.0",
         "@testing-library/jest-dom": "^6.9.1",
-        "@types/nodemailer": "^6.4.17",
+        "@types/nodemailer": "^8.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/sanitize-html": "^2.16.1",
@@ -75,6 +75,16 @@
         "tough-cookie": "^6.0.1",
         "typescript": "^5.7.0",
         "vitest": "^4.1.2"
+      }
+    },
+    "apps/web/node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "apps/web/node_modules/@vitejs/plugin-react": {
@@ -6491,16 +6501,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/nodemailer": {
-      "version": "6.4.23",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.23.tgz",
-      "integrity": "sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "ioredis": "^5.4.0",
         "lucide-react": "^0.468.0",
         "next": "^15.1.0",
-        "nodemailer": "^6.9.16",
+        "nodemailer": "^8.0.4",
         "postcss": "^8.4.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -103,83 +103,13 @@
         }
       }
     },
-    "apps/web/node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
+    "apps/web/node_modules/nodemailer": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
+      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+      "license": "MIT-0",
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
+        "node": ">=6.0.0"
       }
     },
     "apps/worker": {
@@ -4405,7 +4335,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.1"
       },
@@ -4643,7 +4572,6 @@
       "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -4661,565 +4589,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
-    "node_modules/@playwright/experimental-ct-core/node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
       }
     },
     "node_modules/@playwright/experimental-ct-react": {
@@ -5374,7 +4743,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5392,7 +4760,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5410,7 +4777,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5428,7 +4794,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5446,7 +4811,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5464,7 +4828,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5482,7 +4845,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5500,7 +4862,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5518,7 +4879,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5536,7 +4896,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5554,7 +4913,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5572,7 +4930,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5587,7 +4944,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^1.1.1"
       },
@@ -5608,7 +4964,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5626,7 +4981,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5728,7 +5082,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.1",
@@ -5742,7 +5097,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.1",
@@ -5756,7 +5112,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.1",
@@ -5770,7 +5127,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.1",
@@ -5784,7 +5142,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.1",
@@ -5798,7 +5157,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.1",
@@ -5812,7 +5172,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.1",
@@ -5826,7 +5187,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.1",
@@ -5840,7 +5202,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.1",
@@ -5854,7 +5217,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.1",
@@ -5868,7 +5232,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.1",
@@ -5882,7 +5247,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.1",
@@ -5896,7 +5262,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.1",
@@ -5910,7 +5277,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.1",
@@ -5924,7 +5292,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.1",
@@ -5938,7 +5307,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.1",
@@ -5952,7 +5322,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.1",
@@ -5966,7 +5337,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.1",
@@ -5980,7 +5352,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.1",
@@ -5994,7 +5367,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.1",
@@ -6008,7 +5382,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.1",
@@ -6022,7 +5397,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.1",
@@ -6036,7 +5412,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.1",
@@ -6050,7 +5427,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.1",
@@ -6064,7 +5442,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -12506,7 +11885,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -12544,7 +11922,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12566,7 +11943,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12588,7 +11964,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12610,7 +11985,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12632,7 +12006,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12654,7 +12027,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12676,7 +12048,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12698,7 +12069,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12720,7 +12090,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12742,7 +12111,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12764,7 +12132,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13717,15 +13084,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "license": "MIT"
-    },
-    "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -14883,7 +14241,6 @@
       "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
         "@rolldown/pluginutils": "1.0.0-rc.12"
@@ -14917,8 +14274,7 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
       "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -14926,6 +14282,8 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -16596,17 +15954,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -16623,9 +15980,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -16638,13 +15996,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prisma:check": "node scripts/check-prisma-client-drift.mjs",
     "prisma:imports": "node scripts/check-prisma-import-boundaries.mjs",
     "test:integration": "npm run test:integration --workspace=apps/web",
+    "audit:high": "npm audit --audit-level=high",
     "test:release": "npm run test && npm run test:integration",
     "verify:core": "npm run prisma:check && npm run prisma:imports && npm run lint && npm run typecheck && npm run test && npm run build",
     "verify:release": "npm run verify:core && npm run verify:tenant-boundary && npm run test:launch-critical && npm run test:integration",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "postinstall": "node scripts/workspace-symlinks.js && npm run db:generate",
+    "postinstall": "node scripts/workspace-symlinks.js && node scripts/prune-nested-vite.mjs && npm run db:generate",
     "dev": "npm run dev --workspace=apps/web",
     "dev:worker": "npm run dev --workspace=apps/worker",
     "build": "npm run build --workspace=apps/web",
@@ -57,6 +57,7 @@
     },
     "@rollup/plugin-terser": {
       "serialize-javascript": "7.0.5"
-    }
+    },
+    "vite": "8.0.5"
   }
 }

--- a/scripts/check-tenant-boundary-critical.mjs
+++ b/scripts/check-tenant-boundary-critical.mjs
@@ -3,6 +3,14 @@ import { execFileSync } from "node:child_process";
 
 const CRITICAL_ENTRYPOINTS = [
   "src/app/(dashboard)/settings/billing/actions.ts",
+  "src/app/(dashboard)/settings/api-keys/actions.ts",
+  "src/app/(dashboard)/sites/new/actions.ts",
+  "src/app/(dashboard)/sites/[siteId]/actions.ts",
+  "src/app/(dashboard)/sites/[siteId]/scan-actions.ts",
+  "src/app/(dashboard)/sites/[siteId]/settings/actions.ts",
+  "src/app/(dashboard)/remediation/[suggestionId]/actions.ts",
+  "src/app/(dashboard)/reviews/actions.ts",
+  "src/app/(dashboard)/system/operator/actions.ts",
   "src/app/api/comments/route.ts",
   "src/app/api/credits/route.ts",
   "src/app/api/impact/route.ts",

--- a/scripts/prune-nested-vite.mjs
+++ b/scripts/prune-nested-vite.mjs
@@ -3,24 +3,29 @@
  * npm workspaces sometimes install a second copy of vite under apps/web for
  * @vitejs/plugin-react peer resolution. That copy can lag the hoisted root vite
  * and trip `npm audit` even when the tree hoists a patched version at the root.
- * Remove the nested copy so tooling resolves to the root `vite` (see root overrides).
+ *
+ * Remove nested `apps/web/node_modules/vite` when it does not match the hoisted
+ * root `node_modules/vite` version (single source of truth from the lockfile / install).
  */
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 const nestedPkg = join("apps", "web", "node_modules", "vite", "package.json");
-if (!existsSync(nestedPkg)) {
+const rootPkg = join("node_modules", "vite", "package.json");
+
+if (!existsSync(nestedPkg) || !existsSync(rootPkg)) {
   process.exit(0);
 }
 
-let version = "";
+let nestedVersion = "";
+let rootVersion = "";
 try {
-  version = JSON.parse(readFileSync(nestedPkg, "utf8")).version ?? "";
+  nestedVersion = JSON.parse(readFileSync(nestedPkg, "utf8")).version ?? "";
+  rootVersion = JSON.parse(readFileSync(rootPkg, "utf8")).version ?? "";
 } catch {
   process.exit(0);
 }
 
-// Advisory GHSA-* for vite 8.0.0–8.0.4; keep only if it matches patched root.
-if (version && version !== "8.0.5") {
+if (nestedVersion && rootVersion && nestedVersion !== rootVersion) {
   rmSync(join("apps", "web", "node_modules", "vite"), { recursive: true, force: true });
 }

--- a/scripts/prune-nested-vite.mjs
+++ b/scripts/prune-nested-vite.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * npm workspaces sometimes install a second copy of vite under apps/web for
+ * @vitejs/plugin-react peer resolution. That copy can lag the hoisted root vite
+ * and trip `npm audit` even when the tree hoists a patched version at the root.
+ * Remove the nested copy so tooling resolves to the root `vite` (see root overrides).
+ */
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const nestedPkg = join("apps", "web", "node_modules", "vite", "package.json");
+if (!existsSync(nestedPkg)) {
+  process.exit(0);
+}
+
+let version = "";
+try {
+  version = JSON.parse(readFileSync(nestedPkg, "utf8")).version ?? "";
+} catch {
+  process.exit(0);
+}
+
+// Advisory GHSA-* for vite 8.0.0–8.0.4; keep only if it matches patched root.
+if (version && version !== "8.0.5") {
+  rmSync(join("apps", "web", "node_modules", "vite"), { recursive: true, force: true });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Moves org-scoped Prisma work out of high-risk dashboard `actions.ts` / `scan-actions.ts` into `apps/web/src/lib/dashboard-org-scoped-prisma.ts` (ESLint-allowed pattern).
- Remediation/review actions resolve **active dashboard org** and scope loads/updates; **hidden `expectedOrganizationId`** on forms catches stale tabs after org switch (`stale_session` / `review_error=stale_session`).
- Operator console page uses **`resolveOperatorDashboardPageContext`** — same cookie + `org:system:view` resolution as `getOperatorHealthData`; UI copy documents single-org scope.
- **DB integration tests** (`tenant-isolation.integration.test.ts`) assert cross-org read/update failure for remediation/review helpers when Postgres is up (CI).
- **@types/nodemailer** ^8; **vite prune** compares nested vs root version (no hardcoded 8.0.5).
- **CI:** `npm audit --audit-level=high` after `npm ci`. Root **`npm run audit:high`** for local parity.

## Tests / verification
- `npm run verify:release`

## Contributor note
See `docs/ROUTE_SAFE_BOUNDARY.md` for org form tokens and operator scope semantics.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-defd4441-9760-4b55-9bdf-9bc11ba3f549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-defd4441-9760-4b55-9bdf-9bc11ba3f549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

