### PR TITLE
Potential fix for code scanning alert no. 15: Clear-text logging of sensitive information

### DIFF
--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -7,6 +7,34 @@ export enum LogLevel {
   DEBUG = "debug",
 }
 
+const SENSITIVE_KEY_PATTERN =
+  /(key|apikey|api_key|token|secret|password|passwd|authorization|cookie|keyhash|key_hash)/i;
+const REDACTED_VALUE = "[REDACTED]";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizeForLogging(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeForLogging(item));
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      sanitized[key] = REDACTED_VALUE;
+    } else {
+      sanitized[key] = sanitizeForLogging(nestedValue);
+    }
+  }
+  return sanitized;
+}
+
 const logSchema = z.object({
   level: z.nativeEnum(LogLevel),
   message: z.string(),
@@ -35,12 +63,18 @@ class Logger {
       Omit<LogEntry, "level" | "message" | "service" | "timestamp">
     >,
   ) {
+    const sanitizedExtra = extra
+      ? (sanitizeForLogging(extra) as Partial<
+          Omit<LogEntry, "level" | "message" | "service" | "timestamp">
+        >)
+      : undefined;
+
     const entry: LogEntry = {
       level,
       message,
       service: this.service,
       timestamp: new Date().toISOString(),
-      ...extra,
+      ...sanitizedExtra,
     };
 
     // In production, this would go to a proper logging service
@@ -57,7 +91,7 @@ class Logger {
 
       console.log(
         `${color}[${level.toUpperCase()}] ${this.service}: ${message}\x1b[0m`,
-        extra ? JSON.stringify(extra, null, 2) : "",
+        sanitizedExtra ? JSON.stringify(sanitizedExtra, null, 2) : "",
       );
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Hardonian/FlexibleAccessible/security/code-scanning/15](https://github.com/Hardonian/FlexibleAccessible/security/code-scanning/15)

General fix: never log raw structured context directly. Introduce a sanitization/redaction step for `extra` (and anything merged into `entry`) before serialization. Redact sensitive keys (e.g., `key`, `apiKey`, `token`, `secret`, `password`, `authorization`, `cookie`, `keyHash`) recursively, and only log sanitized data.

Best single fix without changing functionality: update `packages/shared/src/logger.ts` so `log()` creates a `sanitizedExtra` object via a recursive sanitizer and uses it for both:
- production output (`JSON.stringify(entry)` where `entry` includes `...sanitizedExtra`), and
- non-production pretty output (`JSON.stringify(sanitizedExtra, null, 2)`).

This preserves structured logging behavior, log levels, message formatting, and fields, while preventing clear-text sensitive values from being emitted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
