### PR TITLE
feat(web): add trust/security redirect, settings Trust & admin link, and tighten review queue truth cues

### DIFF
--- a/apps/web/src/app/(dashboard)/reviews/page.tsx
+++ b/apps/web/src/app/(dashboard)/reviews/page.tsx
@@ -21,6 +21,18 @@ const REVIEW_REASON: Record<ReviewType, string> = {
   MANUAL_AUDIT: "Rule requires explicit human verification.",
 };
 
+const REVIEW_REASON_STATE: Record<
+  ReviewType,
+  "requires_human_review" | "partial"
+> = {
+  ALT_TEXT_REVIEW: "partial",
+  CONTENT_CLARITY: "requires_human_review",
+  KEYBOARD_FLOW: "requires_human_review",
+  SCREEN_READER: "requires_human_review",
+  SUGGESTION_REVIEW: "partial",
+  MANUAL_AUDIT: "requires_human_review",
+};
+
 export default async function ReviewsPage({
   searchParams,
 }: {
@@ -221,8 +233,12 @@ export default async function ReviewsPage({
                   <div className="flex-1 space-y-2">
                     <div className="flex items-center gap-2 flex-wrap">
                       <ReviewStatusBadge status={task.status} />
-                      <TruthBadge state="requires_human_review" />
-                      {stale ? <TruthBadge state="partial" /> : null}
+                      <TruthBadge state={REVIEW_REASON_STATE[task.type]} />
+                      {stale ? (
+                        <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-800">
+                          Stale queue item
+                        </span>
+                      ) : null}
                     </div>
                     <h3 className="text-sm font-semibold text-slate-900">{task.title}</h3>
                     {task.description ? (
@@ -266,7 +282,7 @@ export default async function ReviewsPage({
                       organizationId={orgRes.organizationId}
                       taskId={task.id}
                       status="IN_PROGRESS"
-                      label="Mark pending"
+                      label="Start review"
                     />
                   )}
                   <ReviewActionForm

--- a/apps/web/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/page.tsx
@@ -236,7 +236,7 @@ export default async function SettingsPage() {
         <h2 className="text-lg font-semibold text-slate-900 mb-4">
           Management
         </h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <Link
             href="/settings/api-keys"
             className="group flex items-start gap-3 rounded-xl border border-slate-200 p-4 transition-colors hover:border-brand-200 hover:bg-brand-50/30"
@@ -320,6 +320,35 @@ export default async function SettingsPage() {
               </h3>
               <p className="mt-1 text-xs text-slate-500">
                 Monitor usage and quotas
+              </p>
+            </div>
+          </Link>
+
+          <Link
+            href="/trust"
+            className="group flex items-start gap-3 rounded-xl border border-slate-200 p-4 transition-colors hover:border-brand-200 hover:bg-brand-50/30"
+          >
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-100 text-slate-600 group-hover:bg-brand-100 group-hover:text-brand-600">
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 12l2 2 4-4m5-2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+            <div>
+              <h3 className="font-medium text-slate-900 group-hover:text-brand-700">
+                Trust &amp; admin
+              </h3>
+              <p className="mt-1 text-xs text-slate-500">
+                Security posture, docs, and team-admin references
               </p>
             </div>
           </Link>

--- a/apps/web/src/app/trust/security/page.tsx
+++ b/apps/web/src/app/trust/security/page.tsx
@@ -1,0 +1,5 @@
+import { permanentRedirect } from "next/navigation";
+
+export default function TrustSecurityRedirectPage() {
+  permanentRedirect("/security");
+}


### PR DESCRIPTION
### Motivation
- Improve procurement-facing IA and operator discoverability by making the trust/security path explicit and reachable from the dashboard settings.
- Increase manual-review credibility by surfacing reason-grounded truth badges and clearer stale/transition cues so reviewers and auditors see honest evidence boundaries.
- Keep changes low-conflict and additive (no schema changes) to preserve release safety and CI stability.

### Description
- Added a compatibility redirect route `/trust/security` that permanently redirects to `/security` to align trust IA with procurement expectations (`apps/web/src/app/trust/security/page.tsx`).
- Exposed a new “Trust & admin” card on the Settings → Management grid and expanded the grid to four columns for layout parity (`apps/web/src/app/(dashboard)/settings/page.tsx`).
- Tightened review queue UX by mapping `ReviewTask` types to explicit truth states, replacing the generic badge with reason-aware `TruthBadge` usage, adding a visible "Stale queue item" indicator, and renaming the pending action button to `Start review` (`apps/web/src/app/(dashboard)/reviews/page.tsx`).
- No Prisma schema or migration changes were introduced. Files changed: `reviews/page.tsx`, `settings/page.tsx`, and `trust/security/page.tsx`.

### Testing
- Ran `npm run lint` and the workspace ESLint pass completed successfully.
- Ran `npm run typecheck` and full workspaces typecheck passed with Prisma client check OK.
- Ran `npm run test` and all unit/test suites passed (`Test Files 61 passed`, total tests passed across packages shown in run output).
- Ran `npm run build` and Next.js production build completed successfully with static page generation.
- Ran `npm run test:launch-critical` and launch-critical smoke tests passed.
- No failures introduced by this change and no migrations required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5cc5bbe30832880c5837513fa4248)