### PR TITLE
🔒 Improve script injection validation to prevent bypasses

### DIFF
--- a/packages/remediation/src/__tests__/validator.test.ts
+++ b/packages/remediation/src/__tests__/validator.test.ts
@@ -40,4 +40,39 @@ describe('validateFix', () => {
     expect(result.valid).toBe(true);
     expect(result.checks.syntaxValid).toBe(true);
   });
+
+  it('detects obfuscated script injection with HTML entities', () => {
+    const result = validateFix('<a href="java&#x0A;script:alert(1)">Click</a>');
+    expect(result.valid).toBe(false);
+  });
+
+  it('detects obfuscated script injection with whitespaces and control characters', () => {
+    const result = validateFix('<a href="j a v a s c r i p t :alert(1)">Click</a>');
+    expect(result.valid).toBe(false);
+
+    // Test with null byte (simulation)
+    const result2 = validateFix('<a href="java\x00script:alert(1)">Click</a>');
+    expect(result2.valid).toBe(false);
+  });
+
+  it('detects uppercase variations of script injection', () => {
+    const result1 = validateFix('<script>EVAL("1")</script>');
+    expect(result1.valid).toBe(false);
+
+    const result2 = validateFix('<script>DOCUMENT.WRITE("test")</script>');
+    expect(result2.valid).toBe(false);
+  });
+
+  it('does not produce false positives for conditional text with equals sign', () => {
+    const result = validateFix('<div data-conditional="true">content</div>');
+    expect(result.valid).toBe(true);
+  });
+
+  it('detects vbscript and other execution methods', () => {
+    const result1 = validateFix('<a href="vbscript:msgbox(1)">Click</a>');
+    expect(result1.valid).toBe(false);
+
+    const result2 = validateFix('<script>setTimeout("alert(1)", 1000)</script>');
+    expect(result2.valid).toBe(false);
+  });
 });

--- a/packages/remediation/src/validator.ts
+++ b/packages/remediation/src/validator.ts
@@ -56,15 +56,38 @@ export function validateFix(suggestedCode: string): ValidationResult {
 }
 
 function hasScriptInjection(code: string): boolean {
-  const patterns = [
-    /javascript:/i,
+  // Decode HTML entities to catch obfuscated payloads like java&#x0A;script:
+  const decodedCode = code.replace(/&#(?:x([\da-f]+)|(\d+));?/gi, (_, hex, dec) => {
+    return String.fromCharCode(dec ? parseInt(dec, 10) : parseInt(hex, 16));
+  });
+
+  // Strip control characters and whitespace for protocol matching
+  // This catches things like "j a v a s c r i p t :" or "java\x00script:"
+  const strippedCode = decodedCode.replace(/[\u0000-\u0020\u007F-\u009F\u2000-\u200F\u2028-\u202F\u205F-\u206F\u3000\uFEFF]/g, '');
+
+  const generalPatterns = [
     /<script/i,
-    /on\w+\s*=/i,
-    /eval\s*\(/,
-    /document\.write/,
-    /innerHTML\s*=/,
+    /<object/i,
+    /<embed/i,
+    /<iframe/i,
+    /\bon\w+\s*=/i,
+    /eval\s*\(/i,
+    /setTimeout\s*\(/i,
+    /setInterval\s*\(/i,
+    /document\.write/i,
+    /innerHTML\s*=/i,
   ];
-  return patterns.some((p) => p.test(code));
+
+  const protocolPatterns = [
+    /javascript:/i,
+    /vbscript:/i,
+    /data:text\/html/i,
+  ];
+
+  return (
+    generalPatterns.some((p) => p.test(decodedCode)) ||
+    protocolPatterns.some((p) => p.test(strippedCode))
+  );
 }
 
 function hasBalancedTags(code: string): boolean {


### PR DESCRIPTION
🎯 **What:** The `hasScriptInjection` validation function used basic regexes that could easily be bypassed.
⚠️ **Risk:** Attackers could inject malicious scripts by using HTML entities (`java&#x0A;script:`), whitespace/control characters (`j a v a s c r i p t :`), or varied casing, bypassing the safety checks.
🛡️ **Solution:** Updated the function to decode HTML numeric and hexadecimal entities, strip formatting and control characters before matching protocol-based attacks, and apply case-insensitive matching across all patterns. Added missing attack vectors such as `vbscript:` and `setTimeout`. Added comprehensive test coverage for these obfuscation techniques.

---
*PR created automatically by Jules for task [4023593084622694165](https://jules.google.com/task/4023593084622694165) started by @Hardonian*