### PR TITLE
🧹 [code health] Remove hardcoded development URLs from env schema

### DIFF
--- a/packages/config/src/__tests__/env-diagnostics.test.ts
+++ b/packages/config/src/__tests__/env-diagnostics.test.ts
@@ -7,6 +7,7 @@ describe('parseEnvDiagnostics', () => {
       DATABASE_URL: 'postgresql://localhost:5432/db',
       NEXTAUTH_SECRET: 'test-secret-for-ci-only',
       NEXTAUTH_URL: 'http://localhost:3000',
+      REDIS_URL: 'redis://localhost:6379',
       NODE_ENV: 'test',
     });
     expect(d.valid).toBe(true);

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 export const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   DATABASE_URL: z.string().url(),
-  REDIS_URL: z.string().default('redis://localhost:6379'),
+  REDIS_URL: z.string().url(),
   NEXTAUTH_SECRET: z.string().min(16),
-  NEXTAUTH_URL: z.string().url().default('http://localhost:3000'),
+  NEXTAUTH_URL: z.string().url(),
 
   // Stripe
   STRIPE_SECRET_KEY: z.string().optional(),


### PR DESCRIPTION
🎯 What: Removed the default values for `REDIS_URL` and `NEXTAUTH_URL` in the environment validation schema and ensured both have URL validation. Updated related tests to pass with the new schema.
💡 Why: Relying on hardcoded development URLs as defaults is risky as it might cause production services to connect to local instances if the environment variables are accidentally omitted or misconfigured. This change enforces explicitly setting these variables across all environments.
✅ Verification: Ran `npm run test --workspace=packages/config` to ensure environment diagnostics correctly validate missing vs provided keys. Verified no regressions in config parsing.
✨ Result: Improved safety and explicit configuration enforcement for vital connection strings.

---
*PR created automatically by Jules for task [5028068233553246096](https://jules.google.com/task/5028068233553246096) started by @Hardonian*