### PR TITLE
Harden one-time security token consumption against races

### DIFF
--- a/apps/web/src/lib/security-token.test.ts
+++ b/apps/web/src/lib/security-token.test.ts
@@ -22,7 +22,7 @@ describe("security-token", () => {
     const prisma = {
       securityToken: {
         findUnique: vi.fn().mockResolvedValue({ ...row }),
-        update: vi.fn().mockResolvedValue({}),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       },
     };
     const first = await consumeSecurityToken(prisma as any, {
@@ -30,7 +30,7 @@ describe("security-token", () => {
       kind: SecurityTokenKind.PASSWORD_RESET,
     });
     expect(first).toEqual({ userId: "u1" });
-    expect(prisma.securityToken.update).toHaveBeenCalled();
+    expect(prisma.securityToken.updateMany).toHaveBeenCalled();
 
     prisma.securityToken.findUnique.mockResolvedValue({
       ...row,
@@ -41,5 +41,28 @@ describe("security-token", () => {
       kind: SecurityTokenKind.PASSWORD_RESET,
     });
     expect(second).toBeNull();
+  });
+
+  it("returns null when token was consumed concurrently", async () => {
+    const raw = "race-token";
+    const prisma = {
+      securityToken: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "t1",
+          userId: "u1",
+          kind: SecurityTokenKind.PASSWORD_RESET,
+          usedAt: null,
+          expiresAt: new Date(Date.now() + 60_000),
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+
+    const consumed = await consumeSecurityToken(prisma as any, {
+      rawToken: raw,
+      kind: SecurityTokenKind.PASSWORD_RESET,
+    });
+
+    expect(consumed).toBeNull();
   });
 });

--- a/apps/web/src/lib/security-token.ts
+++ b/apps/web/src/lib/security-token.ts
@@ -30,18 +30,25 @@ export async function consumeSecurityToken(
   prisma: PrismaClient | Prisma.TransactionClient,
   input: { rawToken: string; kind: SecurityTokenKind },
 ): Promise<{ userId: string } | null> {
+  const now = new Date();
   const tokenHash = hashSecurityToken(input.rawToken);
   const row = await prisma.securityToken.findUnique({
     where: { tokenHash },
   });
   if (!row || row.kind !== input.kind) return null;
   if (row.usedAt) return null;
-  if (row.expiresAt < new Date()) return null;
+  if (row.expiresAt < now) return null;
 
-  await prisma.securityToken.update({
-    where: { id: row.id },
-    data: { usedAt: new Date() },
+  const consumed = await prisma.securityToken.updateMany({
+    where: {
+      id: row.id,
+      kind: input.kind,
+      usedAt: null,
+      expiresAt: { gte: now },
+    },
+    data: { usedAt: now },
   });
+  if (consumed.count !== 1) return null;
 
   return { userId: row.userId };
 }


### PR DESCRIPTION
### Motivation
- Prevent a race where two parallel requests could both consume the same one-time security token (password reset / email verification) due to a read-then-unconditional-update flow.  
- Make token consumption idempotent and fail-safe under concurrency without schema changes.

### Description
- Change `consumeSecurityToken` to use a guarded `updateMany` (matching `id`, `kind`, `usedAt: null`, and `expiresAt >= now`) and return `null` when the conditional update affects 0 rows, ensuring only one consumer succeeds; file: `apps/web/src/lib/security-token.ts`.  
- Replace ad-hoc `new Date()` calls with a single `now` to ensure consistent expiry checks in the same operation.  
- Extend `security-token` unit tests to assert normal single-use behavior and to explicitly cover the concurrent-consume/rejection case; file: `apps/web/src/lib/security-token.test.ts`.

### Testing
- Ran the targeted unit test: `npm run test --workspace=apps/web -- security-token.test.ts` and it passed.  
- Executed full repo quality gates: `npm install`, `npm run lint` (warnings only, pre-existing tenant-boundary warnings), `npm run typecheck` (passes), `npm run test` (all workspace tests passed), and `npm run build` (Next.js production build succeeded).  
- No migrations or env changes required and no new failures were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d45350b2bc832883d943ecb64d3108)