### PR TITLE
🧹 [code health improvement] Remove commented-out dead code in state.ts

### DIFF
--- a/packages/core-services/src/state.ts
+++ b/packages/core-services/src/state.ts
@@ -246,20 +246,3 @@ export function calculateServiceHealthScore(
   return calculateHealthScore(posture);
 }
 
-// ==================== MIGRATION GUIDE ====================
-//
-// BEFORE (Legacy):
-//   const { readiness, blockers, warnings } = deriveReadinessFromServices(services);
-//   const { degraded, totalFailed } = queueFailurePressure(snapshot);
-//
-// AFTER (Standardized):
-//   const posture = buildSystemPostureFromServices(services, { queueSnapshot: snapshot });
-//   const { ready, blockers, warnings } = determineReadiness(posture);
-//   const healthScore = calculateHealthScore(posture);
-//   
-//   // Access standardized fields:
-//   posture.overall        // 'healthy' | 'degraded' | 'unhealthy'
-//   posture.degraded       // boolean
-//   posture.degradedReasons // string[]
-//   posture.components     // ComponentPosture[]
-//   posture.failClosed     // boolean (always true


### PR DESCRIPTION
🎯 **What:** Removed commented-out migration guide legacy code at the bottom of `packages/core-services/src/state.ts`.
💡 **Why:** The commented out code provides no value but decreases maintainability and readability by keeping useless noise in the source file. It's safe to be deleted.
✅ **Verification:** Verified tests pass in `@aros/core-services` and that the file still has no type issues related to this change. Pre-existing test failures and type errors are unrelated to this file.
✨ **Result:** Cleaned up code that's no longer useful, maintaining a clean state without functional regressions.

---
*PR created automatically by Jules for task [6186196811666152868](https://jules.google.com/task/6186196811666152868) started by @Hardonian*