### PR TITLE
Potential fix for code scanning alert no. 3: Use of password hash with insufficient computational effort

### DIFF
--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,12 +1,14 @@
 import { PrismaClient } from '@prisma/client';
-import { createHash, randomBytes } from 'crypto';
+import { randomBytes, scrypt } from 'crypto';
+import { promisify } from 'util';
 
 const prisma = new PrismaClient();
+const scryptAsync = promisify(scrypt);
 
 async function hashPassword(password: string): Promise<string> {
   const salt = randomBytes(16).toString('hex');
-  const hash = createHash('sha256').update(salt + password).digest('hex');
-  return `${salt}:${hash}`;
+  const derivedKey = (await scryptAsync(password, salt, 64)) as Buffer;
+  return `${salt}:${derivedKey.toString('hex')}`;
 }
 
 async function main() {


### PR DESCRIPTION
Potential fix for [https://github.com/Hardonian/FlexibleAccessible/security/code-scanning/3](https://github.com/Hardonian/FlexibleAccessible/security/code-scanning/3)

Use a password-specific KDF with a configurable cost factor instead of raw SHA-256. The best minimal fix here is to replace `createHash` usage with Node’s built-in `crypto.scrypt` (via `promisify`), keeping output format `salt:derivedKeyHex` so existing functionality/shape is preserved.

In `packages/db/prisma/seed.ts`:
- Update imports: remove `createHash`, add `scrypt`, and import `promisify` from `util`.
- Add a promisified `scryptAsync`.
- Replace `hashPassword` internals so it:
  - generates a random salt,
  - derives a key with `scryptAsync(password, salt, 64)`,
  - returns `${salt}:${derivedKeyHex}`.

This keeps async behavior and avoids introducing external dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
