### PR TITLE
Add recurrence intelligence and managed-review pressure to reporting surfaces

### DIFF
--- a/apps/web/src/app/(dashboard)/reports/page.tsx
+++ b/apps/web/src/app/(dashboard)/reports/page.tsx
@@ -233,6 +233,94 @@ export default async function ReportsPage({
               Imported: {opSummary.evidenceSourceMix.imported}
             </p>
           </div>
+          <div className="grid gap-4 border-t border-[rgb(var(--color-border))] pt-4 md:grid-cols-2">
+            <div>
+              <p className="text-sm font-medium text-slate-900">
+                Recurrence intelligence (compounding memory)
+              </p>
+              <p className="mt-1 text-xs text-slate-600">
+                These counters track repeated fingerprints and regression signals
+                across completed scan runs.
+              </p>
+              <ul className="mt-2 space-y-1 text-sm text-slate-700">
+                <li>
+                  Recurring across runs:{" "}
+                  <span className="font-semibold tabular-nums">
+                    {opSummary.recurrence.recurringAcrossScanRuns}
+                  </span>
+                </li>
+                <li>
+                  Regressed and still open:{" "}
+                  <span className="font-semibold tabular-nums">
+                    {opSummary.recurrence.regressedOpenFindings}
+                  </span>
+                </li>
+                <li>
+                  Improved but open backlog:{" "}
+                  <span className="font-semibold tabular-nums">
+                    {opSummary.recurrence.improvedOpenBacklog}
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-slate-900">
+                Managed-service review pressure
+              </p>
+              <p className="mt-1 text-xs text-slate-600">
+                Queue pressure is deterministic from unresolved review tasks for
+                this organization.
+              </p>
+              <ul className="mt-2 space-y-1 text-sm text-slate-700">
+                <li>
+                  Unresolved reviews:{" "}
+                  <span className="font-semibold tabular-nums">
+                    {opSummary.reviewQueue.unresolved}
+                  </span>
+                </li>
+                <li>
+                  Overdue (&gt;72h):{" "}
+                  <span className="font-semibold tabular-nums">
+                    {opSummary.reviewQueue.overdue72h}
+                  </span>
+                </li>
+                <li>
+                  Manual audit pending:{" "}
+                  <span className="font-semibold tabular-nums">
+                    {opSummary.reviewQueue.manualAuditPending}
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div className="border-t border-[rgb(var(--color-border))] pt-4">
+            <p className="text-sm font-medium text-slate-900">
+              Top recurring rule hotspots
+            </p>
+            {opSummary.recurrence.topRecurringRuleHotspots.length === 0 ? (
+              <p className="mt-1 text-sm text-slate-500">
+                No recurring scan-run hotspots yet.
+              </p>
+            ) : (
+              <ul className="mt-2 space-y-1 text-sm text-slate-700">
+                {opSummary.recurrence.topRecurringRuleHotspots.map((row) => (
+                  <li key={row.ruleId}>
+                    <span className="font-mono text-xs text-slate-900">
+                      {row.ruleId}
+                    </span>{" "}
+                    · recurring{" "}
+                    <span className="font-semibold tabular-nums">
+                      {row.recurringFindings}
+                    </span>{" "}
+                    · critical open{" "}
+                    <span className="font-semibold tabular-nums">
+                      {row.criticalOpenFindings}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
 
         <div className="card flex flex-col">

--- a/apps/web/src/lib/findings/reporting-summary.test.ts
+++ b/apps/web/src/lib/findings/reporting-summary.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildFindingsOperationalSummary } from "./reporting-summary";
+
+describe("buildFindingsOperationalSummary", () => {
+  it("includes recurrence hotspots and review queue metrics", async () => {
+    const countMock = vi
+      .fn()
+      // totals + severity + evidence mix (17)
+      .mockResolvedValueOnce(10)
+      .mockResolvedValueOnce(4)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(4)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(8)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+      // recurrence + queue + stale automated
+      .mockResolvedValueOnce(6)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(2);
+
+    const groupByMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { ruleId: "color-contrast", _count: { _all: 4 } },
+        { ruleId: "image-alt", _count: { _all: 2 } },
+      ])
+      .mockResolvedValueOnce([{ ruleId: "color-contrast", _count: { _all: 2 } }]);
+
+    const prisma = {
+      canonicalFinding: {
+        count: countMock,
+        groupBy: groupByMock,
+      },
+      scanRun: {
+        findFirst: vi.fn().mockResolvedValue({
+          completedAt: new Date("2026-04-01T00:00:00.000Z"),
+        }),
+      },
+      reviewTask: {
+        count: countMock,
+      },
+    };
+
+    const result = await buildFindingsOperationalSummary(
+      prisma as never,
+      "org_123",
+      true,
+    );
+
+    expect(result.recurrence.recurringAcrossScanRuns).toBe(6);
+    expect(result.recurrence.topRecurringRuleHotspots).toEqual([
+      {
+        ruleId: "color-contrast",
+        recurringFindings: 4,
+        criticalOpenFindings: 2,
+      },
+      {
+        ruleId: "image-alt",
+        recurringFindings: 2,
+        criticalOpenFindings: 0,
+      },
+    ]);
+    expect(result.reviewQueue).toEqual({
+      unresolved: 3,
+      overdue72h: 1,
+      manualAuditPending: 1,
+    });
+    expect(result.staleAutomationCount).toBe(2);
+  });
+});

--- a/apps/web/src/lib/findings/reporting-summary.ts
+++ b/apps/web/src/lib/findings/reporting-summary.ts
@@ -22,6 +22,21 @@ export type FindingsOperationalSummary = {
   };
   severityCounts: { critical: number; serious: number; moderate: number; minor: number };
   evidenceSourceMix: { automatedAxe: number; manualReview: number; imported: number };
+  recurrence: {
+    recurringAcrossScanRuns: number;
+    regressedOpenFindings: number;
+    improvedOpenBacklog: number;
+    topRecurringRuleHotspots: Array<{
+      ruleId: string;
+      recurringFindings: number;
+      criticalOpenFindings: number;
+    }>;
+  };
+  reviewQueue: {
+    unresolved: number;
+    overdue72h: number;
+    manualAuditPending: number;
+  };
   staleAutomationCount: number;
   automationFreshnessNote: string;
 };
@@ -52,6 +67,13 @@ export async function buildFindingsOperationalSummary(
     manualReview,
     imported,
     latestScan,
+    recurringAcrossScanRuns,
+    regressedOpenFindings,
+    improvedOpenBacklog,
+    recurringHotspotsRaw,
+    unresolvedReviewTasks,
+    overdueReviewTasks,
+    manualAuditPendingTasks,
   ] = await Promise.all([
     prisma.canonicalFinding.count({ where: base }),
     prisma.canonicalFinding.count({ where: { ...base, status: 'OPEN' } }),
@@ -83,7 +105,109 @@ export async function buildFindingsOperationalSummary(
       orderBy: { completedAt: 'desc' },
       select: { completedAt: true },
     }),
+    prisma.canonicalFinding.count({
+      where: { ...base, distinctScanRunsObserved: { gt: 1 } },
+    }),
+    prisma.canonicalFinding.count({
+      where: {
+        ...base,
+        reopenedCount: { gt: 0 },
+        status: { in: ['OPEN', 'ACKNOWLEDGED', 'IN_PROGRESS'] },
+      },
+    }),
+    prisma.canonicalFinding.count({
+      where: {
+        ...base,
+        distinctScanRunsAbsentWhenOpen: { gt: 0 },
+        status: { in: ['OPEN', 'ACKNOWLEDGED', 'IN_PROGRESS'] },
+      },
+    }),
+    prisma.canonicalFinding.groupBy({
+      by: ['ruleId'],
+      where: {
+        ...base,
+        distinctScanRunsObserved: { gt: 1 },
+      },
+      _count: { _all: true },
+      orderBy: {
+        _count: { ruleId: 'desc' },
+      },
+      take: 5,
+    }),
+    prisma.reviewTask.count({
+      where: {
+        status: { in: ['PENDING', 'IN_PROGRESS'] },
+        suggestion: {
+          OR: [
+            {
+              finding: {
+                site: { workspace: { organizationId } },
+              },
+            },
+            {
+              cluster: {
+                site: { workspace: { organizationId } },
+              },
+            },
+          ],
+        },
+      },
+    }),
+    prisma.reviewTask.count({
+      where: {
+        status: { in: ['PENDING', 'IN_PROGRESS'] },
+        createdAt: { lt: new Date(Date.now() - 72 * 3_600_000) },
+        suggestion: {
+          OR: [
+            {
+              finding: {
+                site: { workspace: { organizationId } },
+              },
+            },
+            {
+              cluster: {
+                site: { workspace: { organizationId } },
+              },
+            },
+          ],
+        },
+      },
+    }),
+    prisma.reviewTask.count({
+      where: {
+        type: 'MANUAL_AUDIT',
+        status: { in: ['PENDING', 'IN_PROGRESS'] },
+        suggestion: {
+          OR: [
+            {
+              finding: {
+                site: { workspace: { organizationId } },
+              },
+            },
+            {
+              cluster: {
+                site: { workspace: { organizationId } },
+              },
+            },
+          ],
+        },
+      },
+    }),
   ]);
+
+  const criticalOpenByRule = await prisma.canonicalFinding.groupBy({
+    by: ['ruleId'],
+    where: {
+      ...base,
+      impact: 'CRITICAL',
+      status: 'OPEN',
+      ruleId: { in: recurringHotspotsRaw.map((row) => row.ruleId) },
+    },
+    _count: { _all: true },
+  });
+  const criticalOpenByRuleMap = new Map(
+    criticalOpenByRule.map((row) => [row.ruleId, row._count._all]),
+  );
 
   let staleAutomationCount = 0;
   if (latestScan?.completedAt && jobPipelinesHealthy) {
@@ -129,6 +253,21 @@ export async function buildFindingsOperationalSummary(
       minor: minorAll,
     },
     evidenceSourceMix: { automatedAxe, manualReview, imported },
+    recurrence: {
+      recurringAcrossScanRuns,
+      regressedOpenFindings,
+      improvedOpenBacklog,
+      topRecurringRuleHotspots: recurringHotspotsRaw.map((row) => ({
+        ruleId: row.ruleId,
+        recurringFindings: row._count._all,
+        criticalOpenFindings: criticalOpenByRuleMap.get(row.ruleId) ?? 0,
+      })),
+    },
+    reviewQueue: {
+      unresolved: unresolvedReviewTasks,
+      overdue72h: overdueReviewTasks,
+      manualAuditPending: manualAuditPendingTasks,
+    },
     staleAutomationCount,
     automationFreshnessNote,
   };

--- a/docs/FINDINGS_AND_REPORTING_TRUTH.md
+++ b/docs/FINDINGS_AND_REPORTING_TRUTH.md
@@ -7,6 +7,8 @@
 - **Remediation counts**: distribution of `status`.
 - **Evidence source mix**: counts by `evidenceSource`.
 - **Stale automated count**: findings with `AUTOMATED_AXE` where `lastVerifiedAt` is null or older than the latest **completed** org scan, unless job pipelines are degraded (then all automated findings count as stale for messaging).
+- **Recurrence intelligence**: recurring fingerprint counts (`distinctScanRunsObserved > 1`), regressed-open counters (`reopenedCount > 0` and workflow status unresolved), and top recurring `ruleId` hotspots.
+- **Managed-service queue pressure**: unresolved review-task counters derived from `ReviewTask` rows linked to org-scoped suggestions (`unresolved`, `overdue72h`, `manualAuditPending`).
 
 ## What we do **not** show
 
@@ -16,6 +18,7 @@
 ## APIs
 
 - `GET /api/findings/summary` — JSON operational summary; requires `reports:view`. Returns `503` with a safe envelope if org-scoped DB reads are blocked by platform health.
+- `GET /api/findings/summary` includes deterministic recurrence and review-pressure sections so exports and operator workflows can prioritize repeat risk and aging manual-review backlog.
 - `GET /api/reports` — export; requires `reports:export`. Includes `platformTruth` flags so consumers know if workers/pipelines were healthy at generation time.
 
 ## Degraded behavior


### PR DESCRIPTION
### Motivation
- Surface deterministic, compounding signals from existing scan and review history so operators can prioritise recurring risk and manage manual-review backlog without manual aggregation.

### Description
- Extended `buildFindingsOperationalSummary` to include a `recurrence` block with `recurringAcrossScanRuns`, `regressedOpenFindings`, `improvedOpenBacklog`, and `topRecurringRuleHotspots` enriched with critical-open counts using existing persisted fields (`distinctScanRunsObserved`, `reopenedCount`, `distinctScanRunsAbsentWhenOpen`) and `groupBy` aggregation on `ruleId`.
- Added a `reviewQueue` block that reports unresolved review tasks, overdue (>72h) items, and pending `MANUAL_AUDIT` tasks scoped to the organization via existing `ReviewTask` relations.
- Rendered the new metrics in the Reports dashboard snapshot: recurrence panel, managed-service review pressure panel, and top recurring rule hotspots list in `apps/web/src/app/(dashboard)/reports/page.tsx`.
- Added unit tests for the expanded summary in `apps/web/src/lib/findings/reporting-summary.test.ts` and updated `docs/FINDINGS_AND_REPORTING_TRUTH.md` to document the new deterministic fields and API behavior.

### Testing
- Ran the focused unit test with `npx vitest run src/lib/findings/reporting-summary.test.ts` in `apps/web`, and it passed.
- Attempted broader workspace checks: `npm run db:generate`, `npm run test --workspace=apps/web`, and `npm run typecheck --workspace=apps/web` were blocked in this environment by a missing/regen Prisma client step (`prisma generate` / `@prisma/client` resolution), so full `npm run verify` could not be completed here; the PR changes are unit-tested and ready for full CI which should run the standard Prisma generation and workspace verify steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9cd7240b88328b549bfad1a4d76c1)