### PR TITLE
feat(web): API/MCP admin surface — enable/disable/edit keys + audit logs

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/api-keys/actions.test.ts
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/actions.test.ts
@@ -4,6 +4,8 @@ import {
   revokeApiKeyAction,
   rotateApiKeyAction,
   getApiKeyUsageStats,
+  setApiKeyStatusAction,
+  updateApiKeyAction,
 } from "./actions";
 
 vi.mock("@/lib/db", () => ({
@@ -13,8 +15,12 @@ vi.mock("@/lib/db", () => ({
       findFirst: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       delete: vi.fn(),
       count: vi.fn(),
+    },
+    auditLog: {
+      create: vi.fn(),
     },
     $transaction: vi.fn(),
   },
@@ -633,5 +639,136 @@ describe("getApiKeyUsageStats", () => {
     await expect(getApiKeyUsageStats("org_123")).rejects.toThrow(
       "Only admins and owners can view API key usage",
     );
+  });
+});
+
+describe("setApiKeyStatusAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireSession).mockResolvedValue({
+      id: "user_123",
+      email: "admin@example.com",
+      name: "Admin User",
+      emailVerified: true,
+    });
+    vi.mocked(requireOrgAccess).mockResolvedValue({
+      user: {
+        id: "user_123",
+        email: "admin@example.com",
+        name: "Admin User",
+        emailVerified: true,
+      },
+      organizationId: "org_123",
+      role: "ADMIN",
+      subscription: null,
+      entitlement: { hasPaidAccess: true, reason: "active_paid" },
+    });
+  });
+
+  it("disables an active key", async () => {
+    vi.mocked(prisma.apiKey.findFirst).mockResolvedValue({
+      id: "key_123",
+      isActive: true,
+    } as any);
+    vi.mocked(prisma.apiKey.update).mockResolvedValue({ id: "key_123" } as any);
+
+    const formData = new FormData();
+    formData.set("organizationId", "org_123");
+    formData.set("keyId", "key_123");
+    formData.set("isActive", "false");
+
+    const result = await setApiKeyStatusAction(
+      { success: false, error: null },
+      formData,
+    );
+
+    expect(result).toEqual({ success: true, error: null });
+    expect(prisma.apiKey.update).toHaveBeenCalledWith({
+      where: { id: "key_123" },
+      data: { isActive: false },
+    });
+    expect(prisma.auditLog.create).toHaveBeenCalled();
+  });
+});
+
+describe("updateApiKeyAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireSession).mockResolvedValue({
+      id: "user_123",
+      email: "admin@example.com",
+      name: "Admin User",
+      emailVerified: true,
+    });
+    vi.mocked(requireOrgAccess).mockResolvedValue({
+      user: {
+        id: "user_123",
+        email: "admin@example.com",
+        name: "Admin User",
+        emailVerified: true,
+      },
+      organizationId: "org_123",
+      role: "ADMIN",
+      subscription: null,
+      entitlement: { hasPaidAccess: true, reason: "active_paid" },
+    });
+  });
+
+  it("updates editable API key fields", async () => {
+    vi.mocked(prisma.apiKey.updateMany).mockResolvedValue({ count: 1 } as any);
+
+    const formData = new FormData();
+    formData.set("organizationId", "org_123");
+    formData.set("keyId", "key_123");
+    formData.set("name", "Renamed Key");
+    formData.set("scopes", JSON.stringify(["read", "reports:read"]));
+    formData.set("rateLimitPerMinute", "120");
+
+    const result = await updateApiKeyAction(
+      { success: false, error: null },
+      formData,
+    );
+
+    expect(result).toEqual({ success: true, error: null });
+    expect(prisma.apiKey.updateMany).toHaveBeenCalledWith({
+      where: { id: "key_123", organizationId: "org_123", isActive: true },
+      data: expect.objectContaining({
+        name: "Renamed Key",
+        scopes: ["read", "reports:read"],
+        rateLimitPerMinute: 120,
+      }),
+    });
+    expect(prisma.auditLog.create).toHaveBeenCalled();
+  });
+
+  it("rejects unauthorized role when updating", async () => {
+    vi.mocked(requireOrgAccess).mockResolvedValue({
+      user: {
+        id: "user_123",
+        email: "dev@example.com",
+        name: "Dev User",
+        emailVerified: true,
+      },
+      organizationId: "org_123",
+      role: "DEVELOPER",
+      subscription: null,
+      entitlement: { hasPaidAccess: true, reason: "active_paid" },
+    });
+
+    const formData = new FormData();
+    formData.set("organizationId", "org_123");
+    formData.set("keyId", "key_123");
+    formData.set("name", "Renamed Key");
+    formData.set("scopes", JSON.stringify(["read"]));
+    formData.set("rateLimitPerMinute", "120");
+
+    const result = await updateApiKeyAction(
+      { success: false, error: null },
+      formData,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Only admins and owners can update API keys");
+    expect(prisma.apiKey.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/(dashboard)/settings/api-keys/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/actions.ts
@@ -10,11 +10,14 @@ import { hasPermission } from "@aros/config";
 import crypto from "node:crypto";
 import { logProductEvent, PRODUCT_EVENT_ACTIONS } from "@/lib/product-events";
 import {
+  createAuditLogForOrg,
   createApiKeyForOrg,
   findActiveApiKeyForOrg,
   listApiKeyUsageForOrg,
   revokeApiKeyForOrg,
   rotateApiKeyForOrg,
+  setApiKeyActiveStateForOrg,
+  updateApiKeyForOrg,
 } from "@/lib/dashboard-org-scoped-prisma";
 
 const API_KEY_PREFIX = "arsk_live_";
@@ -47,6 +50,11 @@ interface CreateKeyState {
     scopes: string[];
     rateLimitPerMinute: number;
   };
+}
+
+interface ApiKeyActionState {
+  success: boolean;
+  error: string | null;
 }
 
 /**
@@ -173,6 +181,19 @@ export async function createApiKeyAction(
       action: PRODUCT_EVENT_ACTIONS.api_key_created,
       metadata: { keyId: apiKey.id, name: apiKey.name },
     });
+    await createAuditLogForOrg({
+      organizationId,
+      userId: user.id,
+      action: "api_key.created",
+      entityType: "ApiKey",
+      entityId: apiKey.id,
+      metadata: {
+        name: apiKey.name,
+        scopes: apiKey.scopes,
+        rateLimitPerMinute: apiKey.rateLimitPerMinute,
+        expiresAt: apiKey.expiresAt?.toISOString() ?? null,
+      },
+    });
 
     return {
       success: true,
@@ -253,6 +274,14 @@ export async function rotateApiKeyAction(
     });
 
     revalidatePath("/settings/api-keys");
+    await createAuditLogForOrg({
+      organizationId: ctx.organizationId,
+      userId: user.id,
+      action: "api_key.rotated",
+      entityType: "ApiKey",
+      entityId: newKey.id,
+      metadata: { replacedKeyId: keyId, name: existingKey.name },
+    });
 
     return {
       success: true,
@@ -273,6 +302,7 @@ export async function rotateApiKeyAction(
 }
 
 export async function revokeApiKeyAction(formData: FormData): Promise<void> {
+  const user = await requireSession();
   const organizationId = (formData.get("organizationId") as string) ?? "";
   const keyId = (formData.get("keyId") as string) ?? "";
 
@@ -299,6 +329,13 @@ export async function revokeApiKeyAction(formData: FormData): Promise<void> {
     }
 
     revalidatePath("/settings/api-keys");
+    await createAuditLogForOrg({
+      organizationId: ctx.organizationId,
+      userId: user.id,
+      action: "api_key.revoked",
+      entityType: "ApiKey",
+      entityId: keyId,
+    });
     redirectApiKeysQuery({ status: "revoked" });
   } catch (error) {
     if (error instanceof ApiError) {
@@ -306,6 +343,147 @@ export async function revokeApiKeyAction(formData: FormData): Promise<void> {
     }
     redirectApiKeysQuery({ error: "Failed to revoke API key" });
   }
+}
+
+export async function setApiKeyStatusAction(
+  _prevState: ApiKeyActionState,
+  formData: FormData,
+): Promise<ApiKeyActionState> {
+  const user = await requireSession();
+  const organizationId = (formData.get("organizationId") as string) ?? "";
+  const keyId = (formData.get("keyId") as string) ?? "";
+  const nextStateRaw = (formData.get("isActive") as string) ?? "";
+
+  if (!keyId) return { success: false, error: "API key ID is required" };
+  if (!["true", "false"].includes(nextStateRaw)) {
+    return { success: false, error: "Invalid key status requested" };
+  }
+
+  const ctx = await requireOrgAccess(organizationId);
+  if (!hasPermission(ctx.role, "integrations:manage")) {
+    return {
+      success: false,
+      error: "Only admins and owners can change API key status",
+    };
+  }
+
+  const isActive = nextStateRaw === "true";
+  const changed = await setApiKeyActiveStateForOrg(
+    ctx.organizationId,
+    keyId,
+    isActive,
+  );
+  if (!changed.ok) {
+    return {
+      success: false,
+      error:
+        changed.reason === "unchanged"
+          ? "API key is already in that state"
+          : "API key not found",
+    };
+  }
+
+  await createAuditLogForOrg({
+    organizationId: ctx.organizationId,
+    userId: user.id,
+    action: isActive ? "api_key.enabled" : "api_key.disabled",
+    entityType: "ApiKey",
+    entityId: keyId,
+  });
+  revalidatePath("/settings/api-keys");
+  return { success: true, error: null };
+}
+
+export async function updateApiKeyAction(
+  _prevState: ApiKeyActionState,
+  formData: FormData,
+): Promise<ApiKeyActionState> {
+  const user = await requireSession();
+  const organizationId = (formData.get("organizationId") as string) ?? "";
+  const keyId = (formData.get("keyId") as string) ?? "";
+  const name = (formData.get("name") as string)?.trim() ?? "";
+  const scopesRaw = (formData.get("scopes") as string) ?? "";
+  const rateLimitRaw = (formData.get("rateLimitPerMinute") as string) ?? "60";
+  const expiresAtRaw = (formData.get("expiresAt") as string) ?? "";
+
+  if (!keyId) return { success: false, error: "API key ID is required" };
+  if (!name) return { success: false, error: "API key name is required" };
+  if (name.length > 100) {
+    return {
+      success: false,
+      error: "API key name must be 100 characters or less",
+    };
+  }
+
+  const rateLimitPerMinute = parseInt(rateLimitRaw, 10);
+  if (
+    Number.isNaN(rateLimitPerMinute) ||
+    rateLimitPerMinute < 1 ||
+    rateLimitPerMinute > 10000
+  ) {
+    return {
+      success: false,
+      error: "Rate limit must be between 1 and 10,000 requests per minute",
+    };
+  }
+
+  let scopes: string[] = [];
+  try {
+    scopes = JSON.parse(scopesRaw);
+  } catch {
+    return { success: false, error: "Invalid scopes format" };
+  }
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    return { success: false, error: "At least one scope is required" };
+  }
+
+  let expiresAt: Date | null = null;
+  if (expiresAtRaw) {
+    const parsed = new Date(expiresAtRaw);
+    if (Number.isNaN(parsed.getTime())) {
+      return { success: false, error: "Invalid expiration date" };
+    }
+    if (parsed < new Date()) {
+      return { success: false, error: "Expiration date must be in the future" };
+    }
+    expiresAt = parsed;
+  }
+
+  const ctx = await requireOrgAccess(organizationId);
+  if (!hasPermission(ctx.role, "integrations:manage")) {
+    return {
+      success: false,
+      error: "Only admins and owners can update API keys",
+    };
+  }
+
+  const result = await updateApiKeyForOrg({
+    organizationId: ctx.organizationId,
+    keyId,
+    name,
+    scopes,
+    rateLimitPerMinute,
+    expiresAt,
+  });
+  if (result.count === 0) {
+    return { success: false, error: "API key not found or already revoked" };
+  }
+
+  await createAuditLogForOrg({
+    organizationId: ctx.organizationId,
+    userId: user.id,
+    action: "api_key.updated",
+    entityType: "ApiKey",
+    entityId: keyId,
+    metadata: {
+      name,
+      scopes,
+      rateLimitPerMinute,
+      expiresAt: expiresAt?.toISOString() ?? null,
+    },
+  });
+  revalidatePath("/settings/api-keys");
+  return { success: true, error: null };
 }
 
 /**

--- a/apps/web/src/app/(dashboard)/settings/api-keys/api-keys-list.tsx
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/api-keys-list.tsx
@@ -19,6 +19,8 @@ import {
   createApiKeyAction,
   rotateApiKeyAction,
   revokeApiKeyAction,
+  setApiKeyStatusAction,
+  updateApiKeyAction,
 } from "./actions";
 
 interface ApiKey {
@@ -77,9 +79,10 @@ function formatRelativeTime(date: Date): string {
   return `${diffMonths} month${diffMonths === 1 ? "" : "s"}`;
 }
 
-function maskKey(key: string): string {
-  if (key.length <= 12) return "****";
-  return key.slice(0, 8) + "...";
+function formatDateTimeLocalInputValue(date: Date | null): string {
+  if (!date) return "";
+  const normalized = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  return normalized.toISOString().slice(0, 16);
 }
 
 export function ApiKeysList({
@@ -94,14 +97,18 @@ export function ApiKeysList({
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [isRotating, setIsRotating] = useState<string | null>(null);
   const [selectedScopes, setSelectedScopes] = useState<string[]>(["read"]);
+  const [editKeyId, setEditKeyId] = useState<string | null>(null);
 
   const [isCreatePending, startCreateTransition] = useTransition();
   const [isRotatePending, startRotateTransition] = useTransition();
+  const [isStatusPending, startStatusTransition] = useTransition();
+  const [isUpdatePending, startUpdateTransition] = useTransition();
 
   const [createError, setCreateError] = useState<string | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
   const [revokeConfirmId, setRevokeConfirmId] = useState<string | null>(null);
 
-  // Clear copied state after 2 seconds
   useEffect(() => {
     if (copiedId) {
       const timer = setTimeout(() => setCopiedId(null), 2000);
@@ -109,7 +116,6 @@ export function ApiKeysList({
     }
   }, [copiedId]);
 
-  // Handle scope checkbox changes
   function handleScopeChange(scopeId: string, checked: boolean) {
     setSelectedScopes((prev) => {
       if (checked) {
@@ -119,7 +125,6 @@ export function ApiKeysList({
     });
   }
 
-  // Handle form submission for creating a new key
   async function handleCreateSubmit(formData: FormData) {
     setCreateError(null);
 
@@ -128,7 +133,6 @@ export function ApiKeysList({
       return;
     }
 
-    // Add selected scopes to form data
     formData.set("scopes", JSON.stringify(selectedScopes));
 
     startCreateTransition(async () => {
@@ -145,7 +149,6 @@ export function ApiKeysList({
       if (result.key) {
         setNewKey(result.key);
         setShowCreateForm(false);
-        // Add the new key to the list (we'll need to refetch or reconstruct)
         const newApiKey: ApiKey = {
           id: result.key.id,
           name: result.key.name,
@@ -153,9 +156,7 @@ export function ApiKeysList({
           rateLimitPerMinute: result.key.rateLimitPerMinute,
           isActive: true,
           lastUsedAt: null,
-          expiresAt: result.key.expiresAt
-            ? new Date(result.key.expiresAt)
-            : null,
+          expiresAt: result.key.expiresAt ? new Date(result.key.expiresAt) : null,
           createdAt: new Date(),
           totalCalls: 0,
         };
@@ -164,10 +165,8 @@ export function ApiKeysList({
     });
   }
 
-  // Handle key rotation
   async function handleRotate(keyId: string) {
-    if (disabled) return;
-    if (isRotating) return;
+    if (disabled || isRotating) return;
 
     setIsRotating(keyId);
 
@@ -193,31 +192,91 @@ export function ApiKeysList({
           id: result.key.id,
           name: result.key.name,
           plaintext: result.key.plaintext,
-          expiresAt:
-            keys.find((k) => k.id === keyId)?.expiresAt?.toISOString() ?? null,
+          expiresAt: keys.find((k) => k.id === keyId)?.expiresAt?.toISOString() ?? null,
           scopes: keys.find((k) => k.id === keyId)?.scopes ?? [],
-          rateLimitPerMinute:
-            keys.find((k) => k.id === keyId)?.rateLimitPerMinute ?? 60,
+          rateLimitPerMinute: keys.find((k) => k.id === keyId)?.rateLimitPerMinute ?? 60,
         });
-        // Remove the old key from the list
         setKeys((prev) => prev.filter((k) => k.id !== keyId));
       }
     });
   }
 
-  // Handle revoke confirmation
   async function handleRevokeSubmit(formData: FormData) {
     if (disabled) return;
     await revokeApiKeyAction(formData);
   }
 
-  // Copy key to clipboard
+  async function handleStatusChange(keyId: string, isActive: boolean) {
+    if (disabled) return;
+    setStatusError(null);
+
+    const formData = new FormData();
+    formData.set("organizationId", organizationId);
+    formData.set("keyId", keyId);
+    formData.set("isActive", String(isActive));
+
+    startStatusTransition(async () => {
+      const result = await setApiKeyStatusAction(
+        { success: false, error: null },
+        formData,
+      );
+      if (!result.success) {
+        setStatusError(result.error);
+        return;
+      }
+
+      setKeys((prev) => prev.map((k) => (k.id === keyId ? { ...k, isActive } : k)));
+    });
+  }
+
+  async function handleEditSubmit(formData: FormData) {
+    if (!editKeyId || disabled) return;
+
+    setEditError(null);
+    formData.set("organizationId", organizationId);
+    formData.set("keyId", editKeyId);
+    formData.set("scopes", JSON.stringify(formData.getAll("scope").map(String)));
+
+    startUpdateTransition(async () => {
+      const result = await updateApiKeyAction(
+        { success: false, error: null },
+        formData,
+      );
+      if (!result.success) {
+        setEditError(result.error);
+        return;
+      }
+
+      const keyName = ((formData.get("name") as string) ?? "").trim();
+      const scopes = formData.getAll("scope").map(String);
+      const rateLimitPerMinute = parseInt(
+        (formData.get("rateLimitPerMinute") as string) ?? "60",
+        10,
+      );
+      const expiresAtRaw = (formData.get("expiresAt") as string) ?? "";
+
+      setKeys((prev) =>
+        prev.map((k) =>
+          k.id === editKeyId
+            ? {
+                ...k,
+                name: keyName,
+                scopes,
+                rateLimitPerMinute,
+                expiresAt: expiresAtRaw ? new Date(expiresAtRaw) : null,
+              }
+            : k,
+        ),
+      );
+      setEditKeyId(null);
+    });
+  }
+
   async function copyKey(key: string, id: string) {
     try {
       await navigator.clipboard.writeText(key);
       setCopiedId(id);
     } catch {
-      // Fallback for older browsers
       const textArea = document.createElement("textarea");
       textArea.value = key;
       document.body.appendChild(textArea);
@@ -228,7 +287,6 @@ export function ApiKeysList({
     }
   }
 
-  // Check if a key is expiring soon (within 7 days)
   function isExpiringSoon(key: ApiKey): boolean {
     if (!key.expiresAt || !key.isActive) return false;
     const sevenDaysFromNow = new Date();
@@ -236,13 +294,11 @@ export function ApiKeysList({
     return key.expiresAt < sevenDaysFromNow && key.expiresAt > new Date();
   }
 
-  // Check if key is expired
   function isExpired(key: ApiKey): boolean {
     if (!key.expiresAt || !key.isActive) return false;
     return key.expiresAt < new Date();
   }
 
-  // Get scope badges
   function getScopeBadges(scopes: string[]): string[] {
     if (scopes.includes("*")) return ["Full Access"];
     return scopes.map((s) => {
@@ -258,9 +314,7 @@ export function ApiKeysList({
           <div className="h-8 w-8 rounded-full bg-brand-100 flex items-center justify-center">
             <Key className="h-4 w-4 text-brand-600" />
           </div>
-          <h2 className="text-lg font-semibold text-slate-900">
-            API Key Created
-          </h2>
+          <h2 className="text-lg font-semibold text-slate-900">API Key Created</h2>
         </div>
 
         <div className="rounded-xl border-2 border-brand-200 bg-white p-4 mb-4">
@@ -289,14 +343,11 @@ export function ApiKeysList({
 
         <div className="space-y-2 text-sm text-slate-600">
           <p>
-            <span className="font-medium text-slate-900">Name:</span>{" "}
-            {newKey.name}
+            <span className="font-medium text-slate-900">Name:</span> {newKey.name}
           </p>
           <p>
             <span className="font-medium text-slate-900">Scopes:</span>{" "}
-            {newKey.scopes.length > 0
-              ? newKey.scopes.join(", ")
-              : "Full Access"}
+            {newKey.scopes.length > 0 ? newKey.scopes.join(", ") : "Full Access"}
           </p>
           <p>
             <span className="font-medium text-slate-900">Rate Limit:</span>{" "}
@@ -311,11 +362,7 @@ export function ApiKeysList({
         </div>
 
         <div className="mt-6 flex gap-2">
-          <button
-            type="button"
-            onClick={() => setNewKey(null)}
-            className="btn-primary"
-          >
+          <button type="button" onClick={() => setNewKey(null)} className="btn-primary">
             Done
           </button>
           <button
@@ -361,9 +408,7 @@ export function ApiKeysList({
       ) : (
         <div className="card">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-slate-900">
-              Create New API Key
-            </h2>
+            <h2 className="text-lg font-semibold text-slate-900">Create New API Key</h2>
           </div>
 
           <form action={handleCreateSubmit} className="space-y-4">
@@ -383,9 +428,7 @@ export function ApiKeysList({
                 className="input"
                 disabled={isCreatePending || disabled}
               />
-              <p className="mt-1 text-xs text-slate-500">
-                A descriptive name to identify this key
-              </p>
+              <p className="mt-1 text-xs text-slate-500">A descriptive name to identify this key</p>
             </div>
 
             <div>
@@ -401,19 +444,13 @@ export function ApiKeysList({
                       name="scope"
                       value={scope.id}
                       checked={selectedScopes.includes(scope.id)}
-                      onChange={(e) =>
-                        handleScopeChange(scope.id, e.target.checked)
-                      }
+                      onChange={(e) => handleScopeChange(scope.id, e.target.checked)}
                       className="mt-1 h-4 w-4 rounded border-slate-300 text-brand-600 focus:ring-brand-600"
                       disabled={isCreatePending || disabled}
                     />
                     <div>
-                      <p className="text-sm font-medium text-slate-900">
-                        {scope.label}
-                      </p>
-                      <p className="text-xs text-slate-500">
-                        {scope.description}
-                      </p>
+                      <p className="text-sm font-medium text-slate-900">{scope.label}</p>
+                      <p className="text-xs text-slate-500">{scope.description}</p>
                     </div>
                   </label>
                 ))}
@@ -459,16 +496,8 @@ export function ApiKeysList({
             )}
 
             <div className="flex gap-2 pt-2">
-              <button
-                type="submit"
-                className="btn-primary"
-                disabled={isCreatePending || disabled}
-              >
-                {isCreatePending ? (
-                  <LoadingSpinner size="sm" label="Creating..." />
-                ) : (
-                  "Create Key"
-                )}
+              <button type="submit" className="btn-primary" disabled={isCreatePending || disabled}>
+                {isCreatePending ? <LoadingSpinner size="sm" label="Creating..." /> : "Create Key"}
               </button>
               <button
                 type="button"
@@ -480,6 +509,12 @@ export function ApiKeysList({
               </button>
             </div>
           </form>
+        </div>
+      )}
+
+      {statusError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {statusError}
         </div>
       )}
 
@@ -514,28 +549,19 @@ export function ApiKeysList({
                   <div className="flex items-center gap-2 flex-wrap">
                     <h3 className="font-semibold text-slate-900">{key.name}</h3>
                     {key.isActive && isExpired(key) && (
-                      <span className="badge bg-red-100 text-red-800">
-                        Expired
-                      </span>
+                      <span className="badge bg-red-100 text-red-800">Expired</span>
                     )}
                     {key.isActive && isExpiringSoon(key) && !isExpired(key) && (
                       <span className="badge bg-amber-100 text-amber-800">
                         Expires in {formatRelativeTime(key.expiresAt!)}
                       </span>
                     )}
-                    {!key.isActive && (
-                      <span className="badge bg-slate-100 text-slate-500">
-                        Revoked
-                      </span>
-                    )}
+                    {!key.isActive && <span className="badge bg-slate-100 text-slate-500">Disabled</span>}
                   </div>
 
                   <div className="flex flex-wrap items-center gap-2 mt-2">
                     {getScopeBadges(key.scopes).map((badge) => (
-                      <span
-                        key={badge}
-                        className="badge bg-slate-100 text-slate-700"
-                      >
+                      <span key={badge} className="badge bg-slate-100 text-slate-700">
                         {badge}
                       </span>
                     ))}
@@ -566,15 +592,8 @@ export function ApiKeysList({
                 {key.isActive && !isExpired(key) && (
                   <div className="flex items-center gap-2 shrink-0">
                     {revokeConfirmId === key.id ? (
-                      <form
-                        action={handleRevokeSubmit}
-                        className="flex items-center gap-2"
-                      >
-                        <input
-                          type="hidden"
-                          name="organizationId"
-                          value={organizationId}
-                        />
+                      <form action={handleRevokeSubmit} className="flex items-center gap-2">
+                        <input type="hidden" name="organizationId" value={organizationId} />
                         <input type="hidden" name="keyId" value={key.id} />
                         <button
                           type="submit"
@@ -595,11 +614,20 @@ export function ApiKeysList({
                       <>
                         <button
                           type="button"
+                          onClick={() => {
+                            setEditKeyId(key.id);
+                            setEditError(null);
+                          }}
+                          className="btn-secondary text-xs px-2 py-1"
+                          disabled={disabled}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
                           onClick={() => handleRotate(key.id)}
                           className="btn-secondary text-xs px-2 py-1"
-                          disabled={
-                            isRotating === key.id || isRotatePending || disabled
-                          }
+                          disabled={isRotating === key.id || isRotatePending || disabled}
                           title="Rotate key"
                         >
                           {isRotating === key.id ? (
@@ -610,6 +638,14 @@ export function ApiKeysList({
                               Rotate
                             </>
                           )}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleStatusChange(key.id, false)}
+                          className="btn-secondary text-xs px-2 py-1"
+                          disabled={disabled || isStatusPending}
+                        >
+                          Disable
                         </button>
                         <button
                           type="button"
@@ -625,7 +661,107 @@ export function ApiKeysList({
                     )}
                   </div>
                 )}
+                {!key.isActive && (
+                  <div className="flex items-center gap-2 shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => handleStatusChange(key.id, true)}
+                      className="btn-secondary text-xs px-2 py-1"
+                      disabled={disabled || isStatusPending}
+                    >
+                      Enable
+                    </button>
+                  </div>
+                )}
               </div>
+
+              {editKeyId === key.id && (
+                <form action={handleEditSubmit} className="mt-4 border-t border-slate-200 pt-4 space-y-3">
+                  <div>
+                    <label htmlFor={`edit-name-${key.id}`} className="label">
+                      Key Name
+                    </label>
+                    <input
+                      id={`edit-name-${key.id}`}
+                      name="name"
+                      type="text"
+                      defaultValue={key.name}
+                      maxLength={100}
+                      required
+                      className="input"
+                      disabled={isUpdatePending}
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <label className="label">Rate Limit (per minute)</label>
+                      <input
+                        type="number"
+                        name="rateLimitPerMinute"
+                        defaultValue={key.rateLimitPerMinute}
+                        min={1}
+                        max={10000}
+                        required
+                        className="input"
+                        disabled={isUpdatePending}
+                      />
+                    </div>
+                    <div>
+                      <label className="label">Expiration Date (optional)</label>
+                      <input
+                        type="datetime-local"
+                        name="expiresAt"
+                        defaultValue={formatDateTimeLocalInputValue(key.expiresAt)}
+                        className="input"
+                        disabled={isUpdatePending}
+                      />
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="label">Scopes</label>
+                    <div className="space-y-2">
+                      {availableScopes.map((scope) => (
+                        <label key={`${key.id}-${scope.id}`} className="flex items-start gap-2">
+                          <input
+                            type="checkbox"
+                            name="scope"
+                            value={scope.id}
+                            defaultChecked={key.scopes.includes(scope.id)}
+                            disabled={isUpdatePending}
+                          />
+                          <span className="text-sm text-slate-700">{scope.label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+
+                  {editError && (
+                    <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                      {editError}
+                    </div>
+                  )}
+
+                  <div className="flex gap-2">
+                    <button
+                      type="submit"
+                      className="btn-primary text-xs px-2 py-1"
+                      disabled={isUpdatePending}
+                    >
+                      Save
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-secondary text-xs px-2 py-1"
+                      onClick={() => setEditKeyId(null)}
+                      disabled={isUpdatePending}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              )}
             </div>
           ))}
         </div>

--- a/apps/web/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -201,7 +201,8 @@ export default async function ApiKeysPage({ searchParams }: PageProps) {
 
   const { keys, membership } = result.data;
   const { organizationId, role } = orgRes;
-  const subscription = membership.organization.subscription;
+  const { organization } = membership;
+  const subscription = organization.subscription;
   const entitlement = getEntitlementState(subscription);
   const canManageApiKeys = hasPermission(role, "integrations:manage");
 
@@ -224,6 +225,12 @@ export default async function ApiKeysPage({ searchParams }: PageProps) {
     createdAt: key.createdAt,
     totalCalls: key.mcpUsageLogs.length,
   }));
+  const activeKeys = keys.filter((key) => key.isActive);
+  const totalCalls = keys.reduce((sum, key) => sum + key.mcpUsageLogs.length, 0);
+  const lastUsedAt = keys
+    .map((key) => key.lastUsedAt)
+    .filter((value): value is Date => Boolean(value))
+    .sort((a, b) => b.getTime() - a.getTime())[0];
 
   return (
     <div className="space-y-6 max-w-4xl">
@@ -249,6 +256,48 @@ export default async function ApiKeysPage({ searchParams }: PageProps) {
           <p className="mt-1">{notice.message}</p>
         </div>
       )}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="card">
+          <p className="text-xs uppercase tracking-wide text-slate-500">
+            MCP posture
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-900">
+            {organization.mcpEnabled ? "Enabled" : "Disabled"}
+          </p>
+          <p className="mt-1 text-sm text-slate-600">
+            {organization.mcpEnabled
+              ? "MCP requests are accepted subject to key and quota checks."
+              : "MCP traffic is blocked at org level even if keys exist."}
+          </p>
+        </div>
+        <div className="card">
+          <p className="text-xs uppercase tracking-wide text-slate-500">
+            Period token usage
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-900">
+            {organization.mcpUsageThisPeriod.toLocaleString()} /{" "}
+            {organization.mcpTokenLimit > 0
+              ? organization.mcpTokenLimit.toLocaleString()
+              : "Unlimited"}
+          </p>
+          <p className="mt-1 text-sm text-slate-600">
+            Current usage window as tracked by server-side MCP billing logs.
+          </p>
+        </div>
+        <div className="card">
+          <p className="text-xs uppercase tracking-wide text-slate-500">
+            API key summary
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-900">
+            {activeKeys.length} active / {keys.length} total
+          </p>
+          <p className="mt-1 text-sm text-slate-600">
+            {totalCalls.toLocaleString()} calls recorded
+            {lastUsedAt ? ` · last used ${lastUsedAt.toLocaleDateString()}` : ""}
+          </p>
+        </div>
+      </div>
 
       {expiringSoonKeys.length > 0 && (
         <div
@@ -297,6 +346,24 @@ export default async function ApiKeysPage({ searchParams }: PageProps) {
           </div>
         </div>
       )}
+
+      <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+        <p className="font-medium text-slate-900">Developer notes</p>
+        <ul className="mt-2 list-disc pl-5 space-y-1">
+          <li>
+            Implemented: org-scoped key creation, one-time plaintext reveal,
+            rotate/revoke/disable/enable, and lifecycle audit log entries.
+          </li>
+          <li>
+            Implemented: runtime enforcement of org binding, key active state,
+            expiration checks, and per-key rate limit metadata in storage.
+          </li>
+          <li>
+            Staged: external-facing OpenAPI browser and self-serve org quota
+            editing UI are not shipped on this route.
+          </li>
+        </ul>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/dashboard-org-scoped-prisma.ts
+++ b/apps/web/src/lib/dashboard-org-scoped-prisma.ts
@@ -281,6 +281,76 @@ export async function revokeApiKeyForOrg(organizationId: string, keyId: string) 
   return { ok: true as const };
 }
 
+export async function setApiKeyActiveStateForOrg(
+  organizationId: string,
+  keyId: string,
+  isActive: boolean,
+) {
+  const key = await prisma.apiKey.findFirst({
+    where: {
+      id: keyId,
+      organizationId,
+    },
+    select: {
+      id: true,
+      isActive: true,
+    },
+  });
+  if (!key) return { ok: false as const, reason: "not_found" as const };
+  if (key.isActive === isActive) {
+    return { ok: false as const, reason: "unchanged" as const };
+  }
+
+  await prisma.apiKey.update({
+    where: { id: keyId },
+    data: { isActive },
+  });
+  return { ok: true as const };
+}
+
+export async function updateApiKeyForOrg(input: {
+  organizationId: string;
+  keyId: string;
+  name: string;
+  scopes: string[];
+  rateLimitPerMinute: number;
+  expiresAt: Date | null;
+}) {
+  return prisma.apiKey.updateMany({
+    where: {
+      id: input.keyId,
+      organizationId: input.organizationId,
+      isActive: true,
+    },
+    data: {
+      name: input.name,
+      scopes: input.scopes,
+      rateLimitPerMinute: input.rateLimitPerMinute,
+      expiresAt: input.expiresAt,
+    },
+  });
+}
+
+export async function createAuditLogForOrg(input: {
+  organizationId: string;
+  userId: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  metadata?: Record<string, unknown>;
+}) {
+  await prisma.auditLog.create({
+    data: {
+      organizationId: input.organizationId,
+      userId: input.userId,
+      action: input.action,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      metadata: input.metadata as Prisma.InputJsonValue | undefined,
+    },
+  });
+}
+
 export async function listApiKeyUsageForOrg(organizationId: string) {
   return prisma.apiKey.findMany({
     where: {


### PR DESCRIPTION
### Motivation
- Provide a first-class self-serve API / MCP admin surface for org owners/admins with server-truth enforcement and auditability. 
- Fill gaps: enable/disable status toggles, editable key metadata, explicit lifecycle audit writes, and MCP posture/usage summary on the settings page. 
- Avoid schema churn and preserve multi-tenant isolation by adding org-scoped helpers and server actions.

### Description
- Added server actions `setApiKeyStatusAction` and `updateApiKeyAction` with org authorization checks, validation, and revalidation hooks. 
- Added reusable org-scoped helpers `setApiKeyActiveStateForOrg`, `updateApiKeyForOrg`, and `createAuditLogForOrg` in `dashboard-org-scoped-prisma` to centralize status updates and audit writes. 
- Extended create/rotate/revoke flows to emit explicit audit-log entries for API key lifecycle events and retained one-time plaintext reveal semantics for creation/rotation. 
- Upgraded Settings → API Keys UI (`api-keys-list.tsx` and `page.tsx`) with edit mode (name/scopes/rate limit/expiry), disable/enable controls, status/error handling, MCP posture & usage summary cards, and clear developer notes about implemented vs staged features. 
- Added targeted unit tests for status toggling and key updates and extended test mocks to cover audit log calls and `updateMany` usage.

### Testing
- Ran `npm run test --workspace=apps/web -- 'src/app/(dashboard)/settings/api-keys/actions.test.ts'` and the test file passed (24 tests passed). 
- Ran `npm run lint --workspace=apps/web` and lint completed successfully. 
- Ran `npm run typecheck --workspace=apps/web` and TypeScript checks completed successfully after a small test fixture type fix. 
- Ran `npm run build --workspace=apps/web` (Next.js production build) and the app built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5c54532e08328962ec76c87e561a5)