### PR TITLE
Add recurring crawl cadence controls and worker scheduler

### DIFF
--- a/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/page.tsx
@@ -32,6 +32,11 @@ import {
   retryPostCrawlScanKickoffAction,
 } from "./scan-actions";
 import { pageTitle } from "@/lib/product-brand";
+import {
+  nextScheduleRunAt,
+  scheduleBlockedReason,
+  scheduleCadenceLabel,
+} from "@aros/core-services";
 
 export async function generateMetadata({
   params,
@@ -314,6 +319,12 @@ export default async function SiteDetailPage({
         ? "Verification is already running for this site."
         : null;
 
+  const scheduleCron = site.crawlConfig?.scheduleCron ?? null;
+  const cadenceLabel = scheduleCadenceLabel(scheduleCron);
+  const scheduleNextRunAt = nextScheduleRunAt(scheduleCron, new Date());
+  const scheduleBlockedHint = scheduleBlockedReason(scheduleCron);
+  const lastSuccessfulCrawl = recentCrawls.find((crawl) => crawl.status === "COMPLETED" && crawl.completedAt);
+
   const findingsBySeverity = {
     critical: findings.filter((f) => f.impact === "CRITICAL").length,
     serious: findings.filter((f) => f.impact === "SERIOUS").length,
@@ -449,6 +460,17 @@ export default async function SiteDetailPage({
         <div className="card">
           <p className="text-sm text-slate-500">Open Findings</p>
           <p className="text-2xl font-bold text-slate-900">{findings.length}</p>
+        </div>
+        <div className="card sm:col-span-2 lg:col-span-4">
+          <p className="text-sm text-slate-500">Recurring crawl automation</p>
+          <div className="mt-2 grid gap-2 text-sm text-slate-700 sm:grid-cols-3">
+            <p><span className="font-medium text-slate-900">Cadence:</span> {cadenceLabel}</p>
+            <p><span className="font-medium text-slate-900">Last successful crawl:</span> {lastSuccessfulCrawl?.completedAt?.toLocaleString() ?? "Never"}</p>
+            <p><span className="font-medium text-slate-900">Next scheduled run (UTC window end):</span> {scheduleNextRunAt?.toLocaleString() ?? "Not scheduled"}</p>
+          </div>
+          {scheduleBlockedHint ? (
+            <p className="mt-2 text-xs text-amber-700">Blocked: {scheduleBlockedHint}</p>
+          ) : null}
         </div>
       </div>
 

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.test.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.test.ts
@@ -33,26 +33,37 @@ describe('updateAutoScanAfterCrawlAction', () => {
     vi.mocked(prisma.auditLog.create).mockResolvedValue({} as never);
   });
 
-  it('persists autoScanAfterCrawl false when checkbox off', async () => {
+  it('persists automation settings with cadence off', async () => {
     const fd = new FormData();
     fd.set('siteId', 's1');
+    fd.set('scheduleCron', 'off');
     const result = await updateAutoScanAfterCrawlAction(undefined, fd);
     expect(result).toEqual({ ok: true });
     expect(prisma.crawlConfig.updateMany).toHaveBeenCalledWith({
       where: { siteId: 's1', site: { workspace: { organizationId: 'o1' } } },
-      data: { autoScanAfterCrawl: false },
+      data: { autoScanAfterCrawl: false, scheduleCron: null },
     });
   });
 
-  it('persists autoScanAfterCrawl true when checkbox on', async () => {
+  it('persists autoScanAfterCrawl true and supported cadence', async () => {
     const fd = new FormData();
     fd.set('siteId', 's1');
     fd.set('autoScanAfterCrawl', 'on');
+    fd.set('scheduleCron', '@weekly');
     const result = await updateAutoScanAfterCrawlAction(undefined, fd);
     expect(result).toEqual({ ok: true });
     expect(prisma.crawlConfig.updateMany).toHaveBeenCalledWith({
       where: { siteId: 's1', site: { workspace: { organizationId: 'o1' } } },
-      data: { autoScanAfterCrawl: true },
+      data: { autoScanAfterCrawl: true, scheduleCron: '@weekly' },
     });
+  });
+
+  it('rejects unsupported cadence strings', async () => {
+    const fd = new FormData();
+    fd.set('siteId', 's1');
+    fd.set('scheduleCron', '0 0 * * *');
+    const result = await updateAutoScanAfterCrawlAction(undefined, fd);
+    expect(result).toEqual({ ok: false, error: 'Unsupported scan cadence.' });
+    expect(prisma.crawlConfig.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.ts
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.ts
@@ -4,10 +4,17 @@ import { revalidatePath } from 'next/cache';
 import { requireSiteAccess } from '@/lib/auth-guard';
 import {
   createScanAuditLog,
-  updateCrawlConfigAutoScan,
+  updateCrawlAutomationSettings,
 } from '@/lib/dashboard-org-scoped-prisma';
+import { parseSupportedScheduleCron } from '@aros/core-services';
 
 export type AutoScanSettingsState = { ok: true } | { ok: false; error: string };
+
+function normalizeScheduleCron(input: FormDataEntryValue | null): string | null {
+  const raw = typeof input === 'string' ? input.trim() : '';
+  if (!raw || raw === 'off') return null;
+  return parseSupportedScheduleCron(raw);
+}
 
 export async function updateAutoScanAfterCrawlAction(
   _prev: AutoScanSettingsState | undefined,
@@ -23,11 +30,16 @@ export async function updateAutoScanAfterCrawlAction(
       requirePaid: true,
     });
     const enabled = formData.get('autoScanAfterCrawl') === 'on';
+    const scheduleCron = normalizeScheduleCron(formData.get('scheduleCron'));
 
-    const updated = await updateCrawlConfigAutoScan(
+    if (formData.get('scheduleCron') && scheduleCron === null && formData.get('scheduleCron') !== 'off') {
+      return { ok: false, error: 'Unsupported scan cadence.' };
+    }
+
+    const updated = await updateCrawlAutomationSettings(
       ctx.siteId,
       ctx.organizationId,
-      enabled
+      { autoScanAfterCrawl: enabled, scheduleCron }
     );
     if (!updated) {
       return { ok: false, error: 'Could not save settings.' };
@@ -36,10 +48,10 @@ export async function updateAutoScanAfterCrawlAction(
     await createScanAuditLog({
       organizationId: ctx.organizationId,
       userId: ctx.user.id,
-      action: 'crawl.auto_scan_after_crawl.updated',
+      action: 'crawl.automation_settings.updated',
       entityType: 'CrawlConfig',
       entityId: ctx.siteId,
-      metadata: { autoScanAfterCrawl: enabled },
+      metadata: { autoScanAfterCrawl: enabled, scheduleCron },
     }).catch(() => undefined);
 
     revalidatePath(`/sites/${siteId}`);

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/auto-scan-form.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/auto-scan-form.tsx
@@ -6,9 +6,11 @@ import { updateAutoScanAfterCrawlAction } from "./actions";
 export function AutoScanAfterCrawlForm({
   siteId,
   initialEnabled,
+  initialScheduleCron,
 }: {
   siteId: string;
   initialEnabled: boolean;
+  initialScheduleCron: string | null;
 }) {
   const [state, formAction, pending] = useActionState(
     updateAutoScanAfterCrawlAction,
@@ -41,6 +43,26 @@ export function AutoScanAfterCrawlForm({
           </span>
         </span>
       </label>
+
+      <label className="block text-sm text-slate-700" htmlFor="schedule-cadence">
+        <span className="font-medium text-slate-900">Scheduled crawl cadence</span>
+        <span className="mt-1 block text-slate-500">
+          Recurring crawl execution happens in UTC. Scheduled crawls are only
+          enqueued for verified sites on active paid or trialing subscriptions.
+        </span>
+        <select
+          id="schedule-cadence"
+          name="scheduleCron"
+          defaultValue={initialScheduleCron ?? "off"}
+          className="mt-2 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+        >
+          <option value="off">Off</option>
+          <option value="@daily">Daily</option>
+          <option value="@weekly">Weekly</option>
+          <option value="@monthly">Monthly</option>
+        </select>
+      </label>
+
       <div className="flex items-center gap-3">
         <button type="submit" className="btn-primary" disabled={pending}>
           {pending ? "Saving…" : "Save"}

--- a/apps/web/src/app/(dashboard)/sites/[siteId]/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/[siteId]/settings/page.tsx
@@ -104,6 +104,7 @@ export default async function SiteSettingsPage({
   }
 
   const autoScanAfterCrawl = site.crawlConfig?.autoScanAfterCrawl !== false;
+  const scheduleCron = site.crawlConfig?.scheduleCron ?? null;
 
   return (
     <div className="mx-auto max-w-2xl space-y-8">
@@ -132,6 +133,7 @@ export default async function SiteSettingsPage({
         <AutoScanAfterCrawlForm
           siteId={siteId}
           initialEnabled={autoScanAfterCrawl}
+          initialScheduleCron={scheduleCron}
         />
       </div>
     </div>

--- a/apps/web/src/lib/dashboard-org-scoped-prisma.test.ts
+++ b/apps/web/src/lib/dashboard-org-scoped-prisma.test.ts
@@ -38,7 +38,7 @@ import {
   loadRemediationSuggestionForOrg,
   loadReviewTaskForOrg,
   revokeApiKeyForOrg,
-  updateCrawlConfigAutoScan,
+  updateCrawlAutomationSettings,
   updateReviewTaskStatusForOrg,
 } from "./dashboard-org-scoped-prisma";
 
@@ -98,9 +98,9 @@ describe("dashboard-org-scoped-prisma", () => {
     );
   });
 
-  it("updateCrawlConfigAutoScan requires matching site workspace org", async () => {
+  it("updateCrawlAutomationSettings requires matching site workspace org", async () => {
     updateManyCrawlConfig.mockResolvedValueOnce({ count: 0 });
-    const ok = await updateCrawlConfigAutoScan("site-1", "org-y", true);
+    const ok = await updateCrawlAutomationSettings("site-1", "org-y", { autoScanAfterCrawl: true, scheduleCron: "@daily" });
     expect(ok).toBe(false);
     expect(updateManyCrawlConfig).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/src/lib/dashboard-org-scoped-prisma.ts
+++ b/apps/web/src/lib/dashboard-org-scoped-prisma.ts
@@ -422,14 +422,17 @@ export async function createScanAuditLog(input: {
   });
 }
 
-export async function updateCrawlConfigAutoScan(
+export async function updateCrawlAutomationSettings(
   siteId: string,
   organizationId: string,
-  enabled: boolean,
+  input: { autoScanAfterCrawl: boolean; scheduleCron: string | null },
 ) {
   const updated = await prisma.crawlConfig.updateMany({
     where: { siteId, site: { workspace: { organizationId } } },
-    data: { autoScanAfterCrawl: enabled },
+    data: {
+      autoScanAfterCrawl: input.autoScanAfterCrawl,
+      scheduleCron: input.scheduleCron,
+    },
   });
   return updated.count === 1;
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -9,6 +9,7 @@ import { handleRemediationJob } from "./jobs/remediation";
 import { handlePublicScanJob } from "./jobs/public-scan";
 import { AgentOrchestrator } from "@aros/agents";
 import { bullmqConnectionOptions, VISUAL_REVIEW_QUEUE_NAME } from "@aros/shared";
+import { startScheduledCrawlLoop } from "./services/scheduled-crawls";
 
 async function handleVisualReviewJob(job: any) {
   const { siteId, scanRunId, organizationId } = job.data;
@@ -103,9 +104,12 @@ const heartbeatInterval = setInterval(() => {
   void heartbeatTick();
 }, HEARTBEAT_MS);
 
+const scheduledCrawlInterval = startScheduledCrawlLoop(prisma);
+
 async function shutdown() {
   console.log("[Worker] Shutting down...");
   clearInterval(heartbeatInterval);
+  clearInterval(scheduledCrawlInterval);
   await Promise.all([
     crawlWorker.close(),
     scanWorker.close(),

--- a/apps/worker/src/services/scheduled-crawls.ts
+++ b/apps/worker/src/services/scheduled-crawls.ts
@@ -1,0 +1,264 @@
+import { Queue } from "bullmq";
+import type { PrismaClient } from "@aros/db";
+import { bullmqConnectionOptions } from "@aros/shared";
+import {
+  currentScheduleWindow,
+  parseSupportedScheduleCron,
+} from "@aros/core-services";
+
+const ONE_MINUTE_MS = 60_000;
+
+interface CrawlJobData {
+  crawlRunId: string;
+  siteId: string;
+  config: {
+    sitemapUrl?: string;
+    maxDepth: number;
+    maxPages: number;
+    includePatterns: string[];
+    excludePatterns: string[];
+    respectRobots: boolean;
+    renderJavaScript: boolean;
+    viewports: Array<{ width: number; height: number }>;
+    authConfig?: unknown;
+    customHeaders?: Record<string, string>;
+  };
+}
+
+function toCrawlJobData(input: {
+  crawlRunId: string;
+  siteId: string;
+  config: {
+    sitemapUrl: string | null;
+    maxDepth: number;
+    maxPages: number;
+    includePatterns: string[];
+    excludePatterns: string[];
+    respectRobots: boolean;
+    renderJavaScript: boolean;
+    viewports: unknown;
+    authConfig: unknown;
+    customHeaders: unknown;
+  };
+}): CrawlJobData {
+  const rawViewports = Array.isArray(input.config.viewports)
+    ? input.config.viewports
+    : [{ width: 1280, height: 720 }];
+  const parsedViewports = rawViewports
+    .map((v) => ({ width: Number((v as any)?.width), height: Number((v as any)?.height) }))
+    .filter(
+      (v) =>
+        Number.isFinite(v.width) && Number.isFinite(v.height) && v.width > 0 && v.height > 0,
+    );
+
+  return {
+    crawlRunId: input.crawlRunId,
+    siteId: input.siteId,
+    config: {
+      sitemapUrl: input.config.sitemapUrl ?? undefined,
+      maxDepth: input.config.maxDepth,
+      maxPages: input.config.maxPages,
+      includePatterns: input.config.includePatterns,
+      excludePatterns: input.config.excludePatterns,
+      respectRobots: input.config.respectRobots,
+      renderJavaScript: input.config.renderJavaScript,
+      viewports:
+        parsedViewports.length > 0 ? parsedViewports : [{ width: 1280, height: 720 }],
+      authConfig: input.config.authConfig ?? undefined,
+      customHeaders:
+        (input.config.customHeaders as Record<string, string> | null) ?? undefined,
+    },
+  };
+}
+
+export async function runScheduledCrawlTick(prisma: PrismaClient, now = new Date()) {
+  const scheduledConfigs = await prisma.crawlConfig.findMany({
+    where: { scheduleCron: { not: null } },
+    select: {
+      siteId: true,
+      scheduleCron: true,
+      sitemapUrl: true,
+      maxDepth: true,
+      maxPages: true,
+      includePatterns: true,
+      excludePatterns: true,
+      respectRobots: true,
+      renderJavaScript: true,
+      viewports: true,
+      authConfig: true,
+      customHeaders: true,
+      site: {
+        select: {
+          verified: true,
+          workspace: {
+            select: {
+              organizationId: true,
+              organization: {
+                select: {
+                  subscription: {
+                    select: { plan: true, status: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (scheduledConfigs.length === 0) {
+    return { scanned: 0, enqueued: 0, blocked: 0 };
+  }
+
+  const crawlQueue = new Queue("crawl", { connection: bullmqConnectionOptions() });
+
+  let enqueued = 0;
+  let blocked = 0;
+
+  try {
+    for (const cfg of scheduledConfigs) {
+      const schedule = parseSupportedScheduleCron(cfg.scheduleCron);
+      const organizationId = cfg.site.workspace.organizationId;
+
+      if (!schedule || !cfg.site.verified) {
+        blocked += 1;
+        continue;
+      }
+
+      const subscription = cfg.site.workspace.organization.subscription;
+      const paidStatus =
+        subscription &&
+        subscription.plan !== "FREE" &&
+        ["ACTIVE", "TRIALING"].includes(subscription.status);
+      if (!paidStatus) {
+        blocked += 1;
+        continue;
+      }
+
+      const { slotStart, slotEnd } = currentScheduleWindow(schedule, now);
+
+      const [existingInSlot, running] = await Promise.all([
+        prisma.crawlRun.findFirst({
+          where: {
+            siteId: cfg.siteId,
+            createdAt: { gte: slotStart, lt: slotEnd },
+          },
+          select: { id: true },
+        }),
+        prisma.crawlRun.findFirst({
+          where: {
+            siteId: cfg.siteId,
+            status: { in: ["PENDING", "RUNNING"] },
+          },
+          select: { id: true },
+        }),
+      ]);
+
+      if (existingInSlot || running) continue;
+
+      const crawlRun = await prisma.crawlRun.create({
+        data: {
+          siteId: cfg.siteId,
+          status: "PENDING",
+          metadata: {
+            trigger: "scheduled",
+            scheduleCron: schedule,
+            scheduledSlotStart: slotStart.toISOString(),
+          },
+        },
+        select: { id: true },
+      });
+
+      try {
+        const jobData = toCrawlJobData({
+          crawlRunId: crawlRun.id,
+          siteId: cfg.siteId,
+          config: {
+            sitemapUrl: cfg.sitemapUrl,
+            maxDepth: cfg.maxDepth,
+            maxPages: cfg.maxPages,
+            includePatterns: cfg.includePatterns,
+            excludePatterns: cfg.excludePatterns,
+            respectRobots: cfg.respectRobots,
+            renderJavaScript: cfg.renderJavaScript,
+            viewports: cfg.viewports,
+            authConfig: cfg.authConfig,
+            customHeaders: cfg.customHeaders,
+          },
+        });
+
+        await crawlQueue.add("crawl", jobData, {
+          attempts: 3,
+          backoff: { type: "exponential", delay: 5000 },
+          jobId: `scheduled:${cfg.siteId}:${slotStart.toISOString()}`,
+        });
+
+        enqueued += 1;
+        await prisma.auditLog.create({
+          data: {
+            organizationId,
+            action: "crawl.scheduled.enqueued",
+            entityType: "Site",
+            entityId: cfg.siteId,
+            metadata: {
+              scheduleCron: schedule,
+              slotStart: slotStart.toISOString(),
+              crawlRunId: crawlRun.id,
+            },
+          },
+        });
+      } catch (error) {
+        blocked += 1;
+        const message = error instanceof Error ? error.message : "Queue add failed";
+        await prisma.crawlRun.update({
+          where: { id: crawlRun.id },
+          data: {
+            status: "FAILED",
+            errorMessage: `Scheduled crawl enqueue failed: ${message}`,
+            completedAt: new Date(),
+          },
+        });
+        await prisma.auditLog
+          .create({
+            data: {
+              organizationId,
+              action: "crawl.scheduled.enqueue_failed",
+              entityType: "Site",
+              entityId: cfg.siteId,
+              metadata: {
+                scheduleCron: schedule,
+                slotStart: slotStart.toISOString(),
+                error: message,
+              },
+            },
+          })
+          .catch(() => undefined);
+      }
+    }
+  } finally {
+    await crawlQueue.close();
+  }
+
+  return { scanned: scheduledConfigs.length, enqueued, blocked };
+}
+
+export function startScheduledCrawlLoop(prisma: PrismaClient) {
+  const tick = async () => {
+    try {
+      const result = await runScheduledCrawlTick(prisma);
+      if (result.enqueued > 0 || result.blocked > 0) {
+        console.log(
+          `[ScheduledCrawl] scanned=${result.scanned} enqueued=${result.enqueued} blocked=${result.blocked}`,
+        );
+      }
+    } catch (error) {
+      console.error("[ScheduledCrawl] tick failed", error);
+    }
+  };
+
+  void tick();
+  return setInterval(() => {
+    void tick();
+  }, ONE_MINUTE_MS);
+}

--- a/packages/core-services/src/index.ts
+++ b/packages/core-services/src/index.ts
@@ -64,3 +64,13 @@ export {
   revokeFindingGovernanceDecision,
 } from './finding-control-plane';
 export { getDefaultRemediationRecipe, resolveRemediationRecipe } from './remediation-recipes';
+
+export {
+  currentScheduleWindow,
+  nextScheduleRunAt,
+  parseSupportedScheduleCron,
+  scheduleBlockedReason,
+  scheduleCadenceLabel,
+  SUPPORTED_SCHEDULE_CRONS,
+  type SupportedScheduleCron,
+} from './scheduled-crawl';

--- a/packages/core-services/src/scheduled-crawl.test.ts
+++ b/packages/core-services/src/scheduled-crawl.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  currentScheduleWindow,
+  nextScheduleRunAt,
+  parseSupportedScheduleCron,
+  scheduleBlockedReason,
+  scheduleCadenceLabel,
+} from "./scheduled-crawl";
+
+describe("scheduled crawl cadence", () => {
+  it("parses supported cadence macros", () => {
+    expect(parseSupportedScheduleCron("@daily")).toBe("@daily");
+    expect(parseSupportedScheduleCron("@weekly")).toBe("@weekly");
+    expect(parseSupportedScheduleCron("@monthly")).toBe("@monthly");
+    expect(parseSupportedScheduleCron("0 0 * * *")).toBeNull();
+  });
+
+  it("computes daily windows in UTC", () => {
+    const now = new Date("2026-04-08T14:21:00.000Z");
+    const window = currentScheduleWindow("@daily", now);
+    expect(window.slotStart.toISOString()).toBe("2026-04-08T00:00:00.000Z");
+    expect(window.slotEnd.toISOString()).toBe("2026-04-09T00:00:00.000Z");
+  });
+
+  it("computes next run based on active window", () => {
+    const now = new Date("2026-04-08T14:21:00.000Z");
+    expect(nextScheduleRunAt("@weekly", now)?.toISOString()).toBe(
+      "2026-04-12T00:00:00.000Z",
+    );
+    expect(nextScheduleRunAt(null, now)).toBeNull();
+  });
+
+  it("reports blocked reason for unsupported expression", () => {
+    expect(scheduleBlockedReason("0 0 * * *")).toContain("not currently executable");
+    expect(scheduleBlockedReason("@daily")).toBeNull();
+    expect(scheduleCadenceLabel("@monthly")).toBe("Monthly");
+    expect(scheduleCadenceLabel(null)).toBe("Off");
+  });
+});

--- a/packages/core-services/src/scheduled-crawl.ts
+++ b/packages/core-services/src/scheduled-crawl.ts
@@ -1,0 +1,92 @@
+export const SUPPORTED_SCHEDULE_CRONS = [
+  "@daily",
+  "@weekly",
+  "@monthly",
+] as const;
+
+export type SupportedScheduleCron = (typeof SUPPORTED_SCHEDULE_CRONS)[number];
+
+export function parseSupportedScheduleCron(
+  scheduleCron: string | null | undefined,
+): SupportedScheduleCron | null {
+  if (!scheduleCron) return null;
+  if ((SUPPORTED_SCHEDULE_CRONS as readonly string[]).includes(scheduleCron)) {
+    return scheduleCron as SupportedScheduleCron;
+  }
+  return null;
+}
+
+export function scheduleCadenceLabel(
+  scheduleCron: string | null | undefined,
+): string {
+  const parsed = parseSupportedScheduleCron(scheduleCron);
+  if (!parsed) return "Off";
+  switch (parsed) {
+    case "@daily":
+      return "Daily";
+    case "@weekly":
+      return "Weekly";
+    case "@monthly":
+      return "Monthly";
+  }
+}
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function startOfUtcWeek(date: Date): Date {
+  const dayStart = startOfUtcDay(date);
+  const dow = dayStart.getUTCDay();
+  return new Date(dayStart.getTime() - dow * 24 * 60 * 60 * 1000);
+}
+
+function startOfUtcMonth(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+export function currentScheduleWindow(schedule: SupportedScheduleCron, now: Date): {
+  slotStart: Date;
+  slotEnd: Date;
+} {
+  switch (schedule) {
+    case "@daily": {
+      const slotStart = startOfUtcDay(now);
+      return {
+        slotStart,
+        slotEnd: new Date(slotStart.getTime() + 24 * 60 * 60 * 1000),
+      };
+    }
+    case "@weekly": {
+      const slotStart = startOfUtcWeek(now);
+      return {
+        slotStart,
+        slotEnd: new Date(slotStart.getTime() + 7 * 24 * 60 * 60 * 1000),
+      };
+    }
+    case "@monthly": {
+      const slotStart = startOfUtcMonth(now);
+      return {
+        slotStart,
+        slotEnd: new Date(Date.UTC(slotStart.getUTCFullYear(), slotStart.getUTCMonth() + 1, 1)),
+      };
+    }
+  }
+}
+
+export function nextScheduleRunAt(
+  scheduleCron: string | null | undefined,
+  now: Date,
+): Date | null {
+  const parsed = parseSupportedScheduleCron(scheduleCron);
+  if (!parsed) return null;
+  const { slotEnd } = currentScheduleWindow(parsed, now);
+  return slotEnd;
+}
+
+export function scheduleBlockedReason(scheduleCron: string | null | undefined): string | null {
+  if (!scheduleCron) return null;
+  const parsed = parseSupportedScheduleCron(scheduleCron);
+  if (parsed) return null;
+  return "This cadence string is stored but not currently executable by the worker scheduler.";
+}


### PR DESCRIPTION
### Motivation

- Turn the dormant `crawl_configs.scheduleCron` field into a truthful, server-driven recurring crawl system so sites can be verified on a cadence without manual operator work. 
- Preserve tenant safety and monetization (only verified sites on paid/trialing subscriptions are scheduled) and provide explicit, operator-visible blocked/failure semantics. 
- Improve continuity and auditability (audit logs, queue-failure capture) to reduce manual ops burden and increase enterprise trust.

### Description

- Added a reusable cadence primitive in `@aros/core-services` supporting `@daily`, `@weekly`, and `@monthly` with UTC window calculation, next-run projection, and blocked-reason reporting (`packages/core-services/src/scheduled-crawl.ts`) and exported it from the package index. 
- Implemented a worker-side scheduled crawl runner that scans `crawlConfig` rows, enqueues crawl runs when tenant- and plan-safe, avoids duplicate in-slot runs, writes `crawlRun` rows, and audits enqueue outcomes (`apps/worker/src/services/scheduled-crawls.ts`), and wired a loop into the worker lifecycle (`apps/worker/src/index.ts`). 
- Extended server-side settings persistence to accept both `autoScanAfterCrawl` and `scheduleCron` with validation via `parseSupportedScheduleCron` and audit logging (`apps/web/src/app/(dashboard)/sites/[siteId]/settings/actions.ts` and `apps/web/src/lib/dashboard-org-scoped-prisma.ts`). 
- Exposed cadence controls in the site settings UI and surfaced cadence/last-success/next-run/blocked hints on the site details page (`apps/web/src/app/(dashboard)/sites/[siteId]/settings/auto-scan-form.tsx`, `.../settings/page.tsx`, `.../page.tsx`). 
- Added unit tests for cadence parsing/window logic and updated tests for the settings persistence/validation paths, and adjusted Prisma-scoped helper tests accordingly (`packages/core-services/src/scheduled-crawl.test.ts`, `apps/web/src/.../actions.test.ts`, `apps/web/src/lib/dashboard-org-scoped-prisma.test.ts`).

### Testing

- Ran targeted unit tests for the new cadence logic: `npm run test --workspace=packages/core-services -- scheduled-crawl.test.ts` — passed. 
- Ran updated web unit tests: `npm run test --workspace=apps/web -- 'src/app/(dashboard)/sites/[siteId]/settings/actions.test.ts' 'src/lib/dashboard-org-scoped-prisma.test.ts'` — passed. 
- Ran full repo checks: `npm run lint` — passed; `npm run typecheck` — passed; `npm run test` (workspaces) — passed (all suites); `npm run build` (web production build) — passed; `npm run build:worker` — passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5c3979cf48328b0a1f1f7a27613a1)