### PR TITLE
fix(ci): remove CodeQL config that causes error

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: javascript
+          config: default
       - uses: github/codeql-action/autobuild@v3
       - uses: github/codeql-action/analyze@v3
 

--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: javascript
-          config: default
       - uses: github/codeql-action/autobuild@v3
       - uses: github/codeql-action/analyze@v3
 


### PR DESCRIPTION
Removes  that causes 'Cannot create property' error in CodeQL action. This should fix Security Baseline.