### PR TITLE
🧪 Add test for empty findings edge case in formatCsvExport

### DIFF
--- a/packages/integrations/src/__tests__/export.test.ts
+++ b/packages/integrations/src/__tests__/export.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { formatCsvExport, ExportData } from '../export';
+
+describe('formatCsvExport', () => {
+  it('returns only headers when findings array is empty', () => {
+    const data: ExportData = {
+      findings: [],
+      generatedAt: new Date().toISOString(),
+      generatedBy: 'test-user',
+    };
+
+    const expectedHeaders = 'Finding ID,Rule,Impact,Status,Description,WCAG Tags,Occurrences,Sample Page,Sample Selector';
+    expect(formatCsvExport(data)).toBe(expectedHeaders);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap where `formatCsvExport` empty findings edge case is addressed.
📊 **Coverage:** The scenario where the `findings` array is empty is tested to ensure that only CSV headers are returned.
✨ **Result:** Test coverage improved.

---
*PR created automatically by Jules for task [13702008107610279181](https://jules.google.com/task/13702008107610279181) started by @Hardonian*