### PR TITLE
fix(security): use default config for CodeQL to match repo settings

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: javascript
+          config: default
       - uses: github/codeql-action/autobuild@v3
       - uses: github/codeql-action/analyze@v3
 


### PR DESCRIPTION
Fixes Security Baseline failure: CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled. Use default config in workflow to match repo-level settings.