### PR TITLE
🧪 Improve test coverage for planMeetsMinimum

### DIFF
--- a/packages/config/src/__tests__/plan-tier-order.test.ts
+++ b/packages/config/src/__tests__/plan-tier-order.test.ts
@@ -1,16 +1,48 @@
 import { describe, expect, it } from 'vitest';
 import { planMeetsMinimum, planTierRank } from '../plan-tier-order';
+import type { PlanTier } from '../plans';
 
-describe('planMeetsMinimum', () => {
+describe('planTierRank', () => {
   it('ranks tiers in ascending order', () => {
     expect(planTierRank('FREE')).toBeLessThan(planTierRank('STARTER'));
     expect(planTierRank('STARTER')).toBeLessThan(planTierRank('PROFESSIONAL'));
     expect(planTierRank('PROFESSIONAL')).toBeLessThan(planTierRank('ENTERPRISE'));
   });
 
+  it('returns 0 for an unknown tier', () => {
+    expect(planTierRank('UNKNOWN' as PlanTier)).toBe(0);
+  });
+});
+
+describe('planMeetsMinimum', () => {
+
   it('requires same or higher tier', () => {
     expect(planMeetsMinimum('PROFESSIONAL', 'PROFESSIONAL')).toBe(true);
     expect(planMeetsMinimum('ENTERPRISE', 'PROFESSIONAL')).toBe(true);
     expect(planMeetsMinimum('STARTER', 'PROFESSIONAL')).toBe(false);
   });
+
+  it.each([
+    ['FREE', 'FREE', true],
+    ['FREE', 'STARTER', false],
+    ['FREE', 'PROFESSIONAL', false],
+    ['FREE', 'ENTERPRISE', false],
+    ['STARTER', 'FREE', true],
+    ['STARTER', 'STARTER', true],
+    ['STARTER', 'PROFESSIONAL', false],
+    ['STARTER', 'ENTERPRISE', false],
+    ['PROFESSIONAL', 'FREE', true],
+    ['PROFESSIONAL', 'STARTER', true],
+    ['PROFESSIONAL', 'PROFESSIONAL', true],
+    ['PROFESSIONAL', 'ENTERPRISE', false],
+    ['ENTERPRISE', 'FREE', true],
+    ['ENTERPRISE', 'STARTER', true],
+    ['ENTERPRISE', 'PROFESSIONAL', true],
+    ['ENTERPRISE', 'ENTERPRISE', true],
+  ] as const)(
+    'when actual is %s and minimum is %s, it returns %s',
+    (actual: PlanTier, minimum: PlanTier, expected: boolean) => {
+      expect(planMeetsMinimum(actual, minimum)).toBe(expected);
+    }
+  );
 });


### PR DESCRIPTION
🎯 What: The testing gap for planMeetsMinimum and planTierRank in packages/config/src/plan-tier-order.ts has been addressed.
📊 Coverage: A test matrix using it.each has been added to cover all 16 permutations of PlanTier for planMeetsMinimum. Additionally, test coverage has been added for an unknown tier returning 0 in planTierRank.
✨ Result: Exhaustive test coverage has been achieved for plan tier logic.

---
*PR created automatically by Jules for task [844941140463512522](https://jules.google.com/task/844941140463512522) started by @Hardonian*