### PR TITLE
chore: security/docs hardening baseline follow-up

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Hardonian

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+## Type
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Docs
+- [ ] Security
+
+## Validation
+- [ ] CI passed
+- [ ] Security impact reviewed
+- [ ] Backward compatibility reviewed
+
+## AI-assisted changes (if used)
+- [ ] Reviewed by human
+- [ ] No secrets in prompts

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
This PR applies baseline hardening and professional repo docs:

- SECURITY.md
- CONTRIBUTING.md
- QUICKSTART.md
- CODEOWNERS / PR template
- Dependabot + Dependency Review workflow (when path structure allows)
- LICENSE (if missing)

Opened automatically to satisfy branch/repo rules requiring PR-based changes.