### PR TITLE
🧹 Replace console.log with structured logger in public-scan

### DIFF
--- a/apps/worker/src/jobs/public-scan.ts
+++ b/apps/worker/src/jobs/public-scan.ts
@@ -3,6 +3,7 @@ import { Job } from "bullmq";
 import { prisma } from "@aros/db";
 import { chromium, type Browser } from "playwright";
 import { normalizeViolations } from "@aros/scan-engine";
+import { workerLogger } from "@aros/shared";
 
 interface PublicScanJobData {
   publicScanResultId: string;
@@ -19,9 +20,9 @@ interface PublicScanJobData {
 export async function handlePublicScanJob(job: Job<PublicScanJobData>) {
   const { publicScanResultId, url, maxPages } = job.data;
 
-  console.log(
-    `[PublicScan] Starting public scan ${publicScanResultId} for ${url}`,
-  );
+  workerLogger.info(`[PublicScan] Starting public scan ${publicScanResultId} for ${url}`, {
+    metadata: { publicScanResultId, url }
+  });
 
   await prisma.publicScanResult.update({
     where: { id: publicScanResultId },
@@ -113,7 +114,7 @@ export async function handlePublicScanJob(job: Job<PublicScanJobData>) {
         pagesScanned++;
         await page.close();
       } catch (err) {
-        console.error(`[PublicScan] Error scanning ${pageUrl}:`, err);
+        workerLogger.error(`[PublicScan] Error scanning ${pageUrl}`, { error: err, metadata: { pageUrl, publicScanResultId } });
       }
     }
 
@@ -161,11 +162,11 @@ export async function handlePublicScanJob(job: Job<PublicScanJobData>) {
       },
     });
 
-    console.log(
-      `[PublicScan] Completed ${publicScanResultId}: score=${score}, ${totalViolations} violations across ${pagesScanned} pages`,
-    );
+    workerLogger.info(`[PublicScan] Completed ${publicScanResultId}: score=${score}, ${totalViolations} violations across ${pagesScanned} pages`, {
+      metadata: { publicScanResultId, score, totalViolations, pagesScanned }
+    });
   } catch (err) {
-    console.error(`[PublicScan] Failed ${publicScanResultId}:`, err);
+    workerLogger.error(`[PublicScan] Failed ${publicScanResultId}`, { error: err, metadata: { publicScanResultId } });
     const failedAt = new Date();
     await prisma.publicScanResult.update({
       where: { id: publicScanResultId },


### PR DESCRIPTION
🎯 **What:** Replaced console.log and console.error with workerLogger in apps/worker/src/jobs/public-scan.ts.
💡 **Why:** To improve code health and log maintainability by using proper structured logging in production code.
✅ **Verification:** Verified that worker tests pass locally and the correct parameters are provided to the logger API.
✨ **Result:** A more maintainable logging setup.

---
*PR created automatically by Jules for task [6683270548589075438](https://jules.google.com/task/6683270548589075438) started by @Hardonian*