### PR TITLE
fix(ci): import createHash in seed.ts

### DIFF
--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import { randomBytes, scrypt } from 'crypto';
+import { randomBytes, scrypt, createHash } from 'crypto';
 import { promisify } from 'util';
 
 const prisma = new PrismaClient();


### PR DESCRIPTION
## Root cause
The `CI Pipeline` 'Push Schema & Seed' step failed (the pipeline has never
passed on main — 0 successes in the last 60 runs). `db:generate` and
`db:push` succeed; the failure is in `db:seed`:

```
Seed failed: ReferenceError: createHash is not defined
    at packages/db/prisma/seed.ts:280:25
```

Line 280 computes a SHA-256 fingerprint of each canonical finding via
`createHash('sha256')`, but the file only imported `randomBytes` and
`scrypt` from `crypto`. `createHash` was never imported.

## Fix
Add `createHash` to the existing `import { randomBytes, scrypt } from 'crypto'`
on line 2.

## Verification
`createHash` is a standard `node:crypto` export; the file already uses other
`node:crypto` functions, so this is a missing-import fix, not an API change.
This unblocks the CI Pipeline and the 5 held dependency PRs (#267/268/270/273/274)
that were gated behind the broken pipeline.