### PR TITLE
🧹 [code health improvement] Use workerLogger in ScheduledCrawl ticks

### DIFF
--- a/apps/worker/src/services/scheduled-crawls.ts
+++ b/apps/worker/src/services/scheduled-crawls.ts
@@ -1,6 +1,6 @@
 import { Queue } from "bullmq";
 import type { PrismaClient } from "@aros/db";
-import { bullmqConnectionOptions } from "@aros/shared";
+import { bullmqConnectionOptions, workerLogger } from "@aros/shared";
 import {
   currentScheduleWindow,
   parseSupportedScheduleCron,
@@ -248,12 +248,12 @@ export function startScheduledCrawlLoop(prisma: PrismaClient) {
     try {
       const result = await runScheduledCrawlTick(prisma);
       if (result.enqueued > 0 || result.blocked > 0) {
-        console.log(
+        workerLogger.info(
           `[ScheduledCrawl] scanned=${result.scanned} enqueued=${result.enqueued} blocked=${result.blocked}`,
         );
       }
     } catch (error) {
-      console.error("[ScheduledCrawl] tick failed", error);
+      workerLogger.error("[ScheduledCrawl] tick failed", { error });
     }
   };
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -117,6 +117,7 @@ export {
 } from './auth';
 
 export { AppError, ApiError } from './errors';
+export { logAiUsage, checkAiEntitlement } from './ai-usage';
 export { slugify, truncate, pluralize } from './strings';
 export {
   createFingerprint,
@@ -131,7 +132,7 @@ export {
   VISUAL_REVIEW_QUEUE_NAME,
   getSharedScanQueue,
 } from './scan-queue';
-export { apiLogger, authLogger, queueLogger } from './logger';
+export { apiLogger, authLogger, queueLogger, workerLogger } from './logger';
 export {
   FINDING_STATUSES,
   type FindingStatusValue,

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -108,6 +108,7 @@ export const billingLogger = new Logger("billing");
 export const scanLogger = new Logger("scan");
 export const workerLogger = new Logger("worker");
 export const dbLogger = new Logger("db");
+export const queueLogger = new Logger("queue");
 
 // Utility function to create request-scoped logger
 export function createRequestLogger(


### PR DESCRIPTION
🎯 **What:** Replaced `console.log` and `console.error` with `workerLogger` in `apps/worker/src/services/scheduled-crawls.ts`. Exported missing `queueLogger` and `workerLogger` from `@aros/shared`. Fixed `aiUsage` imports in `@aros/shared`.

💡 **Why:** Improves log structure, consistency, and standardizes handling of operational outputs via our structured application loggers instead of untyped console methods. Also fixed existing TS build issues around missing logger exports.

✅ **Verification:** Ran `npm run typecheck` and `npm run test` on the worker to confirm safety.

✨ **Result:** Worker ticks are now logged in the structured format matching the rest of the application.

---
*PR created automatically by Jules for task [3829100512743937963](https://jules.google.com/task/3829100512743937963) started by @Hardonian*