### PR TITLE
🧹 Improve code health by moving eslint-disable from inline comment to global eslint.config.mjs

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -73,6 +73,13 @@ const config = [
       "no-restricted-syntax": "off",
     },
   },
+  {
+    // Mock files in Playwright component tests can use native img tags
+    files: ["playwright/mocks/**"],
+    rules: {
+      "@next/next/no-img-element": "off",
+    },
+  },
 ];
 
 export default config;

--- a/apps/web/playwright/mocks/next-image.tsx
+++ b/apps/web/playwright/mocks/next-image.tsx
@@ -2,6 +2,5 @@ import React from 'react';
 
 // A simple standard HTML image tag to replace Next.js <Image />
 export default function MockNextImage({ src, alt, width, height, className, ...props }: any) {
-  // eslint-disable-next-line @next/next/no-img-element
   return <img src={src} alt={alt} width={width} height={height} className={className} {...props} />;
 }


### PR DESCRIPTION
🎯 **What:** Removed the inline `eslint-disable-next-line @next/next/no-img-element` comment in `apps/web/playwright/mocks/next-image.tsx` and replaced it with a rule override in `apps/web/eslint.config.mjs` specifically for Playwright mock files.
💡 **Why:** `eslint-disable` directives bypass static analysis on a line-by-line basis, which can lead to accidental suppression of other issues and clutters the code. By moving this exception to the global ESLint configuration with a specific file glob `playwright/mocks/**`, we establish a clear, centralized project policy that allows native `<img>` tags in testing mocks while maintaining the rule for the rest of the application code. This improves maintainability and readability.
✅ **Verification:** Verified the code changes were applied using `git diff`. Attempted to run tests, and while some tests failed due to unrelated issues across the monorepo workspace, no new errors were introduced by this ESLint configuration change.
✨ **Result:** The codebase is cleaner with fewer inline disable comments, and the linting policy is clearly defined in the configuration file.

---
*PR created automatically by Jules for task [18097515737535922078](https://jules.google.com/task/18097515737535922078) started by @Hardonian*