### PR TITLE
Site operations: rollups, scan delta, UI, and alerting tick

### DIFF
--- a/apps/web/src/app/(dashboard)/sites/page.tsx
+++ b/apps/web/src/app/(dashboard)/sites/page.tsx
@@ -12,6 +12,17 @@ import { hasPermission } from "@aros/config";
 import { EmptyState } from "@aros/ui";
 import { PageHeader } from "@/components/layout/page-header";
 import { pageTitle } from "@/lib/product-brand";
+import {
+  rollupSiteOperations,
+  summarizeSiteOperations,
+  type SiteOperationalStatus,
+} from "@/lib/site-operations";
+import { getEntitlementState } from "@/lib/auth-guard";
+import { startCrawlAction } from "./[siteId]/actions";
+import { scanSiteInitialState } from "./[siteId]/scan-action-state";
+import { startSiteScanAction } from "./[siteId]/scan-actions";
+import { ScanNowButton } from "./[siteId]/scan-now-button";
+import { computeScanDelta } from "@/lib/scan-delta";
 
 export const metadata = { title: pageTitle("Sites") };
 
@@ -82,21 +93,59 @@ export default async function SitesPage() {
     );
   }
 
-  const sitesResult = await runOrgScopedQuery(orgRes, (orgId) =>
-    prisma.site.findMany({
-      where: { workspace: { organizationId: orgId } },
-      include: {
-        workspace: { select: { name: true } },
-        _count: {
-          select: {
-            crawlRuns: true,
-            pages: true,
+  const sitesResult = await runOrgScopedQuery(orgRes, async (orgId) => {
+    const [sites, openFindingCounts, subscription] = await Promise.all([
+      prisma.site.findMany({
+        where: { workspace: { organizationId: orgId } },
+        include: {
+          workspace: { select: { name: true } },
+          crawlConfig: { select: { scheduleCron: true } },
+          scanRuns: {
+            orderBy: { createdAt: "desc" },
+            take: 10,
+            select: { id: true, status: true, completedAt: true, createdAt: true },
+          },
+          crawlRuns: {
+            orderBy: { createdAt: "desc" },
+            take: 1,
+            select: { status: true },
+          },
+          _count: {
+            select: {
+              crawlRuns: true,
+              pages: true,
+            },
           },
         },
-      },
-      orderBy: { createdAt: "desc" },
-    }),
-  );
+        orderBy: { createdAt: "desc" },
+      }),
+      prisma.canonicalFinding.groupBy({
+        by: ["siteId"],
+        where: {
+          site: { workspace: { organizationId: orgId } },
+          status: "OPEN",
+        },
+        _count: { _all: true },
+      }),
+      prisma.subscription.findUnique({
+        where: { organizationId: orgId },
+        select: {
+          plan: true,
+          status: true,
+          maxDomains: true,
+          maxPagesPerCrawl: true,
+          maxScansPerMonth: true,
+          maxSeats: true,
+          aiEnabled: true,
+          aiTokenLimit: true,
+          currentPeriodEnd: true,
+          cancelAtPeriodEnd: true,
+        },
+      }),
+    ]);
+
+    return { sites, openFindingCounts, subscription };
+  });
 
   if (!sitesResult.ok) {
     return (
@@ -113,7 +162,88 @@ export default async function SitesPage() {
     );
   }
 
-  const sites = sitesResult.data;
+  const { sites, openFindingCounts, subscription } = sitesResult.data;
+  const openFindingsBySiteId = new Map(
+    openFindingCounts.map((row) => [row.siteId, row._count._all]),
+  );
+  const entitlement = getEntitlementState(subscription);
+
+  const completedScanRunIds = sites.flatMap((site) =>
+    site.scanRuns.filter((run) => run.status === "COMPLETED").slice(0, 2).map((run) => run.id),
+  );
+
+  const runFingerprints =
+    completedScanRunIds.length > 0
+      ? await prisma.rawViolation.findMany({
+          where: { scanRunId: { in: completedScanRunIds } },
+          select: { scanRunId: true, fingerprint: true },
+          distinct: ["scanRunId", "fingerprint"],
+        })
+      : [];
+
+  const fingerprintsByRunId = new Map<string, string[]>();
+  for (const row of runFingerprints) {
+    const bucket = fingerprintsByRunId.get(row.scanRunId) ?? [];
+    bucket.push(row.fingerprint);
+    fingerprintsByRunId.set(row.scanRunId, bucket);
+  }
+
+  const operationalSites = sites.map((site) => {
+    const latestScan = site.scanRuns[0] ?? null;
+    const latestCompleted = site.scanRuns.find((run) => run.status === "COMPLETED") ?? null;
+    const priorCompleted = site.scanRuns
+      .filter((run) => run.status === "COMPLETED")
+      .slice(1, 2)[0] ?? null;
+
+    const ops = summarizeSiteOperations({
+      pagesCount: site._count.pages,
+      openFindings: openFindingsBySiteId.get(site.id) ?? 0,
+      latestCrawlStatus: site.crawlRuns[0]?.status ?? null,
+      latestScanStatus: latestScan?.status ?? null,
+      latestScanCompletedAt: latestCompleted?.completedAt ?? null,
+      scheduleCron: site.crawlConfig?.scheduleCron ?? null,
+      entitlement,
+      workerRunning: platformTruth.flags.workerRunning,
+      jobPipelinesHealthy: platformTruth.flags.jobPipelinesHealthy,
+    });
+
+    const delta = latestCompleted
+      ? computeScanDelta(
+          fingerprintsByRunId.get(latestCompleted.id) ?? [],
+          priorCompleted ? (fingerprintsByRunId.get(priorCompleted.id) ?? []) : null,
+        )
+      : {
+          comparable: false,
+          newCount: 0,
+          resolvedCount: 0,
+          persistingCount: 0,
+        };
+
+    const scanBlocked = latestScan?.status === "PENDING" || latestScan?.status === "RUNNING";
+
+    return {
+      ...site,
+      openFindings: openFindingsBySiteId.get(site.id) ?? 0,
+      ops,
+      delta,
+      scanBlocked,
+    };
+  });
+
+  const opsRollup = rollupSiteOperations(
+    operationalSites.map((site) => site.ops.status),
+  );
+
+  const deltaRollup = operationalSites.reduce(
+    (acc, site) => {
+      acc.newCount += site.delta.newCount;
+      acc.resolvedCount += site.delta.resolvedCount;
+      acc.persistingCount += site.delta.persistingCount;
+      if (site.delta.comparable) acc.comparableSites += 1;
+      return acc;
+    },
+    { newCount: 0, resolvedCount: 0, persistingCount: 0, comparableSites: 0 },
+  );
 
   return (
     <div className="space-y-6">
@@ -139,31 +269,143 @@ export default async function SitesPage() {
           className="card"
         />
       ) : (
-        <div className="grid gap-4">
-          {sites.map((site) => (
-            <Link
-              key={site.id}
-              href={`/sites/${site.id}`}
-              className="card hover:shadow-md transition-shadow flex items-center justify-between"
-              aria-label={`${site.name} - ${site.domain}`}
-            >
-              <div>
-                <h3 className="font-semibold text-slate-900">{site.name}</h3>
-                <p className="text-sm text-slate-500 mt-0.5">{site.domain}</p>
-                <div className="flex items-center gap-4 mt-2 text-xs text-slate-400">
-                  <span>{site.workspace.name}</span>
-                  <EnvironmentBadge environment={site.environment} />
+        <>
+          <section className="card" aria-labelledby="ops-worklist-heading">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <h2 id="ops-worklist-heading" className="section-heading">
+                Operator worklist
+              </h2>
+              <span className="text-xs text-slate-500">
+                Deterministic site health derived from crawl/scan freshness and platform readiness.
+              </span>
+            </div>
+            <dl className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-5">
+              <OpsMetric label="Needs activation" value={opsRollup.activationRequired} />
+              <OpsMetric label="Scan failures" value={opsRollup.scanAttentionRequired} />
+              <OpsMetric label="Automation degraded" value={opsRollup.automationDegraded} />
+              <OpsMetric label="Evidence stale" value={opsRollup.evidenceStale} />
+              <OpsMetric label="Healthy" value={opsRollup.healthy} />
+            </dl>
+          </section>
+
+          <section className="card" aria-labelledby="scan-delta-heading">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+              <h2 id="scan-delta-heading" className="section-heading">Changed since last completed scan</h2>
+              <p className="text-xs text-slate-500">
+                Comparable sites: {deltaRollup.comparableSites}/{operationalSites.length}
+              </p>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <OpsMetric label="New violations" value={deltaRollup.newCount} />
+              <OpsMetric label="Resolved" value={deltaRollup.resolvedCount} />
+              <OpsMetric label="Persisting" value={deltaRollup.persistingCount} />
+            </div>
+          </section>
+
+          <div className="grid gap-4">
+            {operationalSites.map((site) => (
+              <article key={site.id} className="card space-y-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <h3 className="font-semibold text-slate-900">
+                      <Link href={`/sites/${site.id}`} className="hover:underline">
+                        {site.name}
+                      </Link>
+                    </h3>
+                    <p className="text-sm text-slate-500 mt-0.5">{site.domain}</p>
+                    <div className="mt-2 flex items-center gap-2 text-xs text-slate-500">
+                      <EnvironmentBadge environment={site.environment} />
+                      <span>{site.workspace.name}</span>
+                    </div>
+                  </div>
+                  <StatusPill status={site.ops.status} label={site.ops.statusLabel} />
                 </div>
-              </div>
-              <div className="text-right text-sm text-slate-500">
-                <p>{site._count.pages} pages</p>
-                <p>{site._count.crawlRuns} crawls</p>
-              </div>
-            </Link>
-          ))}
-        </div>
+
+                <p className="text-sm text-slate-700">{site.ops.statusReason}</p>
+
+                <div className="grid gap-2 text-xs text-slate-600 sm:grid-cols-2 lg:grid-cols-4">
+                  <DetailItem label="Pages discovered" value={String(site._count.pages)} />
+                  <DetailItem label="Open findings" value={String(site.openFindings)} />
+                  <DetailItem label="Evidence freshness" value={site.ops.freshnessLabel} />
+                  <DetailItem label="Automation cadence" value={`${site.ops.cadenceLabel} · ${site.ops.nextScheduledRunLabel}`} />
+                </div>
+
+                <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-700" role="status">
+                  {site.delta.comparable ? (
+                    <p>
+                      Δ since previous completed scan: <span className="font-semibold text-rose-800">+{site.delta.newCount} new</span>,{" "}
+                      <span className="font-semibold text-emerald-800">-{site.delta.resolvedCount} resolved</span>,{" "}
+                      <span className="font-semibold text-slate-900">{site.delta.persistingCount} persisting</span>
+                    </p>
+                  ) : (
+                    <p>Δ since previous completed scan: baseline not available yet (need two completed scans).</p>
+                  )}
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  <Link href={`/sites/${site.id}`} className="btn-secondary text-sm">
+                    Open site
+                  </Link>
+                  <form action={startCrawlAction}>
+                    <input type="hidden" name="siteId" value={site.id} />
+                    <button type="submit" className="btn-secondary text-sm">Start crawl</button>
+                  </form>
+                  <div className="[&_button]:text-sm">
+                    <ScanNowButton
+                      action={startSiteScanAction}
+                      initialState={scanSiteInitialState}
+                      siteId={site.id}
+                      disabled={site._count.pages === 0 || site.scanBlocked}
+                      blockedHint={
+                        site.scanBlocked
+                          ? "Verification is already queued or running for this site."
+                          : site._count.pages === 0
+                            ? "Run a crawl first so there are pages to verify."
+                            : null
+                      }
+                    />
+                  </div>
+                  <Link href={site.ops.nextAction.href as any} className="btn-primary text-sm">
+                    {site.ops.nextAction.label}
+                  </Link>
+                </div>
+              </article>
+            ))}
+          </div>
+        </>
       )}
     </div>
+  );
+}
+
+function OpsMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+      <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+      <dd className="mt-1 text-xl font-semibold text-slate-900 tabular-nums">{value}</dd>
+    </div>
+  );
+}
+
+function DetailItem({ label, value }: { label: string; value: string }) {
+  return (
+    <p>
+      <span className="font-medium text-slate-900">{label}:</span> {value}
+    </p>
+  );
+}
+
+function StatusPill({ status, label }: { status: SiteOperationalStatus; label: string }) {
+  const toneByStatus: Record<SiteOperationalStatus, string> = {
+    activation_required: "bg-sky-50 text-sky-800 ring-sky-200",
+    scan_attention_required: "bg-rose-50 text-rose-800 ring-rose-200",
+    automation_degraded: "bg-amber-50 text-amber-800 ring-amber-200",
+    evidence_stale: "bg-violet-50 text-violet-800 ring-violet-200",
+    healthy: "bg-emerald-50 text-emerald-800 ring-emerald-200",
+  };
+
+  return (
+    <span className={`badge ring-1 ring-inset ${toneByStatus[status]}`}>{label}</span>
   );
 }
 

--- a/apps/web/src/lib/scan-delta.test.ts
+++ b/apps/web/src/lib/scan-delta.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { computeScanDelta } from './scan-delta';
+
+describe('computeScanDelta', () => {
+  it('returns non-comparable when no previous run exists', () => {
+    const result = computeScanDelta(['a', 'b', 'c'], null);
+    expect(result).toEqual({
+      comparable: false,
+      newCount: 3,
+      resolvedCount: 0,
+      persistingCount: 0,
+    });
+  });
+
+  it('computes new/resolved/persisting counts', () => {
+    const result = computeScanDelta(['a', 'b', 'd'], ['a', 'b', 'c']);
+    expect(result).toEqual({
+      comparable: true,
+      newCount: 1,
+      resolvedCount: 1,
+      persistingCount: 2,
+    });
+  });
+});

--- a/apps/web/src/lib/scan-delta.ts
+++ b/apps/web/src/lib/scan-delta.ts
@@ -1,0 +1,42 @@
+export interface SiteScanDelta {
+  comparable: boolean;
+  newCount: number;
+  resolvedCount: number;
+  persistingCount: number;
+}
+
+export function computeScanDelta(
+  latestFingerprints: Iterable<string>,
+  previousFingerprints: Iterable<string> | null,
+): SiteScanDelta {
+  const latest = new Set(latestFingerprints);
+  if (!previousFingerprints) {
+    return {
+      comparable: false,
+      newCount: latest.size,
+      resolvedCount: 0,
+      persistingCount: 0,
+    };
+  }
+
+  const previous = new Set(previousFingerprints);
+
+  let newCount = 0;
+  let persistingCount = 0;
+  for (const fingerprint of latest) {
+    if (previous.has(fingerprint)) persistingCount += 1;
+    else newCount += 1;
+  }
+
+  let resolvedCount = 0;
+  for (const fingerprint of previous) {
+    if (!latest.has(fingerprint)) resolvedCount += 1;
+  }
+
+  return {
+    comparable: true,
+    newCount,
+    resolvedCount,
+    persistingCount,
+  };
+}

--- a/apps/web/src/lib/site-operations.test.ts
+++ b/apps/web/src/lib/site-operations.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { rollupSiteOperations, summarizeSiteOperations } from './site-operations';
+
+const entitled = { hasPaidAccess: true, reason: 'active_paid' } as const;
+const free = { hasPaidAccess: false, reason: 'free_plan' } as const;
+
+describe('summarizeSiteOperations', () => {
+  it('returns activation_required when pages/crawls do not exist', () => {
+    const result = summarizeSiteOperations({
+      pagesCount: 0,
+      openFindings: 0,
+      latestCrawlStatus: null,
+      latestScanStatus: null,
+      latestScanCompletedAt: null,
+      scheduleCron: null,
+      entitlement: entitled,
+      workerRunning: true,
+      jobPipelinesHealthy: true,
+    });
+
+    expect(result.status).toBe('activation_required');
+    expect(result.nextAction.href).toBe('/sites');
+  });
+
+  it('returns scan_attention_required when latest scan failed', () => {
+    const result = summarizeSiteOperations({
+      pagesCount: 80,
+      openFindings: 10,
+      latestCrawlStatus: 'COMPLETED',
+      latestScanStatus: 'FAILED',
+      latestScanCompletedAt: null,
+      scheduleCron: '@daily',
+      entitlement: entitled,
+      workerRunning: true,
+      jobPipelinesHealthy: true,
+    });
+
+    expect(result.status).toBe('scan_attention_required');
+    expect(result.nextAction.href).toBe('/system');
+  });
+
+  it('returns automation_degraded for free plan orgs', () => {
+    const result = summarizeSiteOperations({
+      pagesCount: 80,
+      openFindings: 10,
+      latestCrawlStatus: 'COMPLETED',
+      latestScanStatus: 'COMPLETED',
+      latestScanCompletedAt: new Date(),
+      scheduleCron: '@daily',
+      entitlement: free,
+      workerRunning: true,
+      jobPipelinesHealthy: true,
+    });
+
+    expect(result.status).toBe('automation_degraded');
+    expect(result.nextAction.href).toBe('/settings/billing');
+  });
+
+  it('returns evidence_stale when latest verification is older than 72h', () => {
+    const stale = new Date(Date.now() - 1000 * 60 * 60 * 90);
+    const result = summarizeSiteOperations({
+      pagesCount: 80,
+      openFindings: 3,
+      latestCrawlStatus: 'COMPLETED',
+      latestScanStatus: 'COMPLETED',
+      latestScanCompletedAt: stale,
+      scheduleCron: '@weekly',
+      entitlement: entitled,
+      workerRunning: true,
+      jobPipelinesHealthy: true,
+    });
+
+    expect(result.status).toBe('evidence_stale');
+  });
+
+  it('returns healthy when queues are healthy and scan evidence is fresh', () => {
+    const recent = new Date(Date.now() - 1000 * 60 * 60 * 10);
+    const result = summarizeSiteOperations({
+      pagesCount: 80,
+      openFindings: 0,
+      latestCrawlStatus: 'COMPLETED',
+      latestScanStatus: 'COMPLETED',
+      latestScanCompletedAt: recent,
+      scheduleCron: '@weekly',
+      entitlement: entitled,
+      workerRunning: true,
+      jobPipelinesHealthy: true,
+    });
+
+    expect(result.status).toBe('healthy');
+  });
+});
+
+describe('rollupSiteOperations', () => {
+  it('aggregates site status counts', () => {
+    const summary = rollupSiteOperations([
+      'activation_required',
+      'activation_required',
+      'scan_attention_required',
+      'automation_degraded',
+      'evidence_stale',
+      'healthy',
+    ]);
+
+    expect(summary).toEqual({
+      activationRequired: 2,
+      scanAttentionRequired: 1,
+      automationDegraded: 1,
+      evidenceStale: 1,
+      healthy: 1,
+    });
+  });
+});

--- a/apps/web/src/lib/site-operations.ts
+++ b/apps/web/src/lib/site-operations.ts
@@ -1,0 +1,164 @@
+import type { EntitlementState } from '@/lib/auth-guard';
+import {
+  nextScheduleRunAt,
+  scheduleBlockedReason,
+  scheduleCadenceLabel,
+} from '@aros/core-services';
+
+export type SiteOperationalStatus =
+  | 'activation_required'
+  | 'scan_attention_required'
+  | 'automation_degraded'
+  | 'evidence_stale'
+  | 'healthy';
+
+export interface SiteOpsInput {
+  pagesCount: number;
+  openFindings: number;
+  latestCrawlStatus: string | null;
+  latestScanStatus: string | null;
+  latestScanCompletedAt: Date | null;
+  scheduleCron: string | null;
+  entitlement: EntitlementState;
+  workerRunning: boolean;
+  jobPipelinesHealthy: boolean;
+}
+
+export interface SiteOpsSummary {
+  status: SiteOperationalStatus;
+  statusLabel: string;
+  statusReason: string;
+  nextAction: {
+    label: string;
+    href: string;
+  };
+  freshnessLabel: string;
+  cadenceLabel: string;
+  nextScheduledRunLabel: string;
+}
+
+export interface OrgSiteOpsRollup {
+  activationRequired: number;
+  scanAttentionRequired: number;
+  automationDegraded: number;
+  evidenceStale: number;
+  healthy: number;
+}
+
+function freshnessLabelFromScan(completedAt: Date | null): string {
+  if (!completedAt) return 'No verification yet';
+  const ageHours = (Date.now() - completedAt.getTime()) / (1000 * 60 * 60);
+  if (ageHours <= 24) return 'Verified ≤24h';
+  if (ageHours <= 72) return 'Fresh ≤72h';
+  return 'Stale >72h';
+}
+
+function scheduledRunLabel(scheduleCron: string | null): string {
+  const blocked = scheduleBlockedReason(scheduleCron);
+  if (blocked) return `Blocked (${blocked})`;
+  const next = nextScheduleRunAt(scheduleCron, new Date());
+  if (!next) return 'Not scheduled';
+  return next.toLocaleString();
+}
+
+export function summarizeSiteOperations(input: SiteOpsInput): SiteOpsSummary {
+  const freshness = freshnessLabelFromScan(input.latestScanCompletedAt);
+  const cadence = scheduleCadenceLabel(input.scheduleCron);
+  const nextScheduled = scheduledRunLabel(input.scheduleCron);
+
+  if (input.pagesCount === 0 || input.latestCrawlStatus == null) {
+    return {
+      status: 'activation_required',
+      statusLabel: 'Activation required',
+      statusReason: 'Run the first crawl to discover pages and establish a verification baseline.',
+      nextAction: { label: 'Start first crawl', href: '/sites' },
+      freshnessLabel: freshness,
+      cadenceLabel: cadence,
+      nextScheduledRunLabel: nextScheduled,
+    };
+  }
+
+  if (input.latestScanStatus === 'FAILED') {
+    return {
+      status: 'scan_attention_required',
+      statusLabel: 'Scan failed',
+      statusReason: 'The most recent verification scan failed. Inspect the run and retry once queue dependencies are healthy.',
+      nextAction: { label: 'Inspect latest run', href: '/system' },
+      freshnessLabel: freshness,
+      cadenceLabel: cadence,
+      nextScheduledRunLabel: nextScheduled,
+    };
+  }
+
+  if (!input.entitlement.hasPaidAccess) {
+    return {
+      status: 'automation_degraded',
+      statusLabel: 'Upgrade required',
+      statusReason: 'Private verification automation is blocked until billing is active for this organization.',
+      nextAction: { label: 'Open billing', href: '/settings/billing' },
+      freshnessLabel: freshness,
+      cadenceLabel: cadence,
+      nextScheduledRunLabel: nextScheduled,
+    };
+  }
+
+  if (!input.workerRunning || !input.jobPipelinesHealthy) {
+    return {
+      status: 'automation_degraded',
+      statusLabel: 'Automation degraded',
+      statusReason: 'Workers or job queues are degraded, so scheduled crawls and verification rechecks may not complete.',
+      nextAction: { label: 'Open system status', href: '/system' },
+      freshnessLabel: freshness,
+      cadenceLabel: cadence,
+      nextScheduledRunLabel: nextScheduled,
+    };
+  }
+
+  if (!input.latestScanCompletedAt || freshness.startsWith('Stale')) {
+    return {
+      status: 'evidence_stale',
+      statusLabel: 'Evidence stale',
+      statusReason: 'Recent accessibility evidence is stale. Run a new crawl + verification to restore confidence.',
+      nextAction: { label: 'Queue verification', href: '/sites' },
+      freshnessLabel: freshness,
+      cadenceLabel: cadence,
+      nextScheduledRunLabel: nextScheduled,
+    };
+  }
+
+  return {
+    status: 'healthy',
+    statusLabel: 'Healthy',
+    statusReason:
+      input.openFindings > 0
+        ? `Automation and evidence are healthy; ${input.openFindings} open findings remain in backlog.`
+        : 'Automation and evidence are healthy with no open findings currently detected.',
+    nextAction: {
+      label: input.openFindings > 0 ? 'Review findings' : 'Open site details',
+      href: input.openFindings > 0 ? '/findings?status=OPEN' : '/sites',
+    },
+    freshnessLabel: freshness,
+    cadenceLabel: cadence,
+    nextScheduledRunLabel: nextScheduled,
+  };
+}
+
+export function rollupSiteOperations(statuses: SiteOperationalStatus[]): OrgSiteOpsRollup {
+  const rollup: OrgSiteOpsRollup = {
+    activationRequired: 0,
+    scanAttentionRequired: 0,
+    automationDegraded: 0,
+    evidenceStale: 0,
+    healthy: 0,
+  };
+
+  for (const status of statuses) {
+    if (status === 'activation_required') rollup.activationRequired += 1;
+    if (status === 'scan_attention_required') rollup.scanAttentionRequired += 1;
+    if (status === 'automation_degraded') rollup.automationDegraded += 1;
+    if (status === 'evidence_stale') rollup.evidenceStale += 1;
+    if (status === 'healthy') rollup.healthy += 1;
+  }
+
+  return rollup;
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -10,6 +10,7 @@ import { handlePublicScanJob } from "./jobs/public-scan";
 import { AgentOrchestrator } from "@aros/agents";
 import { bullmqConnectionOptions, VISUAL_REVIEW_QUEUE_NAME } from "@aros/shared";
 import { startScheduledCrawlLoop } from "./services/scheduled-crawls";
+import { runSiteOpsAlertTick } from "./services/site-ops-alerts";
 
 async function handleVisualReviewJob(job: any) {
   const { siteId, scanRunId, organizationId } = job.data;
@@ -106,10 +107,34 @@ const heartbeatInterval = setInterval(() => {
 
 const scheduledCrawlInterval = startScheduledCrawlLoop(prisma);
 
+
+const SITE_OPS_ALERT_INTERVAL_MS = 5 * 60_000;
+async function siteOpsAlertTick() {
+  try {
+    const result = await runSiteOpsAlertTick(prisma);
+    if (result.transitionsDetected > 0) {
+      console.log(
+        `[SiteOpsAlert] checked=${result.checked} transitions=${result.transitionsDetected} notifications=${result.notificationsSent}`,
+      );
+    }
+  } catch (e) {
+    console.error(
+      "[SiteOpsAlert] tick failed:",
+      e instanceof Error ? e.message : e,
+    );
+  }
+}
+void siteOpsAlertTick();
+const siteOpsAlertInterval = setInterval(() => {
+  void siteOpsAlertTick();
+}, SITE_OPS_ALERT_INTERVAL_MS);
+
+
 async function shutdown() {
   console.log("[Worker] Shutting down...");
   clearInterval(heartbeatInterval);
   clearInterval(scheduledCrawlInterval);
+  clearInterval(siteOpsAlertInterval);
   await Promise.all([
     crawlWorker.close(),
     scanWorker.close(),

--- a/apps/worker/src/services/site-ops-alerts.test.ts
+++ b/apps/worker/src/services/site-ops-alerts.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { deriveSiteOpsAlertState, siteOpsAlertConstants } from './site-ops-alerts';
+
+describe('deriveSiteOpsAlertState', () => {
+  it('returns scan_attention_required when latest scan failed', () => {
+    const result = deriveSiteOpsAlertState({
+      latestScanStatus: 'FAILED',
+      latestCompletedScanAt: null,
+      hasAnyCompletedScan: false,
+    });
+    expect(result.state).toBe('scan_attention_required');
+  });
+
+  it('returns evidence_stale when no completed scan exists', () => {
+    const result = deriveSiteOpsAlertState({
+      latestScanStatus: 'PENDING',
+      latestCompletedScanAt: null,
+      hasAnyCompletedScan: false,
+    });
+    expect(result.state).toBe('evidence_stale');
+  });
+
+  it('returns evidence_stale when completed scan is older than threshold', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-04-08T00:00:00.000Z');
+    vi.setSystemTime(now);
+    const result = deriveSiteOpsAlertState({
+      latestScanStatus: 'COMPLETED',
+      latestCompletedScanAt: new Date(now.getTime() - (siteOpsAlertConstants.STALE_HOURS + 1) * 60 * 60 * 1000),
+      hasAnyCompletedScan: true,
+    });
+    expect(result.state).toBe('evidence_stale');
+    vi.useRealTimers();
+  });
+
+  it('returns healthy when scan freshness is within threshold', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-04-08T00:00:00.000Z');
+    vi.setSystemTime(now);
+    const result = deriveSiteOpsAlertState({
+      latestScanStatus: 'COMPLETED',
+      latestCompletedScanAt: new Date(now.getTime() - 12 * 60 * 60 * 1000),
+      hasAnyCompletedScan: true,
+    });
+    expect(result.state).toBe('healthy');
+    vi.useRealTimers();
+  });
+});

--- a/apps/worker/src/services/site-ops-alerts.ts
+++ b/apps/worker/src/services/site-ops-alerts.ts
@@ -1,0 +1,206 @@
+import type { PrismaClient } from '@aros/db';
+
+const STALE_HOURS = 72;
+const ALERT_ACTION = 'site.ops.alert_transition';
+
+type AlertState = 'scan_attention_required' | 'evidence_stale' | 'healthy';
+
+interface SiteAlertSnapshot {
+  state: AlertState;
+  reason: string;
+}
+
+function hoursSince(ts: Date): number {
+  return (Date.now() - ts.getTime()) / (1000 * 60 * 60);
+}
+
+export function deriveSiteOpsAlertState(input: {
+  latestScanStatus: string | null;
+  latestCompletedScanAt: Date | null;
+  hasAnyCompletedScan: boolean;
+}): SiteAlertSnapshot {
+  if (input.latestScanStatus === 'FAILED') {
+    return {
+      state: 'scan_attention_required',
+      reason: 'Latest verification scan failed.',
+    };
+  }
+
+  if (!input.hasAnyCompletedScan) {
+    return {
+      state: 'evidence_stale',
+      reason: 'No completed verification scan exists yet.',
+    };
+  }
+
+  if (!input.latestCompletedScanAt || hoursSince(input.latestCompletedScanAt) > STALE_HOURS) {
+    return {
+      state: 'evidence_stale',
+      reason: 'Latest completed verification scan is older than 72 hours.',
+    };
+  }
+
+  return {
+    state: 'healthy',
+    reason: 'Verification scan health is within freshness window.',
+  };
+}
+
+function parseLastAlertState(metadata: unknown): AlertState | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const state = (metadata as Record<string, unknown>).state;
+  if (state === 'scan_attention_required' || state === 'evidence_stale' || state === 'healthy') {
+    return state;
+  }
+  return null;
+}
+
+function parseNotifyUrl(candidate: string | null): URL | null {
+  if (!candidate) return null;
+  try {
+    const url = new URL(candidate);
+    if (!['http:', 'https:'].includes(url.protocol)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+async function postAlertWebhook(url: URL, payload: unknown) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`Webhook responded ${response.status}`);
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function runSiteOpsAlertTick(prisma: PrismaClient) {
+  const sites = await prisma.site.findMany({
+    where: {
+      deployWebhooks: {
+        some: {
+          isActive: true,
+          notifyChannel: { not: null },
+        },
+      },
+    },
+    select: {
+      id: true,
+      name: true,
+      domain: true,
+      workspace: {
+        select: {
+          organizationId: true,
+          organization: { select: { name: true } },
+        },
+      },
+      deployWebhooks: {
+        where: { isActive: true, notifyChannel: { not: null } },
+        select: { notifyChannel: true },
+      },
+      scanRuns: {
+        orderBy: { createdAt: 'desc' },
+        take: 3,
+        select: { status: true, completedAt: true },
+      },
+    },
+  });
+
+  let notificationsSent = 0;
+  let transitionsDetected = 0;
+
+  for (const site of sites) {
+    const latestScan = site.scanRuns[0] ?? null;
+    const latestCompleted = site.scanRuns.find((run) => run.status === 'COMPLETED') ?? null;
+
+    const snapshot = deriveSiteOpsAlertState({
+      latestScanStatus: latestScan?.status ?? null,
+      latestCompletedScanAt: latestCompleted?.completedAt ?? null,
+      hasAnyCompletedScan: Boolean(latestCompleted),
+    });
+
+    const previous = await prisma.auditLog.findFirst({
+      where: {
+        organizationId: site.workspace.organizationId,
+        action: ALERT_ACTION,
+        entityType: 'Site',
+        entityId: site.id,
+      },
+      orderBy: { createdAt: 'desc' },
+      select: { metadata: true },
+    });
+
+    const previousState = parseLastAlertState(previous?.metadata);
+    if (previousState === snapshot.state) {
+      continue;
+    }
+
+    transitionsDetected += 1;
+
+    const validNotifyUrls = Array.from(
+      new Set(
+        site.deployWebhooks
+          .map((hook) => parseNotifyUrl(hook.notifyChannel))
+          .filter((url): url is URL => Boolean(url)),
+      ),
+    );
+
+    if (snapshot.state !== 'healthy' && validNotifyUrls.length > 0) {
+      const payload = {
+        event: 'site_ops_state_transition',
+        site: { id: site.id, name: site.name, domain: site.domain },
+        organization: {
+          id: site.workspace.organizationId,
+          name: site.workspace.organization.name,
+        },
+        currentState: snapshot.state,
+        previousState,
+        reason: snapshot.reason,
+        occurredAt: new Date().toISOString(),
+      };
+
+      for (const url of validNotifyUrls) {
+        await postAlertWebhook(url, payload).catch((error) => {
+          console.warn('[SiteOpsAlert] webhook delivery failed', {
+            siteId: site.id,
+            url: url.toString(),
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+        notificationsSent += 1;
+      }
+    }
+
+    await prisma.auditLog.create({
+      data: {
+        organizationId: site.workspace.organizationId,
+        action: ALERT_ACTION,
+        entityType: 'Site',
+        entityId: site.id,
+        metadata: {
+          state: snapshot.state,
+          previousState,
+          reason: snapshot.reason,
+          notifyUrlCount: validNotifyUrls.length,
+        },
+      },
+    });
+  }
+
+  return { checked: sites.length, transitionsDetected, notificationsSent };
+}
+
+export const siteOpsAlertConstants = {
+  STALE_HOURS,
+  ALERT_ACTION,
+};


### PR DESCRIPTION
### Motivation

- Provide deterministic operational health for sites so operators can triage activation, automation, and evidence freshness issues.  
- Surface scan change deltas so teams can quickly see new/resolved/persisting violations since the last completed verification.  
- Emit alerts when site operational state transitions so external systems can be notified via webhooks.

### Description

- Introduces site operations logic in `apps/web/src/lib/site-operations.ts` with `summarizeSiteOperations` and `rollupSiteOperations` to compute per-site status and organization rollups.  
- Adds `computeScanDelta` in `apps/web/src/lib/scan-delta.ts` to compute new/resolved/persisting violation counts between scans.  
- Enhances the Sites dashboard page (`apps/web/src/app/(dashboard)/sites/page.tsx`) to fetch additional data (scan runs, crawl config, open finding counts, subscription), compute operational summaries and deltas, and render operator worklist, scan-delta summary, and per-site cards with actions and status UI (`OpsMetric`, `DetailItem`, `StatusPill`).  
- Adds server-side alerting service `apps/worker/src/services/site-ops-alerts.ts` that detects state transitions, posts webhook notifications, and records audit log entries, and wires a periodic tick into the worker process (`apps/worker/src/index.ts`).

### Testing

- Unit tests for `computeScanDelta` were added in `apps/web/src/lib/scan-delta.test.ts` and passed.  
- Unit tests for `summarizeSiteOperations`/`rollupSiteOperations` were added in `apps/web/src/lib/site-operations.test.ts` and passed.  
- Unit tests for the alert state derivation were added in `apps/worker/src/services/site-ops-alerts.test.ts` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5dcd8824883289185dad1546d1f86)