### PR TITLE
🧹 [code health improvement] Remove hardcoded development URLs in env schema

### DIFF
--- a/packages/config/src/__tests__/env-diagnostics.test.ts
+++ b/packages/config/src/__tests__/env-diagnostics.test.ts
@@ -7,6 +7,7 @@ describe('parseEnvDiagnostics', () => {
       DATABASE_URL: 'postgresql://localhost:5432/db',
       NEXTAUTH_SECRET: 'test-secret-for-ci-only',
       NEXTAUTH_URL: 'http://localhost:3000',
+      REDIS_URL: 'redis://localhost:6379',
       NODE_ENV: 'test',
     });
     expect(d.valid).toBe(true);

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 export const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   DATABASE_URL: z.string().url(),
-  REDIS_URL: z.string().default('redis://localhost:6379'),
+  REDIS_URL: z.string(),
   NEXTAUTH_SECRET: z.string().min(16),
-  NEXTAUTH_URL: z.string().url().default('http://localhost:3000'),
+  NEXTAUTH_URL: z.string().url().optional(),
 
   // Stripe
   STRIPE_SECRET_KEY: z.string().optional(),


### PR DESCRIPTION
🎯 **What:** Removed hardcoded defaults for `REDIS_URL` and `NEXTAUTH_URL` from the Zod environment schema. Updated corresponding tests to provide the required `REDIS_URL`.
💡 **Why:** Removing hardcoded defaults in the environment schema enforces providing actual URLs via environment variables, improving maintainability and ensuring safety across development and production environments.
✅ **Verification:** Ran `npm run test --workspace=packages/config` and verified all tests passed successfully. The test mock now properly supplies `REDIS_URL` for `parseEnvDiagnostics`. Typecheck for `@aros/config` succeeds.
✨ **Result:** A safer, more reliable environment configuration that avoids unintended fallback behavior.

---
*PR created automatically by Jules for task [13433429420071826781](https://jules.google.com/task/13433429420071826781) started by @Hardonian*