### PR TITLE
feat(web): trust/docs closure, review UX, and team-admin seat/safety improvements

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "test:ct": "playwright test -c playwright-ct.config.ts",
     "test:e2e:update": "playwright test --update-snapshots",
     "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts src/lib/__tests__/tenant-isolation.integration.test.ts",
-    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts src/lib/operator-org-resolution.test.ts src/lib/dashboard-org-scoped-prisma.test.ts src/lib/dashboard-form-org.test.ts"
+    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts src/lib/operator-org-resolution.test.ts src/lib/dashboard-org-scoped-prisma.test.ts src/lib/dashboard-form-org.test.ts src/lib/marketing-routes.test.ts"
   },
   "dependencies": {
     "@aros/config": "*",

--- a/apps/web/src/app/(dashboard)/reviews/actions.ts
+++ b/apps/web/src/app/(dashboard)/reviews/actions.ts
@@ -29,6 +29,7 @@ export async function updateReviewAction(formData: FormData) {
   const user = await requireSession();
   const taskId = formData.get("taskId") as string;
   const status = (formData.get("status") as string) || "";
+  const note = ((formData.get("note") as string) || "").trim();
 
   if (!taskId) {
     redirect("/reviews?review_error=missing_task");
@@ -63,6 +64,7 @@ export async function updateReviewAction(formData: FormData) {
   const data: Prisma.ReviewTaskUpdateInput = {
     status: reviewStatus,
     assignee: { connect: { id: user.id } },
+    notes: note.length > 0 ? note.slice(0, 2000) : undefined,
     reviewedAt:
       reviewStatus === "APPROVED" || reviewStatus === "REJECTED"
         ? new Date()

--- a/apps/web/src/app/(dashboard)/reviews/page.tsx
+++ b/apps/web/src/app/(dashboard)/reviews/page.tsx
@@ -1,6 +1,6 @@
 import { requireSession } from "@/lib/session";
 import { prisma } from "@/lib/db";
-import type { Prisma } from "@aros/db";
+import type { Prisma, ReviewType } from "@aros/db";
 import Link from "next/link";
 import { updateReviewAction } from "./actions";
 import { getRoutePlatformTruth } from "@/lib/platform-truth-cache";
@@ -8,8 +8,18 @@ import { resolveDashboardOrgMembership } from "@/lib/route-data-boundary";
 import { RouteReliabilityNotice } from "@/components/reliability/route-reliability-notice";
 import { hasPermission } from "@aros/config";
 import { StatusBadge } from "@aros/ui";
+import { TruthBadge } from "@/components/truth/truth-badge";
 
 export const metadata = { title: "Reviews" };
+
+const REVIEW_REASON: Record<ReviewType, string> = {
+  ALT_TEXT_REVIEW: "Visual context ambiguity for alt text quality.",
+  CONTENT_CLARITY: "Language clarity or meaning requires human interpretation.",
+  KEYBOARD_FLOW: "Keyboard and focus order behavior can be context-sensitive.",
+  SCREEN_READER: "Landmark and reading-order behavior needs AT verification.",
+  SUGGESTION_REVIEW: "Generated suggestion requires reviewer confirmation.",
+  MANUAL_AUDIT: "Rule requires explicit human verification.",
+};
 
 export default async function ReviewsPage({
   searchParams,
@@ -102,7 +112,7 @@ export default async function ReviewsPage({
     suggestion: {
       select: { type: true, originalCode: true, suggestedCode: true },
     },
-    _count: { select: { evidence: true } },
+    _count: { select: { evidence: true, controlPlaneEvidence: true } },
   } satisfies Prisma.ReviewTaskInclude;
 
   type ReviewListRow = Prisma.ReviewTaskGetPayload<{
@@ -129,9 +139,8 @@ export default async function ReviewsPage({
           ],
         },
       },
-      orderBy: [{ status: "asc" }, { createdAt: "desc" }],
       include: reviewListInclude,
-      take: 50,
+      take: 80,
     });
   } catch (e) {
     loadError = e instanceof Error ? e.message : "Database error";
@@ -153,9 +162,27 @@ export default async function ReviewsPage({
     );
   }
 
+  const sortedTasks = [...tasks].sort((a, b) => {
+    const priority = (task: ReviewListRow) => {
+      const ageHours = (Date.now() - task.createdAt.getTime()) / 3_600_000;
+      const statusScore =
+        task.status === "PENDING" ? 4 : task.status === "IN_PROGRESS" ? 2 : 0;
+      const reviewRisk = task.type === "MANUAL_AUDIT" || task.type === "KEYBOARD_FLOW" ? 2 : 1;
+      const staleBoost = ageHours > 72 ? 2 : 0;
+      return statusScore + reviewRisk + staleBoost;
+    };
+
+    const diff = priority(b) - priority(a);
+    if (diff !== 0) return diff;
+    return b.createdAt.getTime() - a.createdAt.getTime();
+  });
+
   const pendingCount = tasks.filter((t) => t.status === "PENDING").length;
   const inProgressCount = tasks.filter(
     (t) => t.status === "IN_PROGRESS",
+  ).length;
+  const unresolvedCount = tasks.filter(
+    (t) => t.status === "PENDING" || t.status === "IN_PROGRESS",
   ).length;
 
   return (
@@ -163,14 +190,13 @@ export default async function ReviewsPage({
       <div>
         <h1 className="text-2xl font-bold text-slate-900">Review Queue</h1>
         <p className="text-slate-500 mt-1">
-          {pendingCount} pending, {inProgressCount} in progress
+          {pendingCount} pending, {inProgressCount} in progress, {unresolvedCount} unresolved
         </p>
       </div>
 
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-800">
-        Some accessibility criteria cannot be verified by automated scanning
-        alone. These tasks require human review for accurate conformance
-        assessment.
+      <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 text-sm text-orange-900">
+        Automated scanners reduce manual effort, but do not establish final conformance on their own.
+        Use this queue to document reviewer outcomes and rationale.
       </div>
 
       {reviewError && (
@@ -179,98 +205,128 @@ export default async function ReviewsPage({
         </RouteReliabilityNotice>
       )}
 
-      {tasks.length === 0 ? (
+      {sortedTasks.length === 0 ? (
         <div className="card text-center py-12">
           <p className="text-slate-500">No review tasks yet.</p>
         </div>
       ) : (
         <div className="space-y-3">
-          {tasks.map((task) => (
-            <div key={task.id} className="card">
-              <div className="flex items-start justify-between">
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-1">
-                    <ReviewStatusBadge status={task.status} />
-                    <span className="badge bg-slate-100 text-slate-700">
-                      {task.type.toLowerCase().replace("_", " ")}
-                    </span>
+          {sortedTasks.map((task) => {
+            const ageHours = Math.floor((Date.now() - task.createdAt.getTime()) / 3_600_000);
+            const stale = ageHours > 72;
+
+            return (
+              <article key={task.id} className="card space-y-3">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 space-y-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <ReviewStatusBadge status={task.status} />
+                      <TruthBadge state="requires_human_review" />
+                      {stale ? <TruthBadge state="partial" /> : null}
+                    </div>
+                    <h3 className="text-sm font-semibold text-slate-900">{task.title}</h3>
+                    {task.description ? (
+                      <p className="text-sm text-slate-600">{task.description}</p>
+                    ) : null}
+                    <p className="text-xs text-slate-500">{REVIEW_REASON[task.type]}</p>
+                    <div className="flex items-center gap-4 text-xs text-slate-400">
+                      {task.assignee && (
+                        <span>
+                          Assigned to: {task.assignee.name ?? task.assignee.email}
+                        </span>
+                      )}
+                      <span>Evidence: {task._count.evidence + task._count.controlPlaneEvidence}</span>
+                      <span>Age: {ageHours}h</span>
+                    </div>
                   </div>
-                  <h3 className="text-sm font-semibold text-slate-900">
-                    {task.title}
-                  </h3>
-                  {task.description && (
-                    <p className="text-sm text-slate-500 mt-1">
-                      {task.description}
-                    </p>
-                  )}
-                  <div className="flex items-center gap-4 mt-2 text-xs text-slate-400">
-                    {task.assignee && (
-                      <span>
-                        Assigned to: {task.assignee.name ?? task.assignee.email}
-                      </span>
-                    )}
-                    <span>{task._count.evidence} evidence artifacts</span>
-                    <span>Created: {task.createdAt.toLocaleDateString()}</span>
-                  </div>
-                </div>
-                <div className="flex gap-2">
-                  {task.status === "PENDING" && (
-                    <form action={updateReviewAction}>
-                      <input
-                        type="hidden"
-                        name="expectedOrganizationId"
-                        value={orgRes.organizationId}
-                      />
-                      <input type="hidden" name="taskId" value={task.id} />
-                      <input type="hidden" name="status" value="IN_PROGRESS" />
-                      <button type="submit" className="btn-secondary text-xs">
-                        Start Review
-                      </button>
-                    </form>
-                  )}
-                  {task.status === "IN_PROGRESS" && (
-                    <>
-                      <form action={updateReviewAction}>
-                        <input
-                          type="hidden"
-                          name="expectedOrganizationId"
-                          value={orgRes.organizationId}
-                        />
-                        <input type="hidden" name="taskId" value={task.id} />
-                        <input type="hidden" name="status" value="APPROVED" />
-                        <button type="submit" className="btn-primary text-xs">
-                          Approve
-                        </button>
-                      </form>
-                      <form action={updateReviewAction}>
-                        <input
-                          type="hidden"
-                          name="expectedOrganizationId"
-                          value={orgRes.organizationId}
-                        />
-                        <input type="hidden" name="taskId" value={task.id} />
-                        <input type="hidden" name="status" value="REJECTED" />
-                        <button type="submit" className="btn-danger text-xs">
-                          Reject
-                        </button>
-                      </form>
-                    </>
-                  )}
-                  {task.suggestion && task.suggestionId && (
+                  {task.suggestion && task.suggestionId ? (
                     <Link
                       href={`/remediation/${task.suggestionId}`}
                       className="btn-ghost text-xs"
                     >
-                      View Suggestion
+                      View suggestion
                     </Link>
-                  )}
+                  ) : null}
                 </div>
-              </div>
-            </div>
-          ))}
+
+                <details className="rounded-lg border border-slate-200 p-3">
+                  <summary className="cursor-pointer text-sm font-medium text-slate-800">Evidence and reviewer notes</summary>
+                  <div className="mt-3 space-y-2 text-sm text-slate-600">
+                    <p>Task type: {task.type.replaceAll("_", " ").toLowerCase()}</p>
+                    <p>Automation evidence artifacts: {task._count.evidence}</p>
+                    <p>Control-plane evidence artifacts: {task._count.controlPlaneEvidence}</p>
+                    <p>Suggestion attached: {task.suggestion ? "yes" : "no"}</p>
+                    {task.notes ? <p>Latest reviewer note: {task.notes}</p> : <p>No reviewer note yet.</p>}
+                  </div>
+                </details>
+
+                <div className="flex flex-wrap gap-2">
+                  {task.status === "PENDING" && (
+                    <ReviewActionForm
+                      organizationId={orgRes.organizationId}
+                      taskId={task.id}
+                      status="IN_PROGRESS"
+                      label="Mark pending"
+                    />
+                  )}
+                  <ReviewActionForm
+                    organizationId={orgRes.organizationId}
+                    taskId={task.id}
+                    status="APPROVED"
+                    label="Mark confirmed"
+                  />
+                  <ReviewActionForm
+                    organizationId={orgRes.organizationId}
+                    taskId={task.id}
+                    status="REJECTED"
+                    label="Mark false positive"
+                  />
+                  <ReviewActionForm
+                    organizationId={orgRes.organizationId}
+                    taskId={task.id}
+                    status="NEEDS_CHANGES"
+                    label="Needs escalation"
+                  />
+                </div>
+              </article>
+            );
+          })}
         </div>
       )}
     </div>
+  );
+}
+
+function ReviewActionForm({
+  organizationId,
+  taskId,
+  status,
+  label,
+}: {
+  organizationId: string;
+  taskId: string;
+  status: "IN_PROGRESS" | "APPROVED" | "REJECTED" | "NEEDS_CHANGES";
+  label: string;
+}) {
+  return (
+    <form action={updateReviewAction} className="flex items-center gap-2">
+      <input type="hidden" name="expectedOrganizationId" value={organizationId} />
+      <input type="hidden" name="taskId" value={taskId} />
+      <input type="hidden" name="status" value={status} />
+      <label className="sr-only" htmlFor={`${taskId}-${status}-note`}>
+        Reviewer note
+      </label>
+      <input
+        id={`${taskId}-${status}-note`}
+        name="note"
+        placeholder="Optional reviewer note"
+        className="input h-8 w-52 text-xs"
+        maxLength={2000}
+      />
+      <button type="submit" className="btn-secondary text-xs">
+        {label}
+      </button>
+    </form>
   );
 }
 

--- a/apps/web/src/app/(dashboard)/settings/members/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/members/page.tsx
@@ -12,6 +12,7 @@ import { EntitlementWall } from "@/components/monetization/entitlement-wall";
 import { getEntitlementState } from "@/lib/auth-guard";
 import { hasPermission } from "@aros/config";
 import { MembersList } from "./members-list";
+import { TruthBadge } from "@/components/truth/truth-badge";
 
 export const metadata = { title: "Members" };
 
@@ -134,6 +135,16 @@ export default async function MembersPage() {
   const entitlement = getEntitlementState(subscription);
   const canManageMembers = hasPermission(membership.role, "org:members:manage");
 
+  const pendingInviteCount = await runOrgScopedQuery(orgRes, (orgId) =>
+    prisma.auditLog.count({
+      where: { organizationId: orgId, action: "member:invite_pending" },
+    }),
+  );
+  const pendingInvites = pendingInviteCount.ok ? pendingInviteCount.data : 0;
+  const seatsUsed = org.memberships.length + pendingInvites;
+  const seatCap = subscription?.maxSeats ?? 1;
+  const seatsAtOrOverCap = seatsUsed >= seatCap;
+
   if (!entitlement.hasPaidAccess) {
     return (
       <div className="space-y-6 max-w-4xl">
@@ -171,6 +182,33 @@ export default async function MembersPage() {
         </p>
       </div>
 
+      <div className="card">
+        <h2 className="text-lg font-semibold text-slate-900">Seat usage</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Members + pending invites consume seats. Seat limits are enforced server-side.
+        </p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-3 text-sm">
+          <div>
+            <p className="text-slate-500">Members</p>
+            <p className="font-semibold text-slate-900">{org.memberships.length}</p>
+          </div>
+          <div>
+            <p className="text-slate-500">Pending invites</p>
+            <p className="font-semibold text-slate-900">{pendingInvites}</p>
+          </div>
+          <div>
+            <p className="text-slate-500">Seat cap</p>
+            <p className="font-semibold text-slate-900">{seatCap}</p>
+          </div>
+        </div>
+        {seatsAtOrOverCap ? (
+          <p className="mt-3 text-sm text-amber-800">
+            Seat cap reached. Remove pending invites or upgrade before adding members.
+            <Link href="/settings/billing" className="ml-1 font-medium underline">Open billing</Link>
+          </p>
+        ) : null}
+      </div>
+
       <MembersList
         organizationId={org.id}
         members={org.memberships}
@@ -178,6 +216,19 @@ export default async function MembersPage() {
         currentUserRole={membership.role}
         canManageMembers={canManageMembers}
       />
+
+      <div className="card space-y-3">
+        <h2 className="text-lg font-semibold text-slate-900">Enterprise admin controls</h2>
+        <p className="text-sm text-slate-600">Posture by feature in this deployment:</p>
+        <ul className="space-y-2 text-sm text-slate-700">
+          <li><TruthBadge state="partial" className="mr-2" />Invites are recorded and seat-checked; outbound invite email is not automatic.</li>
+          <li><TruthBadge state="environment_dependent" className="mr-2" />OIDC SSO depends on deployment env and operator configuration.</li>
+          <li><TruthBadge state="staged" className="mr-2" />SCIM and directory sync are staged, not implemented in this build.</li>
+        </ul>
+        <Link href={`/api/org/${org.id}/audit-log`} className="text-sm font-medium text-brand-700 hover:underline">
+          Open org audit-log API
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -443,6 +443,20 @@ export default async function SettingsPage() {
         </div>
       </div>
 
+
+
+      <div className="card">
+        <h2 className="text-lg font-semibold text-slate-900">Trust &amp; administration</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Procurement-facing trust posture, security limits, and team-admin operating guides.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Link href="/trust" className="btn-secondary text-xs">Trust center</Link>
+          <Link href="/security" className="btn-secondary text-xs">Security posture</Link>
+          <Link href="/docs/team-admin" className="btn-secondary text-xs">Team-admin docs</Link>
+        </div>
+      </div>
+
       <div className="card">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-slate-900">Integrations</h2>

--- a/apps/web/src/app/docs/api-mcp/page.tsx
+++ b/apps/web/src/app/docs/api-mcp/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata("API and MCP", "Choosing between session-auth routes, API keys, and MCP tooling.", "/docs/api-mcp");
+
+export default function DocsApiMcpPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md space-y-4">
+        <h1 className="text-3xl font-bold text-slate-900">API and MCP</h1>
+        <p className="text-sm text-slate-700">Use session-auth routes for in-app exports and admin actions. Use org-scoped API keys for integration automation. Use MCP tooling for structured agent workflows.</p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/docs/how-scans-work/page.tsx
+++ b/apps/web/src/app/docs/how-scans-work/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { TruthBadge } from "@/components/truth/truth-badge";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata("How scans work", "Automation boundaries, evidence capture, and review-required conditions.", "/docs/how-scans-work");
+
+export default function DocsHowScansWorkPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md space-y-6">
+        <h1 className="text-3xl font-bold text-slate-900">How scans work</h1>
+        <div className="space-y-3 text-sm text-slate-700">
+          <p><TruthBadge state="implemented" className="mr-2" />Private crawls retain findings history and evidence artifacts.</p>
+          <p><TruthBadge state="partial" className="mr-2" />Public scans are intentionally shallow for orientation, not full certification.</p>
+          <p><TruthBadge state="requires_human_review" className="mr-2" />Keyboard flow, reading order, and visual ambiguity can require manual verification.</p>
+        </div>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -1,72 +1,100 @@
 import type { Metadata } from "next";
+import type { Route } from "next";
 import Link from "next/link";
 import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
 import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
 import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+import { TruthBadge, type TruthState } from "@/components/truth/truth-badge";
 
 export const metadata: Metadata = marketingSurfaceMetadata(
   "Documentation",
-  `Evaluation and onboarding docs for ${PRODUCT_DISPLAY_NAME}: getting started, plans and limits, and API integration paths.`,
+  `Evaluation and onboarding docs for ${PRODUCT_DISPLAY_NAME}: quickstart, review workflow, reports, and team administration grounded in shipped behavior.`,
   "/docs",
 );
 
-const docsCards = [
+const docsCards: Array<{
+  href: Route;
+  title: string;
+  description: string;
+  state: TruthState;
+}> = [
   {
-    href: "/docs/getting-started",
-    title: "Getting started",
-    description:
-      "From account creation to first private scan and first report artifact.",
+    href: "/docs/quickstart",
+    title: "Quickstart",
+    description: "Create a workspace, run a private crawl, and produce first evidence.",
+    state: "implemented",
   },
   {
-    href: "/docs/plans-and-limits",
-    title: "Plans and limits",
-    description:
-      "Exact tier limits and what is self-serve versus contract-shaped enterprise scope.",
+    href: "/docs/how-scans-work",
+    title: "How scans work",
+    description: "What is automated, what is bounded, and where manual verification is required.",
+    state: "implemented",
   },
   {
-    href: "/docs/comparison",
-    title: "How we compare",
-    description:
-      "Category comparison: operations platform vs overlays, score-only tools, and generic AI checkers—scoped to real product behavior.",
+    href: "/docs/reports-and-proof",
+    title: "Reports and proof",
+    description: "How exports, audit logs, and confidence labels work in this build.",
+    state: "implemented",
+  },
+  {
+    href: "/docs/remediation-workflow",
+    title: "Remediation workflow",
+    description: "From finding clusters to suggestions, approvals, and tracked outcomes.",
+    state: "implemented",
+  },
+  {
+    href: "/docs/reviews-and-manual-verification",
+    title: "Reviews and manual verification",
+    description: "How review tasks are prioritized, resolved, and documented.",
+    state: "implemented",
+  },
+  {
+    href: "/docs/team-admin",
+    title: "Team administration",
+    description: "Members, roles, seats, pending invites, and audit trail posture.",
+    state: "partial",
   },
   {
     href: "/docs/api",
     title: "API and integrations",
-    description:
-      "Org-scoped API keys, operational limits, and supported integration surfaces in this build.",
+    description: "Org-scoped API keys and MCP integration surfaces.",
+    state: "implemented",
   },
   {
-    href: "/security",
-    title: "Security overview",
-    description:
-      "Deployment security posture, optional OIDC enterprise SSO, and where to find detailed health and status.",
+    href: "/docs/api-mcp",
+    title: "API + MCP detail",
+    description: "When to use session routes, API keys, and MCP tooling.",
+    state: "implemented",
   },
 ] as const;
 
 export default function DocsIndexPage() {
   return (
     <MarketingSiteChrome>
-      <div className="mx-auto max-w-4xl px-6 py-section-md">
+      <div className="mx-auto max-w-5xl px-6 py-section-md">
         <p className="text-sm font-medium text-brand-700">Documentation</p>
         <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-900">
-          Evaluate and onboard without guesswork
+          Operator-grade docs with explicit boundaries
         </h1>
         <p className="mt-4 text-slate-600">
-          These docs are intentionally operational: what works today, what is
-          plan-gated, and where managed enterprise support begins.
+          These pages distinguish implemented behavior from staged capability,
+          and mark where human review remains mandatory.
         </p>
 
-        <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        <div className="mt-10 grid gap-4 md:grid-cols-2">
           {docsCards.map((card) => (
             <article
               key={card.href}
               className="rounded-xl border border-[rgb(var(--color-border))] bg-[rgb(var(--color-surface-elevated))] p-5"
             >
-              <h2 className="text-lg font-semibold text-slate-900">
-                <Link href={card.href} className="hover:underline">
-                  {card.title}
-                </Link>
-              </h2>
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-lg font-semibold text-slate-900">
+                  <Link href={card.href} className="hover:underline">
+                    {card.title}
+                  </Link>
+                </h2>
+                <TruthBadge state={card.state} />
+              </div>
               <p className="mt-2 text-sm text-slate-600">{card.description}</p>
             </article>
           ))}

--- a/apps/web/src/app/docs/quickstart/page.tsx
+++ b/apps/web/src/app/docs/quickstart/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata("Quickstart", "Quickstart path from signup to first private evidence artifact.", "/docs/quickstart");
+
+export default function DocsQuickstartPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md space-y-6">
+        <h1 className="text-3xl font-bold text-slate-900">Quickstart</h1>
+        <ol className="space-y-4 text-sm text-slate-700 list-decimal pl-6">
+          <li>Create account and verify email (requires deployment SMTP).</li>
+          <li>Add site(s) to your workspace and run a private crawl.</li>
+          <li>Triage findings, then route uncertain items to the review queue.</li>
+          <li>Export reports and audit trail only after human sign-off.</li>
+          <li>Configure member roles and seat limits in settings.</li>
+        </ol>
+        <p className="text-sm text-slate-500">Continue with <Link className="text-brand-700 hover:underline font-medium" href="/docs/how-scans-work">How scans work</Link>.</p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/docs/remediation-workflow/page.tsx
+++ b/apps/web/src/app/docs/remediation-workflow/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata("Remediation workflow", "From findings to suggestions to approved remediation actions.", "/docs/remediation-workflow");
+
+export default function DocsRemediationWorkflowPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md space-y-4">
+        <h1 className="text-3xl font-bold text-slate-900">Remediation workflow</h1>
+        <p className="text-sm text-slate-700">Suggestions are generated, reviewed, and then approved or rejected. Human reviewers remain the release gate for ambiguous findings.</p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/docs/reports-and-proof/page.tsx
+++ b/apps/web/src/app/docs/reports-and-proof/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata("Reports and proof", "How report exports and audit evidence should be interpreted.", "/docs/reports-and-proof");
+
+export default function DocsReportsProofPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md space-y-4">
+        <h1 className="text-3xl font-bold text-slate-900">Reports and proof</h1>
+        <p className="text-sm text-slate-700">Reports can be exported from authenticated routes. Confidence labels indicate machine certainty and review status; they are not legal determinations.</p>
+        <p className="text-sm text-slate-700">Audit logs capture review and team-admin events for organization-scoped evidence trails.</p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/docs/reviews-and-manual-verification/page.tsx
+++ b/apps/web/src/app/docs/reviews-and-manual-verification/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata("Reviews and manual verification", "Review task lifecycle, evidence, and reviewer decisions.", "/docs/reviews-and-manual-verification");
+
+export default function DocsReviewsPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md space-y-4">
+        <h1 className="text-3xl font-bold text-slate-900">Reviews and manual verification</h1>
+        <p className="text-sm text-slate-700">Review tasks prioritize unresolved and stale items first. Evidence panels show stored artifacts and summaries when available; missing evidence is shown explicitly.</p>
+        <p className="text-sm text-slate-700">Reviewer outcomes map to confirmed, false positive, and needs escalation flows inside <Link href="/reviews" className="text-brand-700 hover:underline font-medium">Review Queue</Link>.</p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/docs/team-admin/page.tsx
+++ b/apps/web/src/app/docs/team-admin/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
+import { TruthBadge } from "@/components/truth/truth-badge";
+import { marketingSurfaceMetadata } from "@/lib/site-metadata";
+
+export const metadata: Metadata = marketingSurfaceMetadata("Team admin", "Member roles, seat usage, pending invites, and staged enterprise controls.", "/docs/team-admin");
+
+export default function DocsTeamAdminPage() {
+  return (
+    <MarketingSiteChrome>
+      <div className="mx-auto max-w-3xl px-6 py-section-md space-y-4">
+        <h1 className="text-3xl font-bold text-slate-900">Team administration</h1>
+        <p className="text-sm text-slate-700"><TruthBadge state="implemented" className="mr-2" />Organization members, role changes, seat usage, and pending invite records are available in settings.</p>
+        <p className="text-sm text-slate-700"><TruthBadge state="staged" className="mr-2" />SSO/SCIM and automated outbound invite email remain deployment-dependent and staged by operator configuration.</p>
+      </div>
+    </MarketingSiteChrome>
+  );
+}

--- a/apps/web/src/app/trust/page.tsx
+++ b/apps/web/src/app/trust/page.tsx
@@ -5,6 +5,7 @@ import { PRODUCT_DISPLAY_NAME } from "@/lib/product-brand";
 import { marketingSurfaceMetadata } from "@/lib/site-metadata";
 import { CONFIDENCE_LABELS } from "@/lib/assurance-ladder";
 import { getPublicPlanCards } from "@/lib/public-packaging";
+import { TruthBadge } from "@/components/truth/truth-badge";
 
 export const metadata: Metadata = marketingSurfaceMetadata(
   "Trust",
@@ -121,6 +122,33 @@ export default function TrustPage() {
           </div>
         </section>
 
+
+        <section className="mt-12">
+          <h2 className="text-lg font-semibold text-slate-900">Procurement posture summary</h2>
+          <div className="mt-4 space-y-3 text-sm text-slate-700">
+            <p><TruthBadge state="implemented" className="mr-2" />Organization-scoped access controls, audit logs, and server-side entitlement checks are implemented.</p>
+            <p><TruthBadge state="environment_dependent" className="mr-2" />Email verification, Redis-backed limits, and object storage behavior depend on deployment configuration.</p>
+            <p><TruthBadge state="staged" className="mr-2" />Procurement extras such as custom SLA language and enterprise IAM controls are contract/operator scoped, not implied by default.</p>
+          </div>
+        </section>
+
+        <section className="mt-12">
+          <h2 className="text-lg font-semibold text-slate-900">Procurement FAQ</h2>
+          <dl className="mt-4 space-y-4 text-sm text-slate-700">
+            <div>
+              <dt className="font-semibold text-slate-900">Does AROS guarantee legal compliance?</dt>
+              <dd className="mt-1">No. The platform provides evidence, automation, and review workflow support. Legal/compliance determinations require qualified human review.</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-slate-900">What data is persisted?</dt>
+              <dd className="mt-1">Workspace metadata, scan findings, remediation suggestions, review tasks, and audit events. Evidence storage mode depends on deployment object storage configuration.</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-slate-900">Can teams export evidence?</dt>
+              <dd className="mt-1">Yes. Reports and audit-log export routes exist with organization-scoped access and permission checks.</dd>
+            </div>
+          </dl>
+        </section>
         <section className="mt-12">
           <h2 className="text-lg font-semibold text-slate-900">Commitments by service lane</h2>
           <p className="mt-2 text-sm text-slate-600">

--- a/apps/web/src/components/truth/truth-badge.tsx
+++ b/apps/web/src/components/truth/truth-badge.tsx
@@ -1,0 +1,59 @@
+export type TruthState =
+  | "implemented"
+  | "partial"
+  | "staged"
+  | "not_supported"
+  | "admin_configured"
+  | "environment_dependent"
+  | "requires_human_review";
+
+const TRUTH_META: Record<TruthState, { label: string; className: string }> = {
+  implemented: {
+    label: "Implemented",
+    className: "bg-emerald-100 text-emerald-800 border-emerald-200",
+  },
+  partial: {
+    label: "Partial",
+    className: "bg-amber-100 text-amber-800 border-amber-200",
+  },
+  staged: {
+    label: "Staged",
+    className: "bg-slate-100 text-slate-700 border-slate-200",
+  },
+  not_supported: {
+    label: "Not supported",
+    className: "bg-rose-100 text-rose-800 border-rose-200",
+  },
+  admin_configured: {
+    label: "Admin configured",
+    className: "bg-sky-100 text-sky-800 border-sky-200",
+  },
+  environment_dependent: {
+    label: "Environment dependent",
+    className: "bg-violet-100 text-violet-800 border-violet-200",
+  },
+  requires_human_review: {
+    label: "Requires human review",
+    className: "bg-orange-100 text-orange-800 border-orange-200",
+  },
+};
+
+export function TruthBadge({
+  state,
+  className,
+}: {
+  state: TruthState;
+  className?: string;
+}) {
+  const meta = TRUTH_META[state];
+
+  return (
+    <span
+      className={["inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium", meta.className, className]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {meta.label}
+    </span>
+  );
+}

--- a/apps/web/src/lib/marketing-routes.test.ts
+++ b/apps/web/src/lib/marketing-routes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { MARKETING_ROUTES } from "@/lib/marketing-routes";
+
+describe("marketing routes", () => {
+  it("includes trust, security, and docs closure routes", () => {
+    const hrefs = MARKETING_ROUTES.map((r) => r.href);
+    expect(hrefs).toContain("/trust");
+    expect(hrefs).toContain("/security");
+    expect(hrefs).toContain("/docs");
+    expect(hrefs).toContain("/docs/quickstart");
+    expect(hrefs).toContain("/docs/how-scans-work");
+    expect(hrefs).toContain("/docs/reports-and-proof");
+    expect(hrefs).toContain("/docs/remediation-workflow");
+    expect(hrefs).toContain("/docs/reviews-and-manual-verification");
+    expect(hrefs).toContain("/docs/team-admin");
+    expect(hrefs).toContain("/docs/api-mcp");
+  });
+
+  it("does not define duplicate route hrefs", () => {
+    const hrefs = MARKETING_ROUTES.map((r) => r.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});

--- a/apps/web/src/lib/marketing-routes.ts
+++ b/apps/web/src/lib/marketing-routes.ts
@@ -31,6 +31,36 @@ export const MARKETING_ROUTES: readonly MarketingRoute[] = [
     includeInSitemap: true,
   },
   {
+    href: "/docs/quickstart",
+    label: "Quickstart",
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs/how-scans-work",
+    label: "How scans work",
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs/reports-and-proof",
+    label: "Reports & proof",
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs/remediation-workflow",
+    label: "Remediation workflow",
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs/reviews-and-manual-verification",
+    label: "Reviews & manual verification",
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs/team-admin",
+    label: "Team admin",
+    includeInSitemap: true,
+  },
+  {
     href: "/docs/plans-and-limits",
     label: "Plans & limits",
     includeInSitemap: true,
@@ -44,6 +74,11 @@ export const MARKETING_ROUTES: readonly MarketingRoute[] = [
     href: "/docs/api",
     label: "API & integrations",
     includeInPrimaryNav: true,
+    includeInSitemap: true,
+  },
+  {
+    href: "/docs/api-mcp",
+    label: "API + MCP",
     includeInSitemap: true,
   },
   {


### PR DESCRIPTION
### Motivation

- Provide procurement-safe, evidence-first trust surfaces and consistent truth vocabulary so buyers and operators can evaluate real product behavior without overstated claims.  
- Productize manual review workflows so uncertain/ambiguous findings are clearly prioritized, accompanied by evidence and reviewer rationale.  
- Close public docs gaps and harden release checks so route registry/drift regressions are caught early while improving team-admin visibility for seat usage and auditability.

### Description

- Add a reusable truth-state badge primitive `TruthBadge` to standardize vocabulary across trust/docs/admin/review UIs (`apps/web/src/components/truth/truth-badge.tsx`).
- Expand the public Trust page with a procurement posture summary and FAQ that reflect implemented vs staged capabilities (`apps/web/src/app/trust/page.tsx`).
- Replace the Docs index with an operator-focused landing and add new docs routes: `/docs/quickstart`, `/docs/how-scans-work`, `/docs/reports-and-proof`, `/docs/remediation-workflow`, `/docs/reviews-and-manual-verification`, `/docs/team-admin`, and `/docs/api-mcp` (`apps/web/src/app/docs/**`).
- Improve Review queue UX: risk + staleness prioritization, explicit per-type review reasons, evidence/notes disclosure panel, reviewer action forms that accept a bounded optional note, and server-side persistence of notes (bounded to 2000 chars) in `updateReviewAction` (`apps/web/src/app/(dashboard)/reviews/*`, `apps/web/src/app/(dashboard)/reviews/actions.ts`).
- Team admin: surface seat usage (members + pending invites), seat-cap warning + billing link, and an enterprise posture card that truthfully marks invites/SSO/SCIM as implemented/staged/env-dependent as appropriate (`apps/web/src/app/(dashboard)/settings/members/page.tsx` and `apps/web/src/app/(dashboard)/settings/page.tsx`).
- Release/CI: add a marketing route registry unit test and include it in launch-critical tests to prevent docs/trust registry regressions (`apps/web/src/lib/marketing-routes.test.ts`, `apps/web/src/lib/marketing-routes.ts`, and apps/web package.json test script update).
- Minor build/type safety fix: `docs` cards' `href` typed as `Route` to satisfy Next.js typing during `next build`.

### Testing

- Ran `npm run lint` (workspace) — passed after fixing a docs string/template issue.  
- Ran `npm run typecheck` (workspace) — passed (`tsc --noEmit` across workspaces).  
- Ran full unit test suite `npm run test` (workspaces) and targeted tests: `npm run test --workspace=apps/web -- src/lib/marketing-routes.test.ts` — all passed (report: multiple packages green; single-file marketing test passed).  
- Built the web app `npm run build` — Next.js build completed successfully after resolving a `Link href` typing issue.  
- Ran `npm run test:launch-critical` (apps/web) — passed, including the new `marketing-routes.test.ts` guard.  

All automated checks listed above completed successfully; one type/Link issue was detected during `next build` and fixed in this change set (no residual failing checks remain).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5c67998488328aea8a3590e7412cf)