### PR TITLE
Second-pass closure: strengthen trust, review operations, admin audit visibility, and CI safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,23 @@ jobs:
           REDIS_URL: redis://localhost:6379
         run: npm run db:push && npm run db:seed
 
-      - name: Run Release Verification (Core + Integration)
+      - name: Run Core Verification
         env:
           DATABASE_URL: postgresql://aros_user:aros_password@localhost:5432/aros_test?schema=public
           REDIS_URL: redis://localhost:6379
-        run: npm run verify:release
+        run: npm run verify:core
+
+      - name: Run Touched Route Safety Checks
+        env:
+          DATABASE_URL: postgresql://aros_user:aros_password@localhost:5432/aros_test?schema=public
+          REDIS_URL: redis://localhost:6379
+        run: npm run verify:touched-routes
+
+      - name: Run Tenant Boundary + Integration Verification
+        env:
+          DATABASE_URL: postgresql://aros_user:aros_password@localhost:5432/aros_test?schema=public
+          REDIS_URL: redis://localhost:6379
+        run: npm run verify:tenant-boundary && npm run test:integration
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Open http://localhost:3000
 
 ```bash
 npm run verify        # lint + typecheck + unit tests + production build
-npm run verify:release # verify:core + integration tests (strict release gate before E2E)
+npm run verify:release # verify:core + touched-route safety + tenant boundary + integration tests
+npm run verify:touched-routes # launch-critical route/workflow checks for public trust and review/admin surfaces
 npm run test          # Run all unit tests (Vitest)
 npm run test:e2e      # Playwright (requires DATABASE_URL; preflight validates env before db:push + db:seed)
 npm run typecheck     # TypeScript type checking

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "test:ct": "playwright test -c playwright-ct.config.ts",
     "test:e2e:update": "playwright test --update-snapshots",
     "test:integration": "vitest run src/lib/__tests__/stripe-webhook.integration.test.ts src/lib/__tests__/tenant-isolation.integration.test.ts",
-    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts src/lib/operator-org-resolution.test.ts src/lib/dashboard-org-scoped-prisma.test.ts src/lib/dashboard-form-org.test.ts src/lib/marketing-routes.test.ts"
+    "test:launch-critical": "vitest run src/app/api/public-scan/route.test.ts src/app/api/public-scan/[id]/route.test.ts src/lib/public-scan/og-render-model.test.ts src/lib/public-scan/validity.test.ts src/lib/public-scan/target-validation.test.ts src/app/api/github-action/status/[scanRunId]/route.test.ts src/app/api/reports/vpat/route.test.ts src/lib/server-org-boundary.test.ts src/lib/operator-org-resolution.test.ts src/lib/dashboard-org-scoped-prisma.test.ts src/lib/dashboard-form-org.test.ts src/lib/marketing-routes.test.ts src/lib/review-operations.test.ts"
   },
   "dependencies": {
     "@aros/config": "*",

--- a/apps/web/src/app/(dashboard)/reviews/page.tsx
+++ b/apps/web/src/app/(dashboard)/reviews/page.tsx
@@ -1,6 +1,6 @@
 import { requireSession } from "@/lib/session";
 import { prisma } from "@/lib/db";
-import type { Prisma, ReviewType } from "@aros/db";
+import type { Prisma } from "@aros/db";
 import Link from "next/link";
 import { updateReviewAction } from "./actions";
 import { getRoutePlatformTruth } from "@/lib/platform-truth-cache";
@@ -9,29 +9,21 @@ import { RouteReliabilityNotice } from "@/components/reliability/route-reliabili
 import { hasPermission } from "@aros/config";
 import { StatusBadge } from "@aros/ui";
 import { TruthBadge } from "@/components/truth/truth-badge";
+import {
+  REVIEW_REASON_META,
+  getReviewAgeHours,
+  getReviewPriorityScore,
+  groupReviewQueueTasks,
+} from "@/lib/review-operations";
 
 export const metadata = { title: "Reviews" };
 
-const REVIEW_REASON: Record<ReviewType, string> = {
-  ALT_TEXT_REVIEW: "Visual context ambiguity for alt text quality.",
-  CONTENT_CLARITY: "Language clarity or meaning requires human interpretation.",
-  KEYBOARD_FLOW: "Keyboard and focus order behavior can be context-sensitive.",
-  SCREEN_READER: "Landmark and reading-order behavior needs AT verification.",
-  SUGGESTION_REVIEW: "Generated suggestion requires reviewer confirmation.",
-  MANUAL_AUDIT: "Rule requires explicit human verification.",
-};
-
-const REVIEW_REASON_STATE: Record<
-  ReviewType,
-  "requires_human_review" | "partial"
-> = {
-  ALT_TEXT_REVIEW: "partial",
-  CONTENT_CLARITY: "requires_human_review",
-  KEYBOARD_FLOW: "requires_human_review",
-  SCREEN_READER: "requires_human_review",
-  SUGGESTION_REVIEW: "partial",
-  MANUAL_AUDIT: "requires_human_review",
-};
+const GROUP_LABELS = {
+  overdue: "Overdue unresolved",
+  active: "In progress",
+  pending: "Pending review",
+  resolved: "Recently resolved",
+} as const;
 
 export default async function ReviewsPage({
   searchParams,
@@ -41,6 +33,8 @@ export default async function ReviewsPage({
   const user = await requireSession();
   const platformTruth = await getRoutePlatformTruth();
   const params = await searchParams;
+  const now = new Date();
+
   let canViewSystem = false;
   try {
     const memberships = await prisma.membership.findMany({
@@ -152,7 +146,7 @@ export default async function ReviewsPage({
         },
       },
       include: reviewListInclude,
-      take: 80,
+      take: 120,
     });
   } catch (e) {
     loadError = e instanceof Error ? e.message : "Database error";
@@ -174,41 +168,47 @@ export default async function ReviewsPage({
     );
   }
 
-  const sortedTasks = [...tasks].sort((a, b) => {
-    const priority = (task: ReviewListRow) => {
-      const ageHours = (Date.now() - task.createdAt.getTime()) / 3_600_000;
-      const statusScore =
-        task.status === "PENDING" ? 4 : task.status === "IN_PROGRESS" ? 2 : 0;
-      const reviewRisk = task.type === "MANUAL_AUDIT" || task.type === "KEYBOARD_FLOW" ? 2 : 1;
-      const staleBoost = ageHours > 72 ? 2 : 0;
-      return statusScore + reviewRisk + staleBoost;
-    };
-
-    const diff = priority(b) - priority(a);
-    if (diff !== 0) return diff;
-    return b.createdAt.getTime() - a.createdAt.getTime();
-  });
+  const groupedTasks = groupReviewQueueTasks(
+    tasks.map((task) => ({
+      id: task.id,
+      type: task.type,
+      status: task.status,
+      createdAt: task.createdAt,
+      updatedAt: task.updatedAt,
+      reviewedAt: task.reviewedAt,
+      evidenceCount: task._count.evidence,
+      controlPlaneEvidenceCount: task._count.controlPlaneEvidence,
+    })),
+    now,
+  );
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
 
   const pendingCount = tasks.filter((t) => t.status === "PENDING").length;
-  const inProgressCount = tasks.filter(
-    (t) => t.status === "IN_PROGRESS",
-  ).length;
-  const unresolvedCount = tasks.filter(
-    (t) => t.status === "PENDING" || t.status === "IN_PROGRESS",
-  ).length;
+  const inProgressCount = tasks.filter((t) => t.status === "IN_PROGRESS").length;
+  const resolvedCount = tasks.filter((t) => ["APPROVED", "REJECTED", "NEEDS_CHANGES"].includes(t.status)).length;
+  const unresolvedCount = pendingCount + inProgressCount;
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-slate-900">Review Queue</h1>
-        <p className="text-slate-500 mt-1">
-          {pendingCount} pending, {inProgressCount} in progress, {unresolvedCount} unresolved
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Review Queue</h1>
+          <p className="text-slate-500 mt-1">
+            {pendingCount} pending · {inProgressCount} in progress · {unresolvedCount} unresolved · {resolvedCount} resolved
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link href="/docs/reviews-and-manual-verification" className="btn-secondary text-xs">
+            Review docs
+          </Link>
+          <Link href="/trust" className="btn-secondary text-xs">
+            Trust posture
+          </Link>
+        </div>
       </div>
 
       <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 text-sm text-orange-900">
-        Automated scanners reduce manual effort, but do not establish final conformance on their own.
-        Use this queue to document reviewer outcomes and rationale.
+        Automation surfaces likely issues and draft remediation; reviewer decisions establish operational truth for this queue.
       </div>
 
       {reviewError && (
@@ -217,94 +217,152 @@ export default async function ReviewsPage({
         </RouteReliabilityNotice>
       )}
 
-      {sortedTasks.length === 0 ? (
-        <div className="card text-center py-12">
+      {tasks.length === 0 ? (
+        <div className="card text-center py-12 space-y-3">
           <p className="text-slate-500">No review tasks yet.</p>
+          <p className="text-xs text-slate-400">
+            New manual-review tasks appear when findings or suggestions require human judgment.
+          </p>
         </div>
       ) : (
-        <div className="space-y-3">
-          {sortedTasks.map((task) => {
-            const ageHours = Math.floor((Date.now() - task.createdAt.getTime()) / 3_600_000);
-            const stale = ageHours > 72;
+        <div className="space-y-8">
+          {(Object.keys(groupedTasks) as Array<keyof typeof groupedTasks>).map((groupKey) => {
+            const entries = groupedTasks[groupKey];
+            if (entries.length === 0) return null;
 
             return (
-              <article key={task.id} className="card space-y-3">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1 space-y-2">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <ReviewStatusBadge status={task.status} />
-                      <TruthBadge state={REVIEW_REASON_STATE[task.type]} />
-                      {stale ? (
-                        <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-800">
-                          Stale queue item
-                        </span>
-                      ) : null}
-                    </div>
-                    <h3 className="text-sm font-semibold text-slate-900">{task.title}</h3>
-                    {task.description ? (
-                      <p className="text-sm text-slate-600">{task.description}</p>
-                    ) : null}
-                    <p className="text-xs text-slate-500">{REVIEW_REASON[task.type]}</p>
-                    <div className="flex items-center gap-4 text-xs text-slate-400">
-                      {task.assignee && (
-                        <span>
-                          Assigned to: {task.assignee.name ?? task.assignee.email}
-                        </span>
-                      )}
-                      <span>Evidence: {task._count.evidence + task._count.controlPlaneEvidence}</span>
-                      <span>Age: {ageHours}h</span>
-                    </div>
-                  </div>
-                  {task.suggestion && task.suggestionId ? (
-                    <Link
-                      href={`/remediation/${task.suggestionId}`}
-                      className="btn-ghost text-xs"
-                    >
-                      View suggestion
-                    </Link>
+              <section key={groupKey} className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-700">
+                    {GROUP_LABELS[groupKey]} ({entries.length})
+                  </h2>
+                  {groupKey === "overdue" ? (
+                    <span className="text-xs font-medium text-amber-700">
+                      Older than 72h while unresolved
+                    </span>
                   ) : null}
                 </div>
 
-                <details className="rounded-lg border border-slate-200 p-3">
-                  <summary className="cursor-pointer text-sm font-medium text-slate-800">Evidence and reviewer notes</summary>
-                  <div className="mt-3 space-y-2 text-sm text-slate-600">
-                    <p>Task type: {task.type.replaceAll("_", " ").toLowerCase()}</p>
-                    <p>Automation evidence artifacts: {task._count.evidence}</p>
-                    <p>Control-plane evidence artifacts: {task._count.controlPlaneEvidence}</p>
-                    <p>Suggestion attached: {task.suggestion ? "yes" : "no"}</p>
-                    {task.notes ? <p>Latest reviewer note: {task.notes}</p> : <p>No reviewer note yet.</p>}
-                  </div>
-                </details>
+                <div className="space-y-3">
+                  {entries.map((entry) => {
+                    const task = taskById.get(entry.id);
+                    if (!task) return null;
 
-                <div className="flex flex-wrap gap-2">
-                  {task.status === "PENDING" && (
-                    <ReviewActionForm
-                      organizationId={orgRes.organizationId}
-                      taskId={task.id}
-                      status="IN_PROGRESS"
-                      label="Start review"
-                    />
-                  )}
-                  <ReviewActionForm
-                    organizationId={orgRes.organizationId}
-                    taskId={task.id}
-                    status="APPROVED"
-                    label="Mark confirmed"
-                  />
-                  <ReviewActionForm
-                    organizationId={orgRes.organizationId}
-                    taskId={task.id}
-                    status="REJECTED"
-                    label="Mark false positive"
-                  />
-                  <ReviewActionForm
-                    organizationId={orgRes.organizationId}
-                    taskId={task.id}
-                    status="NEEDS_CHANGES"
-                    label="Needs escalation"
-                  />
+                    const reasonMeta = REVIEW_REASON_META[task.type];
+                    const ageHours = getReviewAgeHours(entry, now);
+                    const totalEvidence = task._count.evidence + task._count.controlPlaneEvidence;
+                    const priorityScore = getReviewPriorityScore(entry, now);
+                    const evidenceState =
+                      totalEvidence === 0
+                        ? "No evidence attached yet"
+                        : `${task._count.evidence} automation artifact(s), ${task._count.controlPlaneEvidence} control-plane artifact(s)`;
+
+                    return (
+                      <article key={task.id} className="card space-y-4">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="flex-1 space-y-2">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <ReviewStatusBadge status={task.status} />
+                              <TruthBadge state={reasonMeta.truthState} />
+                              <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 text-xs font-medium text-slate-700">
+                                {reasonMeta.taxonomy}
+                              </span>
+                              {groupKey === "overdue" ? (
+                                <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-800">
+                                  Escalation candidate
+                                </span>
+                              ) : null}
+                            </div>
+
+                            <h3 className="text-sm font-semibold text-slate-900">{task.title}</h3>
+                            {task.description ? (
+                              <p className="text-sm text-slate-600">{task.description}</p>
+                            ) : null}
+                            <p className="text-xs text-slate-600">{reasonMeta.description}</p>
+                            <p className="text-xs text-slate-500">Reviewer expectation: {reasonMeta.reviewerExpectation}</p>
+
+                            <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                              {task.assignee ? (
+                                <span>
+                                  Assigned: {task.assignee.name ?? task.assignee.email}
+                                </span>
+                              ) : (
+                                <span>Assigned: unassigned</span>
+                              )}
+                              <span>Evidence: {totalEvidence}</span>
+                              <span>Age: {ageHours}h</span>
+                              <span>Priority score: {priorityScore}</span>
+                            </div>
+                          </div>
+
+                          {task.suggestion && task.suggestionId ? (
+                            <Link
+                              href={`/remediation/${task.suggestionId}`}
+                              className="btn-ghost text-xs"
+                            >
+                              Open suggestion
+                            </Link>
+                          ) : null}
+                        </div>
+
+                        <details className="rounded-lg border border-slate-200 p-3">
+                          <summary className="cursor-pointer text-sm font-medium text-slate-800">
+                            Evidence and rationale context
+                          </summary>
+                          <div className="mt-3 space-y-2 text-sm text-slate-600">
+                            <p>Review reason taxonomy: {reasonMeta.taxonomy}</p>
+                            <p>{evidenceState}</p>
+                            <p>Suggestion attached: {task.suggestion ? "yes" : "no"}</p>
+                            {task.notes ? <p>Latest reviewer note: {task.notes}</p> : <p>No reviewer note yet.</p>}
+                            {task.reviewedAt ? (
+                              <p>Last reviewed: {task.reviewedAt.toLocaleString()}</p>
+                            ) : (
+                              <p>Not marked reviewed yet.</p>
+                            )}
+                          </div>
+                        </details>
+
+                        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600">
+                          For confirmed/false-positive/escalation actions, include rationale and references to evidence IDs when available.
+                        </div>
+
+                        <div className="flex flex-wrap gap-2">
+                          {task.status === "PENDING" && (
+                            <ReviewActionForm
+                              organizationId={orgRes.organizationId}
+                              taskId={task.id}
+                              status="IN_PROGRESS"
+                              label="Start review"
+                              notePlaceholder="What are you verifying first?"
+                            />
+                          )}
+                          <ReviewActionForm
+                            organizationId={orgRes.organizationId}
+                            taskId={task.id}
+                            status="APPROVED"
+                            label="Mark confirmed"
+                            notePlaceholder="Why is this confirmed? Include evidence IDs."
+                          />
+                          <ReviewActionForm
+                            organizationId={orgRes.organizationId}
+                            taskId={task.id}
+                            status="REJECTED"
+                            label="Mark false positive"
+                            notePlaceholder="Why is this a false positive?"
+                          />
+                          <ReviewActionForm
+                            organizationId={orgRes.organizationId}
+                            taskId={task.id}
+                            status="NEEDS_CHANGES"
+                            label="Needs escalation"
+                            notePlaceholder="What escalation or changes are required?"
+                          />
+                        </div>
+                      </article>
+                    );
+                  })}
                 </div>
-              </article>
+              </section>
             );
           })}
         </div>
@@ -318,11 +376,13 @@ function ReviewActionForm({
   taskId,
   status,
   label,
+  notePlaceholder,
 }: {
   organizationId: string;
   taskId: string;
   status: "IN_PROGRESS" | "APPROVED" | "REJECTED" | "NEEDS_CHANGES";
   label: string;
+  notePlaceholder: string;
 }) {
   return (
     <form action={updateReviewAction} className="flex items-center gap-2">
@@ -335,8 +395,8 @@ function ReviewActionForm({
       <input
         id={`${taskId}-${status}-note`}
         name="note"
-        placeholder="Optional reviewer note"
-        className="input h-8 w-52 text-xs"
+        placeholder={notePlaceholder}
+        className="input h-8 w-64 text-xs"
         maxLength={2000}
       />
       <button type="submit" className="btn-secondary text-xs">

--- a/apps/web/src/app/(dashboard)/settings/members/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/members/page.tsx
@@ -134,6 +134,7 @@ export default async function MembersPage() {
   const subscription = org.subscription;
   const entitlement = getEntitlementState(subscription);
   const canManageMembers = hasPermission(membership.role, "org:members:manage");
+  const canViewAudit = hasPermission(membership.role, "audit:view");
 
   const pendingInviteCount = await runOrgScopedQuery(orgRes, (orgId) =>
     prisma.auditLog.count({
@@ -141,6 +142,23 @@ export default async function MembersPage() {
     }),
   );
   const pendingInvites = pendingInviteCount.ok ? pendingInviteCount.data : 0;
+  const recentAuditResult = canViewAudit
+    ? await runOrgScopedQuery(orgRes, (orgId) =>
+        prisma.auditLog.findMany({
+          where: {
+            organizationId: orgId,
+            OR: [
+              { action: { startsWith: "member:" } },
+              { action: { startsWith: "review:" } },
+            ],
+          },
+          orderBy: { createdAt: "desc" },
+          take: 5,
+          select: { id: true, action: true, createdAt: true },
+        }),
+      )
+    : null;
+  const recentAudit = recentAuditResult && recentAuditResult.ok ? recentAuditResult.data : [];
   const seatsUsed = org.memberships.length + pendingInvites;
   const seatCap = subscription?.maxSeats ?? 1;
   const seatsAtOrOverCap = seatsUsed >= seatCap;
@@ -183,7 +201,12 @@ export default async function MembersPage() {
       </div>
 
       <div className="card">
-        <h2 className="text-lg font-semibold text-slate-900">Seat usage</h2>
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-lg font-semibold text-slate-900">Seat usage</h2>
+          <Link href="/docs/team-admin" className="text-xs font-medium text-brand-700 hover:underline">
+            Team-admin guide
+          </Link>
+        </div>
         <p className="mt-1 text-sm text-slate-500">
           Members + pending invites consume seats. Seat limits are enforced server-side.
         </p>
@@ -225,9 +248,41 @@ export default async function MembersPage() {
           <li><TruthBadge state="environment_dependent" className="mr-2" />OIDC SSO depends on deployment env and operator configuration.</li>
           <li><TruthBadge state="staged" className="mr-2" />SCIM and directory sync are staged, not implemented in this build.</li>
         </ul>
-        <Link href={`/api/org/${org.id}/audit-log`} className="text-sm font-medium text-brand-700 hover:underline">
-          Open org audit-log API
-        </Link>
+      </div>
+
+      <div className="card space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">Admin audit visibility</h2>
+          {canViewAudit ? (
+            <Link href={`/api/org/${org.id}/audit-log?format=csv`} className="text-xs font-medium text-brand-700 hover:underline">
+              Export CSV
+            </Link>
+          ) : null}
+        </div>
+        {canViewAudit ? (
+          recentAudit.length > 0 ? (
+            <ul className="space-y-2 text-sm text-slate-700">
+              {recentAudit.map((event) => (
+                <li key={event.id} className="flex items-center justify-between rounded-lg border border-slate-200 px-3 py-2">
+                  <span className="font-mono text-xs text-slate-600">{event.action}</span>
+                  <span className="text-xs text-slate-500">{event.createdAt.toLocaleString()}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-500">No recent member/review audit events.</p>
+          )
+        ) : (
+          <p className="text-sm text-slate-500">Your role can manage members but cannot view audit exports.</p>
+        )}
+        <div className="flex flex-wrap gap-2">
+          <Link href={`/api/org/${org.id}/audit-log`} className="text-sm font-medium text-brand-700 hover:underline">
+            Open org audit-log API
+          </Link>
+          <Link href="/trust" className="text-sm font-medium text-brand-700 hover:underline">
+            Trust posture
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/docs/reports-and-proof/page.tsx
+++ b/apps/web/src/app/docs/reports-and-proof/page.tsx
@@ -1,16 +1,32 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
 import { marketingSurfaceMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = marketingSurfaceMetadata("Reports and proof", "How report exports and audit evidence should be interpreted.", "/docs/reports-and-proof");
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Reports and proof",
+  "How report exports, confidence labels, and audit evidence should be interpreted.",
+  "/docs/reports-and-proof",
+);
 
 export default function DocsReportsProofPage() {
   return (
     <MarketingSiteChrome>
       <div className="mx-auto max-w-3xl px-6 py-section-md space-y-4">
         <h1 className="text-3xl font-bold text-slate-900">Reports and proof</h1>
-        <p className="text-sm text-slate-700">Reports can be exported from authenticated routes. Confidence labels indicate machine certainty and review status; they are not legal determinations.</p>
-        <p className="text-sm text-slate-700">Audit logs capture review and team-admin events for organization-scoped evidence trails.</p>
+        <p className="text-sm text-slate-700">
+          Reports can be exported from authenticated routes. Confidence labels
+          indicate machine certainty and review status; they are not legal determinations.
+        </p>
+        <p className="text-sm text-slate-700">
+          Audit logs capture review and team-admin events for organization-scoped
+          evidence trails, with JSON/CSV export options through the org audit route.
+        </p>
+        <div className="flex flex-wrap gap-2 pt-2">
+          <Link href="/trust" className="btn-secondary text-xs">Trust overview</Link>
+          <Link href="/docs/reviews-and-manual-verification" className="btn-secondary text-xs">Review operations docs</Link>
+          <Link href="/docs/team-admin" className="btn-secondary text-xs">Team-admin docs</Link>
+        </div>
       </div>
     </MarketingSiteChrome>
   );

--- a/apps/web/src/app/docs/reviews-and-manual-verification/page.tsx
+++ b/apps/web/src/app/docs/reviews-and-manual-verification/page.tsx
@@ -3,15 +3,36 @@ import Link from "next/link";
 import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
 import { marketingSurfaceMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = marketingSurfaceMetadata("Reviews and manual verification", "Review task lifecycle, evidence, and reviewer decisions.", "/docs/reviews-and-manual-verification");
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Reviews and manual verification",
+  "Review task lifecycle, evidence, reviewer rationale, and escalation posture.",
+  "/docs/reviews-and-manual-verification",
+);
 
 export default function DocsReviewsPage() {
   return (
     <MarketingSiteChrome>
       <div className="mx-auto max-w-3xl px-6 py-section-md space-y-4">
         <h1 className="text-3xl font-bold text-slate-900">Reviews and manual verification</h1>
-        <p className="text-sm text-slate-700">Review tasks prioritize unresolved and stale items first. Evidence panels show stored artifacts and summaries when available; missing evidence is shown explicitly.</p>
-        <p className="text-sm text-slate-700">Reviewer outcomes map to confirmed, false positive, and needs escalation flows inside <Link href="/reviews" className="text-brand-700 hover:underline font-medium">Review Queue</Link>.</p>
+        <p className="text-sm text-slate-700">
+          Review Queue groups work into overdue unresolved, in-progress, pending,
+          and resolved queues so teams can prioritize aging human-review risk.
+        </p>
+        <p className="text-sm text-slate-700">
+          Task taxonomy distinguishes interaction behavior, assistive technology,
+          language clarity, remediation quality, and governance checks. These
+          labels indicate where human validation is required, not deterministic
+          compliance truth.
+        </p>
+        <p className="text-sm text-slate-700">
+          Evidence panels summarize available automation and control-plane artifacts;
+          reviewer notes should capture rationale and evidence references for auditability.
+        </p>
+        <div className="flex flex-wrap gap-2 pt-2">
+          <Link href="/reviews" className="btn-secondary text-xs">Open Review Queue</Link>
+          <Link href="/docs/team-admin" className="btn-secondary text-xs">Team-admin docs</Link>
+          <Link href="/trust" className="btn-secondary text-xs">Trust posture</Link>
+        </div>
       </div>
     </MarketingSiteChrome>
   );

--- a/apps/web/src/app/docs/team-admin/page.tsx
+++ b/apps/web/src/app/docs/team-admin/page.tsx
@@ -1,17 +1,51 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { MarketingSiteChrome } from "@/components/marketing/marketing-site-chrome";
 import { TruthBadge } from "@/components/truth/truth-badge";
 import { marketingSurfaceMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = marketingSurfaceMetadata("Team admin", "Member roles, seat usage, pending invites, and staged enterprise controls.", "/docs/team-admin");
+export const metadata: Metadata = marketingSurfaceMetadata(
+  "Team admin",
+  "Member roles, seat usage, pending invites, audit trail posture, and staged enterprise controls.",
+  "/docs/team-admin",
+);
 
 export default function DocsTeamAdminPage() {
   return (
     <MarketingSiteChrome>
-      <div className="mx-auto max-w-3xl px-6 py-section-md space-y-4">
+      <div className="mx-auto max-w-3xl px-6 py-section-md space-y-5">
         <h1 className="text-3xl font-bold text-slate-900">Team administration</h1>
-        <p className="text-sm text-slate-700"><TruthBadge state="implemented" className="mr-2" />Organization members, role changes, seat usage, and pending invite records are available in settings.</p>
-        <p className="text-sm text-slate-700"><TruthBadge state="staged" className="mr-2" />SSO/SCIM and automated outbound invite email remain deployment-dependent and staged by operator configuration.</p>
+        <p className="text-sm text-slate-700">
+          This guide reflects current shipped behavior for team-admin workflows in
+          AROS, including what is implemented, environment-dependent, or staged.
+        </p>
+
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold text-slate-900">Current posture</h2>
+          <p className="text-sm text-slate-700"><TruthBadge state="implemented" className="mr-2" />Organization members, role changes, seat usage, pending invite records, and org-scoped audit-log export routes are available.</p>
+          <p className="text-sm text-slate-700"><TruthBadge state="partial" className="mr-2" />Invites are recorded and seat-checked; outbound invite email remains manual in this deployment.</p>
+          <p className="text-sm text-slate-700"><TruthBadge state="environment_dependent" className="mr-2" />OIDC SSO depends on deployment env/operator configuration.</p>
+          <p className="text-sm text-slate-700"><TruthBadge state="staged" className="mr-2" />SCIM and directory sync are staged and should not be sold as default capabilities.</p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold text-slate-900">Operator quick links</h2>
+          <div className="flex flex-wrap gap-2">
+            <Link href="/settings/members" className="btn-secondary text-xs">Members workspace</Link>
+            <Link href="/reviews" className="btn-secondary text-xs">Review queue</Link>
+            <Link href="/trust" className="btn-secondary text-xs">Trust center</Link>
+            <Link href="/docs/reviews-and-manual-verification" className="btn-secondary text-xs">Review operations docs</Link>
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold text-slate-900">Seat and audit guidance</h2>
+          <ul className="list-disc pl-5 text-sm text-slate-700 space-y-1">
+            <li>Seat usage is measured as current members + pending invites, with server-side seat-cap enforcement.</li>
+            <li>Review and membership actions are intended to be visible through org audit-log exports for buyer and support workflows.</li>
+            <li>When enterprise controls are staged, use explicit contract language that reflects deployed configuration.</li>
+          </ul>
+        </section>
       </div>
     </MarketingSiteChrome>
   );

--- a/apps/web/src/app/trust/page.tsx
+++ b/apps/web/src/app/trust/page.tsx
@@ -37,8 +37,8 @@ export default function TrustPage() {
             <p className="mt-2 text-sm leading-relaxed">
               Automated checks surface many failures and regressions; they do not
               replace manual audit, assistive technology testing, or legal
-              advice. We say so on every public sample and in-product where it
-              matters.
+              advice. We reinforce this in public docs and review workflows so
+              there is no deterministic “AI compliance” implication.
             </p>
           </li>
           <li>
@@ -61,7 +61,7 @@ export default function TrustPage() {
               otherwise remediation falls back to rule-based suggestions and
               copilot returns an explicit unavailable state. Usage is bounded by
               plan limits and requires human review before exports or remediation
-              workflows advance. There is no “autopilot compliance” story.
+              workflows advance.
             </p>
           </li>
           <li>
@@ -90,7 +90,46 @@ export default function TrustPage() {
           </li>
         </ul>
 
-
+        <section className="mt-12">
+          <h2 className="text-lg font-semibold text-slate-900">Evidence model and export posture</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Procurement and operators should distinguish between stored operational data,
+            review rationale, and externally shareable evidence.
+          </p>
+          <div className="mt-4 overflow-x-auto rounded-xl border border-[rgb(var(--color-border))]">
+            <table className="min-w-full text-left text-sm">
+              <thead className="bg-slate-50 text-slate-700">
+                <tr>
+                  <th className="px-4 py-3 font-semibold">Surface</th>
+                  <th className="px-4 py-3 font-semibold">Stored data</th>
+                  <th className="px-4 py-3 font-semibold">Export posture</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-t border-[rgb(var(--color-border))] align-top">
+                  <td className="px-4 py-3 font-medium text-slate-900">Scans and findings</td>
+                  <td className="px-4 py-3 text-slate-600">Site/workspace metadata, findings, severities, and trend history.</td>
+                  <td className="px-4 py-3 text-slate-600">Used in reports and dashboards with confidence labels.</td>
+                </tr>
+                <tr className="border-t border-[rgb(var(--color-border))] align-top">
+                  <td className="px-4 py-3 font-medium text-slate-900">Review operations</td>
+                  <td className="px-4 py-3 text-slate-600">Review task status, reviewer notes, timestamps, and evidence linkage counts.</td>
+                  <td className="px-4 py-3 text-slate-600">Operational evidence, exportable through org-scoped APIs.</td>
+                </tr>
+                <tr className="border-t border-[rgb(var(--color-border))] align-top">
+                  <td className="px-4 py-3 font-medium text-slate-900">Admin audit trail</td>
+                  <td className="px-4 py-3 text-slate-600">Member/admin actions, entity references, and timestamps.</td>
+                  <td className="px-4 py-3 text-slate-600">JSON/CSV org audit-log route for support, buyers, and internal governance.</td>
+                </tr>
+                <tr className="border-t border-[rgb(var(--color-border))] align-top">
+                  <td className="px-4 py-3 font-medium text-slate-900">Object storage evidence</td>
+                  <td className="px-4 py-3 text-slate-600">Artifact storage mode depends on operator deployment configuration.</td>
+                  <td className="px-4 py-3 text-slate-600">Environment-dependent. Confirm deployment posture during procurement review.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
 
         <section className="mt-12">
           <h2 className="text-lg font-semibold text-slate-900">Confidence labels used in product and exports</h2>
@@ -122,7 +161,6 @@ export default function TrustPage() {
           </div>
         </section>
 
-
         <section className="mt-12">
           <h2 className="text-lg font-semibold text-slate-900">Procurement posture summary</h2>
           <div className="mt-4 space-y-3 text-sm text-slate-700">
@@ -144,11 +182,30 @@ export default function TrustPage() {
               <dd className="mt-1">Workspace metadata, scan findings, remediation suggestions, review tasks, and audit events. Evidence storage mode depends on deployment object storage configuration.</dd>
             </div>
             <div>
+              <dt className="font-semibold text-slate-900">What evidence can procurement teams request during evaluation?</dt>
+              <dd className="mt-1">Audit-log exports (JSON/CSV), reports with confidence labels, and review queue records with reviewer rationale. Operator-managed deployment settings determine infrastructure-specific artifacts.</dd>
+            </div>
+            <div>
               <dt className="font-semibold text-slate-900">Can teams export evidence?</dt>
               <dd className="mt-1">Yes. Reports and audit-log export routes exist with organization-scoped access and permission checks.</dd>
             </div>
+            <div>
+              <dt className="font-semibold text-slate-900">Are SSO and directory sync available by default?</dt>
+              <dd className="mt-1">No. OIDC support is environment/operator-configured and SCIM remains staged in this build. Procurement commitments should reflect deployed configuration, not roadmap assumptions.</dd>
+            </div>
           </dl>
         </section>
+
+        <section className="mt-12">
+          <h2 className="text-lg font-semibold text-slate-900">In-app trust and admin surfaces</h2>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Link href="/reviews" className="btn-secondary text-xs">Review queue</Link>
+            <Link href="/settings/members" className="btn-secondary text-xs">Team members</Link>
+            <Link href="/docs/reviews-and-manual-verification" className="btn-secondary text-xs">Review docs</Link>
+            <Link href="/docs/team-admin" className="btn-secondary text-xs">Team-admin docs</Link>
+          </div>
+        </section>
+
         <section className="mt-12">
           <h2 className="text-lg font-semibold text-slate-900">Commitments by service lane</h2>
           <p className="mt-2 text-sm text-slate-600">

--- a/apps/web/src/lib/review-operations.test.ts
+++ b/apps/web/src/lib/review-operations.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  REVIEW_REASON_META,
+  getReviewPriorityScore,
+  groupReviewQueueTasks,
+} from "@/lib/review-operations";
+import type { ReviewQueueItem } from "@/lib/review-operations";
+
+const now = new Date("2026-04-08T12:00:00.000Z");
+
+function task(partial: Partial<ReviewQueueItem>): ReviewQueueItem {
+  return {
+    id: partial.id ?? "task-id",
+    type: partial.type ?? "MANUAL_AUDIT",
+    status: partial.status ?? "PENDING",
+    createdAt: partial.createdAt ?? new Date("2026-04-06T12:00:00.000Z"),
+    updatedAt: partial.updatedAt ?? new Date("2026-04-07T12:00:00.000Z"),
+    reviewedAt: partial.reviewedAt ?? null,
+    evidenceCount: partial.evidenceCount ?? 1,
+    controlPlaneEvidenceCount: partial.controlPlaneEvidenceCount ?? 0,
+  };
+}
+
+describe("review operations", () => {
+  it("prioritizes overdue unresolved high-risk work above recent items", () => {
+    const overdue = task({
+      id: "overdue",
+      type: "KEYBOARD_FLOW",
+      createdAt: new Date("2026-04-01T12:00:00.000Z"),
+    });
+    const recent = task({
+      id: "recent",
+      type: "SUGGESTION_REVIEW",
+      createdAt: new Date("2026-04-08T06:00:00.000Z"),
+    });
+
+    expect(getReviewPriorityScore(overdue, now)).toBeGreaterThan(
+      getReviewPriorityScore(recent, now),
+    );
+  });
+
+  it("groups tasks into overdue/active/pending/resolved buckets", () => {
+    const grouped = groupReviewQueueTasks(
+      [
+        task({ id: "overdue", createdAt: new Date("2026-04-01T12:00:00.000Z") }),
+        task({ id: "active", status: "IN_PROGRESS", createdAt: new Date("2026-04-08T09:00:00.000Z") }),
+        task({ id: "pending", status: "PENDING", createdAt: new Date("2026-04-08T08:00:00.000Z") }),
+        task({ id: "resolved", status: "APPROVED", reviewedAt: new Date("2026-04-08T10:00:00.000Z") }),
+      ],
+      now,
+    );
+
+    expect(grouped.overdue.map((t) => t.id)).toEqual(["overdue"]);
+    expect(grouped.active.map((t) => t.id)).toEqual(["active"]);
+    expect(grouped.pending.map((t) => t.id)).toEqual(["pending"]);
+    expect(grouped.resolved.map((t) => t.id)).toEqual(["resolved"]);
+  });
+
+  it("tracks human-review truth state taxonomy", () => {
+    expect(REVIEW_REASON_META.MANUAL_AUDIT.truthState).toBe(
+      "requires_human_review",
+    );
+    expect(REVIEW_REASON_META.SUGGESTION_REVIEW.truthState).toBe("partial");
+  });
+});

--- a/apps/web/src/lib/review-operations.ts
+++ b/apps/web/src/lib/review-operations.ts
@@ -1,0 +1,113 @@
+import type { ReviewStatus, ReviewType } from "@aros/db";
+
+export type ReviewReasonMeta = {
+  taxonomy: string;
+  description: string;
+  reviewerExpectation: string;
+  truthState: "requires_human_review" | "partial";
+};
+
+export const REVIEW_REASON_META: Record<ReviewType, ReviewReasonMeta> = {
+  ALT_TEXT_REVIEW: {
+    taxonomy: "Perception and context",
+    description: "Visual context ambiguity for alt text quality.",
+    reviewerExpectation:
+      "Confirm intent, audience context, and whether alternate text preserves meaning.",
+    truthState: "partial",
+  },
+  CONTENT_CLARITY: {
+    taxonomy: "Language and comprehension",
+    description: "Language clarity or meaning requires human interpretation.",
+    reviewerExpectation:
+      "Validate readability and intent in the authored context; automation cannot infer audience comprehension.",
+    truthState: "requires_human_review",
+  },
+  KEYBOARD_FLOW: {
+    taxonomy: "Interaction behavior",
+    description: "Keyboard and focus order behavior can be context-sensitive.",
+    reviewerExpectation:
+      "Verify tab order, focus visibility, and trapped-focus risk through real keyboard walkthroughs.",
+    truthState: "requires_human_review",
+  },
+  SCREEN_READER: {
+    taxonomy: "Assistive technology behavior",
+    description: "Landmark and reading-order behavior needs AT verification.",
+    reviewerExpectation:
+      "Use target screen readers to validate reading order and semantic landmarks.",
+    truthState: "requires_human_review",
+  },
+  SUGGESTION_REVIEW: {
+    taxonomy: "Remediation quality",
+    description: "Generated suggestion requires reviewer confirmation.",
+    reviewerExpectation:
+      "Confirm fix safety, regressions, and whether generated suggestions fit authoring constraints.",
+    truthState: "partial",
+  },
+  MANUAL_AUDIT: {
+    taxonomy: "Policy and governance",
+    description: "Rule requires explicit human verification.",
+    reviewerExpectation:
+      "Record reviewer rationale and, when needed, escalation path before marking resolved.",
+    truthState: "requires_human_review",
+  },
+};
+
+export type ReviewQueueItem = {
+  id: string;
+  type: ReviewType;
+  status: ReviewStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  reviewedAt: Date | null;
+  evidenceCount: number;
+  controlPlaneEvidenceCount: number;
+};
+
+export type ReviewQueueGroupKey =
+  | "overdue"
+  | "active"
+  | "pending"
+  | "resolved";
+
+export function getReviewPriorityScore(task: ReviewQueueItem, now = new Date()): number {
+  const ageHours = getReviewAgeHours(task, now);
+  const unresolved = task.status === "PENDING" || task.status === "IN_PROGRESS";
+  const statusWeight =
+    task.status === "PENDING" ? 5 : task.status === "IN_PROGRESS" ? 3 : 0;
+  const riskWeight = task.type === "MANUAL_AUDIT" || task.type === "KEYBOARD_FLOW" ? 3 : 1;
+  const overdueWeight = unresolved && ageHours >= 72 ? 4 : 0;
+  const evidenceWeight = task.evidenceCount + task.controlPlaneEvidenceCount === 0 ? 1 : 0;
+  return statusWeight + riskWeight + overdueWeight + evidenceWeight;
+}
+
+export function getReviewAgeHours(task: Pick<ReviewQueueItem, "createdAt">, now = new Date()): number {
+  return Math.floor((now.getTime() - task.createdAt.getTime()) / 3_600_000);
+}
+
+export function groupReviewQueueTasks(
+  tasks: ReviewQueueItem[],
+  now = new Date(),
+): Record<ReviewQueueGroupKey, ReviewQueueItem[]> {
+  const sorted = [...tasks].sort((a, b) => {
+    const priorityDiff = getReviewPriorityScore(b, now) - getReviewPriorityScore(a, now);
+    if (priorityDiff !== 0) return priorityDiff;
+    return b.createdAt.getTime() - a.createdAt.getTime();
+  });
+
+  return sorted.reduce<Record<ReviewQueueGroupKey, ReviewQueueItem[]>>(
+    (acc, task) => {
+      const ageHours = getReviewAgeHours(task, now);
+      if ((task.status === "PENDING" || task.status === "IN_PROGRESS") && ageHours >= 72) {
+        acc.overdue.push(task);
+      } else if (task.status === "IN_PROGRESS") {
+        acc.active.push(task);
+      } else if (task.status === "PENDING") {
+        acc.pending.push(task);
+      } else {
+        acc.resolved.push(task);
+      }
+      return acc;
+    },
+    { overdue: [], active: [], pending: [], resolved: [] },
+  );
+}

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "audit:high": "npm audit --audit-level=high",
     "test:release": "npm run test && npm run test:integration",
     "verify:core": "npm run prisma:check && npm run prisma:imports && npm run lint && npm run typecheck && npm run test && npm run build",
-    "verify:release": "npm run verify:core && npm run verify:tenant-boundary && npm run test:launch-critical && npm run test:integration",
+    "verify:release": "npm run verify:core && npm run verify:touched-routes && npm run verify:tenant-boundary && npm run test:launch-critical && npm run test:integration",
     "verify:tenant-boundary": "node scripts/check-tenant-boundary-critical.mjs",
-    "test:launch-critical": "npm run test:launch-critical --workspace=apps/web"
+    "test:launch-critical": "npm run test:launch-critical --workspace=apps/web",
+    "verify:touched-routes": "npm run test:launch-critical"
   },
   "devDependencies": {
     "turbo": "^2.7.4",


### PR DESCRIPTION
### Motivation
- Close the substantive gaps between marketing/trust copy and in-app procurement/export/evidence behavior so procurement and operators see implementation-backed posture. 
- Productize review operations by adding an explicit taxonomy, priority scoring, grouping, and clearer evidence/rationale surfaces so human review is the operational source of truth. 
- Harden release verification and local/CI ergonomics with a touched-route safety gate and clearer verification ordering to avoid silent route regressions. 
- Improve team-admin discoverability and audit visibility so seat usage, invites, and audit exports are actionable for operators and buyers.

### Description
- Introduced a review-operations domain library with taxonomy, priority scoring, age calculation, and grouping helpers in `apps/web/src/lib/review-operations.ts` and added unit tests in `apps/web/src/lib/review-operations.test.ts`. 
- Refactored the Reviews UI (`apps/web/src/app/(dashboard)/reviews/page.tsx`) to use the new helpers, present grouped queues (overdue/active/pending/resolved), show taxonomy and reviewer expectations, surface evidence counts and priority scores, add stale/escalation cues, and provide status-specific reviewer-note prompts. 
- Expanded the Trust and Reports docs (`apps/web/src/app/trust/page.tsx`, `apps/web/src/app/docs/reports-and-proof/page.tsx`) to include an evidence/export posture matrix, procurement FAQ clarifications, and in-app discoverability links. 
- Strengthened team-admin surfaces (`apps/web/src/app/(dashboard)/settings/members/page.tsx`, `apps/web/src/app/docs/team-admin/page.tsx`) with seat-guide links, role-gated recent audit visibility, CSV export discoverability, and clearer staged/environment-dependent statements (OIDC/SCIM/invite delivery). 
- Hardening for release verification and CI: added `verify:touched-routes` script, included the review-operations tests in the `test:launch-critical` bundle, updated `verify:release` and CI workflow steps (`package.json`, `apps/web/package.json`, `.github/workflows/ci.yml`), and documented the touched-route check in `README.md`.

### Testing
- Ran `npm run lint` and the linter completed without blocking errors. (Succeeded.)
- Ran `npm run typecheck` and full workspace TypeScript checks completed with no errors. (Succeeded.)
- Ran `npm run test` (workspace unit tests) and all unit suites passed across apps/packages. (Succeeded.)
- Ran `npm run build` (production Next.js build) and the web build completed successfully with static pages generated. (Succeeded.)
- Ran the targeted safety bundle `npm run test:launch-critical` (now includes `review-operations.test.ts`) and the launch-critical tests passed. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5da56f1e4832886f4d7813eb52be9)