### PR TITLE
feat(web): AROS productization pass — activation, conversion, entitlement trust

### DIFF
--- a/apps/web/src/app/(dashboard)/clusters/page.tsx
+++ b/apps/web/src/app/(dashboard)/clusters/page.tsx
@@ -108,11 +108,18 @@ export default async function ClustersPage() {
       </div>
 
       {clusters.length === 0 ? (
-        <div className="card text-center py-12">
-          <h3 className="text-lg font-medium text-slate-900">No clusters yet</h3>
-          <p className="text-slate-500 mt-2">
-            Clusters are generated after scanning. Run a scan to discover component-level patterns.
-          </p>
+        <div className="card py-10 px-6">
+          <div className="mx-auto max-w-md text-center">
+            <h3 className="text-base font-semibold text-slate-900">No issue clusters yet</h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-500">
+              Issue clusters group related findings by component or selector pattern.
+              Fix a cluster once and resolve the same issue across every affected page —
+              higher leverage than fixing individual occurrences.
+            </p>
+            <Link href="/sites" className="btn-primary mt-6 inline-block text-sm">
+              Run a scan to discover patterns
+            </Link>
+          </div>
         </div>
       ) : (
         <div className="space-y-3">

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { requireSession } from "@/lib/session";
 import { prisma } from "@/lib/db";
 import Link from "next/link";
-import { Globe } from "lucide-react";
+import { ArrowRight, Globe, Sparkles } from "lucide-react";
 import { getRoutePlatformTruth } from "@/lib/platform-truth-cache";
 import {
   resolveDashboardOrgMembership,
@@ -247,78 +247,181 @@ export default async function DashboardPage() {
       </RouteReliabilityNotice>
     ) : null;
 
+  const isFirstRun = onboarding.stage === "not_started";
+
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       {workerNote}
+
+      {/* Free-plan upgrade banner */}
+      {!entitlement.hasPaidAccess && (
+        <div
+          className="flex flex-col gap-3 rounded-xl border border-brand-200 bg-brand-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+          role="status"
+          aria-label="Free plan notice"
+        >
+          <div className="flex items-start gap-3">
+            <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-brand-600" aria-hidden="true" />
+            <div>
+              <p className="text-sm font-semibold text-brand-900">You are on the Free plan</p>
+              <p className="mt-0.5 text-xs text-brand-700">
+                Private workspace, scans, findings, exports, and automation require an active paid subscription.
+              </p>
+            </div>
+          </div>
+          <Link
+            href="/settings/billing"
+            className="btn-primary shrink-0 self-start text-sm sm:self-auto"
+          >
+            View plans
+          </Link>
+        </div>
+      )}
+
       <PageHeader
         title="Dashboard"
         description={`Operational overview for ${orgName}.`}
       />
 
-      <section className="card space-y-4" aria-labelledby="assurance-posture-heading">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <h2 id="assurance-posture-heading" className="section-heading">
-            Assurance posture
-          </h2>
-          <span className="badge w-fit bg-slate-50 text-slate-800 ring-1 ring-inset ring-slate-200">
-            {automationHealth}
-          </span>
-        </div>
-        <p className="text-sm text-slate-600">
-          Current evidence is <span className="font-medium text-slate-800">{freshness}</span>. Comparability is <span className="font-medium text-slate-800">{comparability}</span>.
-          {latestCrawl
-            ? " Verification status requires a fresh follow-up crawl after remediation status changes."
-            : " Run the first crawl to establish a baseline before making proof claims."}
-        </p>
-        <div className="grid gap-3 sm:grid-cols-3">
-          <TruthTile label="Freshness" value={freshness} />
-          <TruthTile label="Comparability" value={comparability} />
-          <TruthTile label="Automation lane" value={automationHealth} />
-        </div>
-      </section>
+      {/* Activation hub — prominent when workspace is not started */}
+      {isFirstRun ? (
+        <section
+          className="overflow-hidden rounded-2xl border border-brand-200 bg-gradient-to-br from-white to-brand-50/40"
+          aria-labelledby="activation-hub-heading"
+        >
+          <div className="px-6 py-6 sm:px-8">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-brand-700">
+              Start here
+            </p>
+            <h2
+              id="activation-hub-heading"
+              className="mt-2 text-xl font-semibold text-slate-900"
+            >
+              Set up your first private workspace
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm text-slate-600">
+              Add a site, run your first private scan, and start building an evidence record that your team can stand behind.
+              Every step below unlocks the next.
+            </p>
+            <ol className="mt-5 space-y-3" aria-label="Activation steps">
+              {onboarding.stages.map((stage, i) => (
+                <li
+                  key={stage.id}
+                  className={`flex items-start gap-4 rounded-xl border px-4 py-3 ${
+                    stage.complete
+                      ? "border-emerald-200 bg-emerald-50/60"
+                      : stage.blocked
+                        ? "border-amber-200 bg-amber-50/60"
+                        : i === onboarding.stages.findIndex((s) => !s.complete)
+                          ? "border-brand-300 bg-white shadow-sm"
+                          : "border-slate-200 bg-slate-50/60"
+                  }`}
+                >
+                  <div
+                    className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+                      stage.complete
+                        ? "bg-emerald-600 text-white"
+                        : stage.blocked
+                          ? "bg-amber-200 text-amber-900"
+                          : "bg-brand-600 text-white"
+                    }`}
+                    aria-hidden="true"
+                  >
+                    {stage.complete ? "✓" : i + 1}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-slate-900">{stage.label}</p>
+                    {stage.blockerReason && (
+                      <p className="mt-0.5 text-xs text-amber-800">{stage.blockerReason}</p>
+                    )}
+                  </div>
+                  {!stage.complete && !stage.blocked && (
+                    <Link
+                      href={stage.href as any}
+                      className="flex shrink-0 items-center gap-1 rounded-lg bg-brand-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-1"
+                    >
+                      Go
+                      <ArrowRight className="h-3 w-3" aria-hidden="true" />
+                    </Link>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+      ) : (
+        <section className="card space-y-4" aria-labelledby="onboarding-status-heading">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h2 id="onboarding-status-heading" className="section-heading">
+              Workspace readiness
+            </h2>
+            <span className="badge w-fit bg-slate-50 text-slate-800 ring-1 ring-inset ring-slate-200">
+              {onboarding.stage.replaceAll("_", " ")}
+            </span>
+          </div>
+          {onboarding.stage !== "first_value_reached" && (
+            <p className="text-sm text-slate-600">
+              Next step:{" "}
+              <Link href={onboarding.nextStep.href as any} className="font-medium text-brand-700 underline underline-offset-2">
+                {onboarding.nextStep.label}
+              </Link>
+              {onboarding.nextStep.blockerReason
+                ? ` — Blocked: ${onboarding.nextStep.blockerReason}`
+                : "."}
+            </p>
+          )}
+          <ol className="space-y-2" aria-label="Onboarding checklist">
+            {onboarding.stages.map((stage) => (
+              <li key={stage.id} className="flex items-start justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium text-slate-900">{stage.label}</p>
+                  {stage.blockerReason && (
+                    <p className="text-xs text-amber-700">{stage.blockerReason}</p>
+                  )}
+                </div>
+                <span
+                  className={`badge ${
+                    stage.complete
+                      ? "bg-emerald-50 text-emerald-700 border border-emerald-200"
+                      : stage.blocked
+                        ? "bg-amber-50 text-amber-700 border border-amber-200"
+                        : "bg-slate-100 text-slate-700 border border-slate-200"
+                  }`}
+                >
+                  {stage.complete ? "Complete" : stage.blocked ? "Blocked" : "Pending"}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
 
-      <section className="card space-y-4" aria-labelledby="onboarding-status-heading">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <h2 id="onboarding-status-heading" className="section-heading">
-            Workspace readiness
-          </h2>
-          <span className="badge w-fit bg-slate-50 text-slate-800 ring-1 ring-inset ring-slate-200">
-            {onboarding.stage.replaceAll("_", " ")}
-          </span>
-        </div>
-        <p className="text-sm text-slate-600">
-          Next step:{" "}
-          <Link href={onboarding.nextStep.href as any} className="font-medium text-brand-700 underline">
-            {onboarding.nextStep.label}
-          </Link>
-          {onboarding.nextStep.blockerReason
-            ? ` — Blocked: ${onboarding.nextStep.blockerReason}`
-            : "."}
-        </p>
-        <ol className="space-y-2" aria-label="Onboarding checklist">
-          {onboarding.stages.map((stage) => (
-            <li key={stage.id} className="flex items-start justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2">
-              <div>
-                <p className="text-sm font-medium text-slate-900">{stage.label}</p>
-                {stage.blockerReason && (
-                  <p className="text-xs text-amber-700">{stage.blockerReason}</p>
-                )}
-              </div>
-              <span
-                className={`badge ${
-                  stage.complete
-                    ? "bg-emerald-50 text-emerald-700 border border-emerald-200"
-                    : stage.blocked
-                      ? "bg-amber-50 text-amber-700 border border-amber-200"
-                      : "bg-slate-100 text-slate-700 border border-slate-200"
-                }`}
+      {/* Priority actions — only show when there's meaningful data */}
+      {(openFindings > 0 || pendingReviews > 0) && (
+        <section className="card space-y-3" aria-labelledby="priority-actions-heading">
+          <h2 id="priority-actions-heading" className="section-heading">Needs attention</h2>
+          <div className="flex flex-wrap gap-3">
+            {openFindings > 0 && (
+              <Link
+                href="/findings?status=OPEN"
+                className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm font-medium text-red-800 transition-colors hover:bg-red-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
               >
-                {stage.complete ? "Complete" : stage.blocked ? "Blocked" : "Pending"}
-              </span>
-            </li>
-          ))}
-        </ol>
-      </section>
+                {openFindings} open finding{openFindings !== 1 ? "s" : ""}
+                <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+              </Link>
+            )}
+            {pendingReviews > 0 && (
+              <Link
+                href="/reviews"
+                className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-medium text-amber-800 transition-colors hover:bg-amber-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1"
+              >
+                {pendingReviews} pending review{pendingReviews !== 1 ? "s" : ""}
+                <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+              </Link>
+            )}
+          </div>
+        </section>
+      )}
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard label="Sites" value={sitesCount} href="/sites" />
@@ -335,8 +438,30 @@ export default async function DashboardPage() {
         />
       </div>
 
+      <section className="card space-y-4" aria-labelledby="assurance-posture-heading">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <h2 id="assurance-posture-heading" className="section-heading">
+            Assurance posture
+          </h2>
+          <span className="badge w-fit bg-slate-50 text-slate-800 ring-1 ring-inset ring-slate-200">
+            {automationHealth}
+          </span>
+        </div>
+        <p className="text-sm text-slate-600">
+          Evidence freshness is <span className="font-medium text-slate-800">{freshness}</span>. Scan comparability is <span className="font-medium text-slate-800">{comparability}</span>.
+          {latestCrawl
+            ? " A fresh crawl and scan after each code change keeps evidence current."
+            : " Run your first crawl to establish an evidence baseline."}
+        </p>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <TruthTile label="Evidence freshness" value={freshness} />
+          <TruthTile label="Scan comparability" value={comparability} />
+          <TruthTile label="Automation lane" value={automationHealth} />
+        </div>
+      </section>
+
       <div className="card">
-        <h2 className="section-heading mb-4">Next steps</h2>
+        <h2 className="section-heading mb-4">Quick actions</h2>
         <div className="flex flex-wrap gap-3">
           <Link href="/sites/new" className="btn-primary">
             Add site
@@ -356,10 +481,10 @@ export default async function DashboardPage() {
           <EmptyState
             icon={Globe}
             title="No crawls yet"
-            description="Add a site to get started with accessibility scanning."
+            description="Add a site and run your first crawl to begin collecting accessibility evidence."
             action={
               <Link href="/sites/new" className="btn-primary">
-                Add a Site
+                Add a site
               </Link>
             }
           />

--- a/apps/web/src/app/(dashboard)/remediation/page.tsx
+++ b/apps/web/src/app/(dashboard)/remediation/page.tsx
@@ -142,17 +142,29 @@ export default async function RemediationPage() {
         </p>
       </div>
 
-      <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
-        All suggestions are AI-generated drafts. They must be reviewed by a
-        human before export or application. Automated scanning cannot guarantee
-        full WCAG conformance.
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+        All suggestions are AI-generated drafts and require human review before export or application.
+        Source-first means fixing the actual broken element — not adding an overlay.
+        Automated analysis cannot guarantee full WCAG conformance; expert manual audit may still be required.
       </div>
 
       {suggestions.length === 0 ? (
-        <div className="card text-center py-12">
-          <p className="text-slate-500">
-            No remediation suggestions yet. Run scans to generate them.
-          </p>
+        <div className="card py-10 px-6">
+          <div className="mx-auto max-w-md text-center">
+            <h3 className="text-base font-semibold text-slate-900">No remediation suggestions yet</h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-500">
+              Source-first remediation suggestions are AI-drafted code fixes generated from your findings.
+              Each suggestion targets the actual broken element — not an overlay workaround — and must be reviewed by a human before it is safe to apply.
+            </p>
+            <div className="mt-6 flex flex-col items-center gap-2">
+              <Link href="/sites" className="btn-primary text-sm">
+                Go to sites and run a scan
+              </Link>
+              <p className="text-xs text-slate-400">
+                After a scan completes, open any finding to generate a suggestion.
+              </p>
+            </div>
+          </div>
         </div>
       ) : (
         <div className="space-y-3">

--- a/apps/web/src/app/(dashboard)/reviews/page.tsx
+++ b/apps/web/src/app/(dashboard)/reviews/page.tsx
@@ -167,10 +167,9 @@ export default async function ReviewsPage({
         </p>
       </div>
 
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-800">
-        Some accessibility criteria cannot be verified by automated scanning
-        alone. These tasks require human review for accurate conformance
-        assessment.
+      <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800">
+        Some accessibility criteria require human judgment — automated scanning cannot capture them.
+        Each review task here records a human decision for audit purposes.
       </div>
 
       {reviewError && (
@@ -180,8 +179,22 @@ export default async function ReviewsPage({
       )}
 
       {tasks.length === 0 ? (
-        <div className="card text-center py-12">
-          <p className="text-slate-500">No review tasks yet.</p>
+        <div className="card py-10 px-6">
+          <div className="mx-auto max-w-md text-center">
+            <h3 className="text-base font-semibold text-slate-900">No review tasks yet</h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-500">
+              Review tasks are created when AI-assisted remediation suggestions are generated for your findings.
+              Each suggestion must pass human review before it can be exported or applied — automated analysis alone is not enough.
+            </p>
+            <div className="mt-6 flex flex-col items-center gap-2">
+              <Link href="/findings" className="btn-primary text-sm">
+                View findings backlog
+              </Link>
+              <p className="text-xs text-slate-400">
+                Findings → Remediation suggestions → Review tasks
+              </p>
+            </div>
+          </div>
         </div>
       ) : (
         <div className="space-y-3">

--- a/apps/web/src/app/(public)/scan/[domain]/public-scan-body.tsx
+++ b/apps/web/src/app/(public)/scan/[domain]/public-scan-body.tsx
@@ -334,22 +334,49 @@ export function PublicScanBody({ domain, initialScan }: Props) {
             </div>
           )}
 
-          <div className="card border-[rgb(var(--color-border))] bg-[rgb(var(--color-canvas))] text-center py-10">
-            <h2 className="text-xl font-bold text-slate-900">
-              Need monitored coverage and exports?
-            </h2>
-            <p className="mt-2 text-slate-600 max-w-xl mx-auto text-sm">
-              Workspaces add private crawls, tracked findings, remediation
-              workflows, and plan-gated exports with server-enforced limits.
+          <div className="rounded-2xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-canvas))] px-6 py-8">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-brand-700">
+              Private workspace
             </p>
-            <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+            <h2 className="mt-2 text-xl font-bold text-slate-900">
+              {currentProof.totalViolations > 0
+                ? `Track and address these ${currentProof.totalViolations} issue${currentProof.totalViolations !== 1 ? "s" : ""} over time`
+                : "Monitor this site continuously with a private workspace"}
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm text-slate-600">
+              {currentProof.totalViolations > 0
+                ? `This public sample covered ${currentProof.pagesScanned} page${currentProof.pagesScanned !== 1 ? "s" : ""} and expires shortly. A private workspace stores your full scan history, lets you track regressions, and produces evidence reports for auditors and stakeholders.`
+                : `Your site returned a clean public sample. A private workspace runs recurring scans across your full domain, so regressions surface before they reach production.`}
+            </p>
+            <ul className="mt-4 space-y-1.5 text-sm text-slate-700" role="list">
+              <li className="flex items-start gap-2">
+                <span className="mt-0.5 text-brand-600" aria-hidden="true">›</span>
+                <span><span className="font-medium">Persistent history:</span> compare each scan run — detect regressions before stakeholders do</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-0.5 text-brand-600" aria-hidden="true">›</span>
+                <span><span className="font-medium">Full-domain coverage:</span> scan beyond the 5-page public sample limit</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-0.5 text-brand-600" aria-hidden="true">›</span>
+                <span><span className="font-medium">Evidence exports:</span> structured JSON/CSV reports for audits, tickets, and legal review</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-0.5 text-brand-600" aria-hidden="true">›</span>
+                <span><span className="font-medium">Source-first remediation:</span> AI-drafted fix suggestions with human-review workflows — no overlay substitutes</span>
+              </li>
+            </ul>
+            <div className="mt-6 flex flex-wrap items-center gap-3">
               <Link href="/signup" className="btn-primary px-6 py-3">
-                Create workspace
+                Create free workspace
               </Link>
               <Link href="/" className="btn-secondary px-6 py-3">
                 Scan another site
               </Link>
             </div>
+            <p className="mt-4 text-xs text-slate-500">
+              Free to start. Paid plans unlock full-domain scans, team seats, saved org history, and API access — enforced server-side.
+            </p>
           </div>
 
           <div className="rounded-lg border border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))] px-4 py-3 text-center text-sm text-slate-600">

--- a/apps/web/src/components/layout/mobile-dashboard-nav.tsx
+++ b/apps/web/src/components/layout/mobile-dashboard-nav.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useTransition } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Key, Users } from "lucide-react";
+import { CreditCard, Key, Lock, Sparkles, Users } from "lucide-react";
 import {
   DASHBOARD_NAV_ITEMS,
   NAV_ICON_MAP,
@@ -165,11 +165,11 @@ export function MobileDashboardNav({
 
         <nav className="flex-1 overflow-y-auto p-3" aria-label="Main">
           <ul className="space-y-1" role="list">
-            {DASHBOARD_NAV_ITEMS.filter(
-              (item) => hasPaidAccess || !item.premium,
-            ).map((item, i) => {
+            {DASHBOARD_NAV_ITEMS.map((item, i) => {
+              const isLocked = item.premium && !hasPaidAccess;
               const isActive =
-                pathname === item.href || pathname.startsWith(item.href + "/");
+                !isLocked &&
+                (pathname === item.href || pathname.startsWith(item.href + "/"));
               const Icon = NAV_ICON_MAP[item.icon];
               return (
                 <li key={item.href}>
@@ -177,17 +177,23 @@ export function MobileDashboardNav({
                     ref={i === 0 ? firstLinkRef : undefined}
                     href={item.href}
                     className={`flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                      isActive
-                        ? "bg-brand-50 text-brand-700"
-                        : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                      isLocked
+                        ? "text-slate-400 hover:bg-slate-50 hover:text-slate-500"
+                        : isActive
+                          ? "bg-brand-50 text-brand-700"
+                          : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
                     }`}
                     aria-current={isActive ? "page" : undefined}
+                    aria-label={isLocked ? `${item.label} — requires paid plan` : undefined}
                     onClick={closeMobileNav}
                   >
                     {Icon && (
                       <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
                     )}
-                    {item.label}
+                    <span className="flex-1">{item.label}</span>
+                    {isLocked && (
+                      <Lock className="h-3.5 w-3.5 shrink-0 text-slate-300" aria-hidden="true" />
+                    )}
                   </Link>
                 </li>
               );
@@ -221,6 +227,30 @@ export function MobileDashboardNav({
               Settings
             </div>
             <ul className="mt-1 space-y-1" role="list">
+              <li>
+                <Link
+                  href="/settings/billing"
+                  className={`flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                    pathname.startsWith("/settings/billing")
+                      ? "bg-brand-50 text-brand-700"
+                      : !hasPaidAccess
+                        ? "text-brand-700 hover:bg-brand-50"
+                        : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                  }`}
+                  aria-current={
+                    pathname.startsWith("/settings/billing") ? "page" : undefined
+                  }
+                  onClick={closeMobileNav}
+                >
+                  <CreditCard className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  <span className="flex-1">Billing</span>
+                  {!hasPaidAccess && (
+                    <span className="rounded-full bg-brand-100 px-1.5 py-0.5 text-[10px] font-semibold text-brand-700">
+                      Upgrade
+                    </span>
+                  )}
+                </Link>
+              </li>
               <li>
                 <Link
                   href="/settings/api-keys"
@@ -257,6 +287,19 @@ export function MobileDashboardNav({
               </li>
             </ul>
           </div>
+
+          {!hasPaidAccess && (
+            <div className="mt-4 px-1">
+              <Link
+                href="/settings/billing"
+                className="flex min-h-[44px] items-center gap-2 rounded-lg border border-brand-100 bg-brand-50 px-3 py-2 text-sm font-semibold text-brand-700 transition-colors hover:bg-brand-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-1"
+                onClick={closeMobileNav}
+              >
+                <Sparkles className="h-4 w-4 shrink-0" aria-hidden="true" />
+                Upgrade to unlock workspace
+              </Link>
+            </div>
+          )}
 
           {aiUsage && (
             <AiUsageIndicator

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import { useTransition } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Key, Users } from "lucide-react";
+import { CreditCard, Key, Lock, Sparkles, Users } from "lucide-react";
 import {
   DASHBOARD_NAV_ITEMS,
   NAV_ICON_MAP,
@@ -93,27 +93,33 @@ export function Sidebar({
 
       <nav className="flex-1 overflow-y-auto p-3">
         <ul className="space-y-1" role="list">
-          {DASHBOARD_NAV_ITEMS.filter(
-            (item) => hasPaidAccess || !item.premium,
-          ).map((item) => {
+          {DASHBOARD_NAV_ITEMS.map((item) => {
+            const isLocked = item.premium && !hasPaidAccess;
             const isActive =
-              pathname === item.href || pathname.startsWith(item.href + "/");
+              !isLocked &&
+              (pathname === item.href || pathname.startsWith(item.href + "/"));
             const Icon = NAV_ICON_MAP[item.icon];
             return (
               <li key={item.href}>
                 <Link
                   href={item.href}
                   className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                    isActive
-                      ? "bg-brand-50 text-brand-700"
-                      : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                    isLocked
+                      ? "text-slate-400 hover:bg-slate-50 hover:text-slate-500"
+                      : isActive
+                        ? "bg-brand-50 text-brand-700"
+                        : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
                   }`}
                   aria-current={isActive ? "page" : undefined}
+                  aria-label={isLocked ? `${item.label} — requires paid plan` : undefined}
                 >
                   {Icon && (
                     <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
                   )}
-                  {item.label}
+                  <span className="flex-1">{item.label}</span>
+                  {isLocked && (
+                    <Lock className="h-3 w-3 shrink-0 text-slate-300" aria-hidden="true" />
+                  )}
                 </Link>
               </li>
             );
@@ -166,6 +172,29 @@ export function Sidebar({
           <ul className="mt-1 space-y-1" role="list">
             <li>
               <Link
+                href="/settings/billing"
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  pathname.startsWith("/settings/billing")
+                    ? "bg-brand-50 text-brand-700"
+                    : !hasPaidAccess
+                      ? "text-brand-700 hover:bg-brand-50"
+                      : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                }`}
+                aria-current={
+                  pathname.startsWith("/settings/billing") ? "page" : undefined
+                }
+              >
+                <CreditCard className="h-4 w-4 shrink-0" aria-hidden="true" />
+                <span className="flex-1">Billing</span>
+                {!hasPaidAccess && (
+                  <span className="rounded-full bg-brand-100 px-1.5 py-0.5 text-[10px] font-semibold text-brand-700">
+                    Upgrade
+                  </span>
+                )}
+              </Link>
+            </li>
+            <li>
+              <Link
                 href="/settings/api-keys"
                 className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                   pathname.startsWith("/settings/api-keys")
@@ -198,6 +227,18 @@ export function Sidebar({
             </li>
           </ul>
         </div>
+
+        {!hasPaidAccess && (
+          <div className="mt-4 px-1">
+            <Link
+              href="/settings/billing"
+              className="flex items-center gap-2 rounded-lg border border-brand-100 bg-brand-50 px-3 py-2 text-xs font-semibold text-brand-700 transition-colors hover:bg-brand-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-1"
+            >
+              <Sparkles className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              Upgrade to unlock workspace
+            </Link>
+          </div>
+        )}
 
         {aiUsage && (
           <AiUsageIndicator

--- a/apps/web/src/components/monetization/ai-upsell.tsx
+++ b/apps/web/src/components/monetization/ai-upsell.tsx
@@ -38,17 +38,11 @@ export function AiUpsell({ reason }: AiUpsellProps) {
             {description}
           </p>
           <div className="mt-4 flex flex-wrap gap-3">
-            <Link 
-              href={"/settings/billing" as any} 
-              className="bg-brand-600 hover:bg-brand-700 text-white px-5 py-2 rounded-lg text-sm font-semibold transition-all shadow-md shadow-brand-100"
+            <Link
+              href={"/settings/billing" as any}
+              className="rounded-lg bg-brand-600 px-5 py-2 text-sm font-semibold text-white shadow-md shadow-brand-100 transition-all hover:bg-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-1"
             >
               View plans and upgrade
-            </Link>
-            <Link 
-              href={"/settings/billing" as any} 
-              className="bg-white border border-slate-200 text-slate-700 px-5 py-2 rounded-lg text-sm font-semibold hover:bg-slate-50 transition-all"
-            >
-              Manage billing
             </Link>
           </div>
         </div>


### PR DESCRIPTION
Closes the gap between public curiosity, first-value, and paid conversion:

SIDEBAR / NAVIGATION
- Show all premium nav items for free users with a Lock icon instead of
  hiding them — makes locked value visible and creates persistent upgrade pressure
- Add a Billing link to the settings section; highlight it as "Upgrade" with
  a pill badge when the org has no paid access
- Add an "Upgrade to unlock workspace" CTA at the bottom of nav for free users
- Mirror all changes in MobileDashboardNav for mobile parity

DASHBOARD ACTIVATION HUB
- First-run state (no sites / scans / findings) now renders a full hero-style
  activation card with numbered steps, step-specific CTAs, and per-step blocked
  state handling — replaces a flat checklist with a decisive operator flow
- Collected-data state retains the checklist but shows "next step" as a link
- Add a free-plan upgrade banner at the top of the dashboard for orgs without
  a paid subscription — honest, non-alarmist, always visible
- Priority attention section surfaces open-findings and pending-reviews counts
  as colored action chips when data exists
- Reorganize section order: upgrade banner → activation hub → attention → stats
  → assurance posture → quick actions → recent crawls

PUBLIC SCAN → ACCOUNT CONVERSION
- Conversion CTA at the bottom of public scan results is now contextual:
  references the actual totalViolations count and page sample size
  instead of generic feature boilerplate
- Lists four specific private workspace values (history, full-domain, exports,
  source-first remediation) with honest "Free to start" caveat
- CTA label changed from "Create workspace" to "Create free workspace" to
  reduce friction

EMPTY STATES (reviews / remediation / clusters)
- Reviews: explain the review-task lifecycle (findings → suggestions → tasks),
  link to findings, clarify that human review is an audit requirement
- Remediation: explain source-first philosophy, link to sites, clarify
  AI-draft-requires-human-review constraint
- Clusters: explain component-level leverage, link to scan initiation
- All three replace bare single-line placeholders with structured guidance

COPY / TRUST TIGHTENING
- Remediation amber notice now explicitly states "source-first means fixing the
  actual broken element — not adding an overlay"
- Reviews blue notice condensed and made more precise
- Dashboard assurance posture labels updated: "Evidence freshness" and
  "Scan comparability" instead of "Freshness" / "Comparability"

AI UPSELL
- Remove the duplicate "Manage billing" button (identical href to "View plans")

VERIFICATION
- npm run typecheck: PASS
- npm run build: PASS
- npm run test: 230/231 passing; 1 pre-existing DNS-timeout failure in
  target-validation.test.ts unrelated to this change (confirmed by stash test)
- npm run lint: pre-existing @eslint/eslintrc env failure; not introduced here

https://claude.ai/code/session_01L3LATC2FYgZd5B6P6wfH4t